### PR TITLE
Add missing packages to Glance

### DIFF
--- a/roles/openstack_helm_glance/defaults/main.yml
+++ b/roles/openstack_helm_glance/defaults/main.yml
@@ -14,13 +14,13 @@
 # .. envvar:: openstack_helm_glance_image_repository [[[
 #
 # Image repository location to be prefixed for all images
-openstack_helm_glance_image_repository: "{{ atmosphere_image_repository | default('us-docker.pkg.dev/vexxhost-infra/openstack') }}"
+openstack_helm_glance_image_repository: "{{ atmosphere_image_repository | default('quay.io/vexxhost') }}"
 
                                                                    # ]]]
 # .. envvar:: openstack_helm_glance_image_tag [[[
 #
 # Image tag for container
-openstack_helm_glance_image_tag: 22.1.1.dev2-1
+openstack_helm_glance_image_tag: 677c89c23631e9083261a1a18ed438d8966e0de2
 
                                                                    # ]]]
 # .. envvar:: openstack_helm_glance_heat_image_tag [[[


### PR DESCRIPTION
This should take care of using an image that has the missing `kubectl` package as well as the Cinder ones.

Fixes #36 