### PR TITLE
Set image_conversion_disable to true by default

### DIFF
--- a/roles/openstack_helm_cinder/vars/main.yml
+++ b/roles/openstack_helm_cinder/vars/main.yml
@@ -52,6 +52,7 @@ _openstack_helm_cinder_values:
         os_region_name: "{{ openstack_helm_endpoints['identity']['auth']['cinder']['region_name'] }}"
         volume_usage_audit_period: hour
         volume_name_template: volume-%s
+        image_conversion_disable: true
       barbican:
         barbican_endpoint_type: internal
       cors:


### PR DESCRIPTION
Adopt config image_conversion_disable from [1].
Set it to true by default.

[1] https://review.opendev.org/c/openstack/cinder/+/839793