### PR TITLE
Switch to use vnc_lite instead of vnc_auto

### DIFF
--- a/roles/openstack_helm_nova/vars/main.yml
+++ b/roles/openstack_helm_nova/vars/main.yml
@@ -137,3 +137,7 @@ __openstack_helm_nova_values:
     service_placement: false
     # NOTE(mnaser): Enable this once we've got Ironic deployed.
     statefulset_compute_ironic: false
+  compute_novnc_proxy:
+    # NOTE(rlin): vnc_auto was rename to vnc_lite in noVNC
+    # ref: https://github.com/novnc/noVNC/issues/695
+    path: /vnc_lite.html


### PR DESCRIPTION
Change noVNC to use novnc_lite.html instead of vnc_auto.html.

vnc_auto.html was replaced in noVNC long time ago, we should adopt that change as well.

ref: https://github.com/novnc/noVNC/issues/695