### PR TITLE
feat: allow for a custom cluster IP address for the neutron coredns service

### DIFF
--- a/roles/coredns/tasks/main.yml
+++ b/roles/coredns/tasks/main.yml
@@ -37,7 +37,7 @@
                 enabled: true
             service:
               name: neutron-coredns
-              clusterIP: 10.96.0.20
+              clusterIP: "{{ neutron_coredns_cluster_ip | default('10.96.0.20') }}"
             isClusterService: false
             servers:
               - port: 53

--- a/roles/openstack_helm_neutron/vars/main.yml
+++ b/roles/openstack_helm_neutron/vars/main.yml
@@ -63,7 +63,7 @@ _openstack_helm_neutron_values:
         service_provider: VPN:strongswan:neutron_vpnaas.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default
     dhcp_agent:
       DEFAULT:
-        dnsmasq_dns_servers: 10.96.0.20
+        dnsmasq_dns_servers: "{{ neutron_coredns_cluster_ip | default('10.96.0.20') }}"
         enable_isolated_metadata: true
     l3_agent:
       AGENT:


### PR DESCRIPTION
Default is set to '10.96.0.20' (matching current configuration). This will support Atmosphere running the 'openstack' playbook against a Kubernetes cluster that is not using the default `10.96.0.0/12` implemented with `kubeadm`.