### PR TITLE
Make clusterPoolIPv4PodCIDR configurable

### DIFF
--- a/roles/cilium/tasks/main.yml
+++ b/roles/cilium/tasks/main.yml
@@ -31,4 +31,4 @@
           openstack-control-plane: enabled
       ipam:
         operator:
-          clusterPoolIPv4PodCIDR: "{{ kubernetes_cluster_cidr | default('10.0.0.0/8') }}"
+          clusterPoolIPv4PodCIDR: "{{ cilium_ipv4_cidr | default('10.0.0.0/8') }}"

--- a/roles/cilium/tasks/main.yml
+++ b/roles/cilium/tasks/main.yml
@@ -29,3 +29,6 @@
       operator:
         nodeSelector:
           openstack-control-plane: enabled
+      ipam:
+        operator:
+          clusterPoolIPv4PodCIDR: "{{ kubernetes_cluster_cidr | default('10.0.0.0/8') }}"


### PR DESCRIPTION
Make clusterPoolIPv4PodCIDR configurable, this to solve conflicts with the 10.0.0.0 subnets