### PR TITLE
feat: allow for custom clusterissuer and certificate secretName when atmosphere is not responsible for cert-manager

### DIFF
--- a/roles/openstack_helm_ingress/tasks/main.yml
+++ b/roles/openstack_helm_ingress/tasks/main.yml
@@ -29,7 +29,7 @@
             http:
               paths: "{{ _openstack_helm_ingress_paths }}"
         tls:
-          - secretName: "{{ openstack_helm_ingress_secretname | default(openstack_helm_ingress_service_name + '-certs') }}"
+          - secretName: "{{ openstack_helm_ingress_secret_name | default(openstack_helm_ingress_service_name + '-certs') }}"
             hosts:
               - "{{ openstack_helm_endpoints[openstack_helm_ingress_endpoint]['host_fqdn_override']['public']['host'] }}"
   # NOTE(mnaser): The Atmosphere operator is so fast that the Ingress webhook

--- a/roles/openstack_helm_ingress/tasks/main.yml
+++ b/roles/openstack_helm_ingress/tasks/main.yml
@@ -29,7 +29,7 @@
             http:
               paths: "{{ _openstack_helm_ingress_paths }}"
         tls:
-          - secretName: "{{ openstack_helm_ingress_service_name }}-certs"
+          - secretName: "{{ openstack_helm_ingress_secretname | default(openstack_helm_ingress_service_name + '-certs') }}"
             hosts:
               - "{{ openstack_helm_endpoints[openstack_helm_ingress_endpoint]['host_fqdn_override']['public']['host'] }}"
   # NOTE(mnaser): The Atmosphere operator is so fast that the Ingress webhook

--- a/roles/openstack_helm_ingress/vars/main.yml
+++ b/roles/openstack_helm_ingress/vars/main.yml
@@ -13,7 +13,7 @@
 # under the License.
 
 _openstack_helm_ingress_annotations:
-  cert-manager.io/cluster-issuer: atmosphere
+  cert-manager.io/cluster-issuer: "{{ openstack_helm_ingress_clusterissuer | default('atmosphere') }}"
 
 _openstack_helm_ingress_paths: "{{ openstack_helm_ingress_paths + __openstack_helm_ingress_paths }}"
 __openstack_helm_ingress_paths:

--- a/roles/openstack_helm_ingress/vars/main.yml
+++ b/roles/openstack_helm_ingress/vars/main.yml
@@ -13,7 +13,7 @@
 # under the License.
 
 _openstack_helm_ingress_annotations:
-  cert-manager.io/cluster-issuer: "{{ openstack_helm_ingress_clusterissuer | default('atmosphere') }}"
+  cert-manager.io/cluster-issuer: "{{ openstack_helm_ingress_cluster_issuer | default('atmosphere') }}"
 
 _openstack_helm_ingress_paths: "{{ openstack_helm_ingress_paths + __openstack_helm_ingress_paths }}"
 __openstack_helm_ingress_paths:


### PR DESCRIPTION
Defaults for `cert-manager.io/cluster-issuer` remains `atmosphere` and for `secretName` remains `{{ openstack_helm_ingress_service_name }}-certs`.

This allows for those defaults to be overridden by setting the `openstack_helm_ingress_secretname` and `openstack_helm_ingress_clusterissuer` variables in the cluster inventory.