### PR TITLE
chore: Set nova virt_type as qemu in molecule env

### DIFF
--- a/molecule/default/group_vars/all/molecule.yml
+++ b/molecule/default/group_vars/all/molecule.yml
@@ -11,3 +11,9 @@ openstack_helm_glance_images:
     disk_format: raw
     container_format: bare
     is_public: true
+
+openstack_helm_nova_values:
+  conf:
+    nova:
+      libvirt:
+        libvirt:: qemu


### PR DESCRIPTION
To fix `qemu-system-x86_64: failed to initialize KVM: Permission denied` error in nova-compute