### PR TITLE
fix: Correct task "Upload logs to object storage"

### DIFF
--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -63,8 +63,8 @@
     - name: Upload logs to object storage
       ignore_errors: True
       when:
-        - not lookup('env', 'GITHUB_RUN_ID') == ""
-        - not lookup('env', 'GITHUB_RUN_NUMBER') == ""
+        - lookup('env', 'GITHUB_RUN_ID')|length > 0
+        - lookup('env', 'GITHUB_RUN_NUMBER')|length > 0
       vars:
         build_id: "{{ lookup('env', 'GITHUB_RUN_ID') }}-{{ lookup('env', 'GITHUB_RUN_NUMBER') }}"
         container_name: atmosphere-ci-logs

--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -63,8 +63,8 @@
     - name: Upload logs to object storage
       ignore_errors: True
       when:
-        - lookup('env', 'GITHUB_RUN_ID') is defined
-        - lookup('env', 'GITHUB_RUN_NUMBER') is defined
+        - not lookup('env', 'GITHUB_RUN_ID') == ""
+        - not lookup('env', 'GITHUB_RUN_NUMBER') == ""
       vars:
         build_id: "{{ lookup('env', 'GITHUB_RUN_ID') }}-{{ lookup('env', 'GITHUB_RUN_NUMBER') }}"
         container_name: atmosphere-ci-logs


### PR DESCRIPTION
Correct task "Upload logs to object storage"
When the GITHUB_RUN_ID & GITHUB_RUN_NUMBER variable is undefined they return  a "" string.