### PR TITLE
fix: Ignore unrechable hosts error in log capture playbook of molecul…

### DIFF
--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -16,6 +16,7 @@
 #               there is no Molecule phase that runs after the converge phase.
 - hosts: controllers[0]
   gather_facts: false
+  ignore_unreachable: true
   vars:
     logs_dir: /tmp/logs
   tasks:


### PR DESCRIPTION
…e destroy

When os_stack removal fails by some reason after instanaces are deleted, this log capture playbook always fail and we cannot finish destroy step. This PR ingores unrechable hosts error.