### PR TITLE
feat: Set retries of helmreleases

### DIFF
--- a/atmosphere/operator/api/types.py
+++ b/atmosphere/operator/api/types.py
@@ -124,6 +124,10 @@ class HelmChartTemplate(pydantic.BaseModel):
     spec: HelmChartTemplateSpec
 
 
+class HelmReleaseActionRemediation(pydantic.BaseModel):
+    retries: int = 3
+
+
 class HelmReleaseActionSpecCRDsPolicy(str, Enum):
     SKIP = "Skip"
     CREATE = "Create"
@@ -135,6 +139,7 @@ class HelmReleaseActionSpec(pydantic.BaseModel):
         HelmReleaseActionSpecCRDsPolicy.CREATE_REPLACE
     )
     disable_wait: bool = pydantic.Field(default=True, alias="disableWait")
+    remediation: HelmReleaseActionRemediation = HelmReleaseActionRemediation()
 
     class Config:
         allow_population_by_field_name = True

--- a/atmosphere/operator/tasks.py
+++ b/atmosphere/operator/tasks.py
@@ -120,10 +120,16 @@ class ApplyHelmReleaseTask(ApplyKubernetesObjectTask):
                     "install": {
                         "crds": "CreateReplace",
                         "disableWait": True,
+                        "remediation": {
+                            "retries": 3,
+                        },
                     },
                     "upgrade": {
                         "crds": "CreateReplace",
                         "disableWait": True,
+                        "remediation": {
+                            "retries": 3,
+                        },
                     },
                     "values": values,
                     "valuesFrom": values_from,

--- a/atmosphere/tasks/kubernetes/flux.py
+++ b/atmosphere/tasks/kubernetes/flux.py
@@ -66,10 +66,16 @@ class ApplyHelmReleaseTask(base.ApplyKubernetesObjectTask):
                     "install": {
                         "crds": "CreateReplace",
                         "disableWait": True,
+                        "remediation": {
+                            "retries": 3,
+                        },
                     },
                     "upgrade": {
                         "crds": "CreateReplace",
                         "disableWait": True,
+                        "remediation": {
+                            "retries": 3,
+                        },
                     },
                     "values": self._values,
                     "valuesFrom": self._values_from,

--- a/atmosphere/tests/unit/operator/test_objects.py
+++ b/atmosphere/tests/unit/operator/test_objects.py
@@ -193,11 +193,17 @@ class TestHelmRelease:
                     "install": {
                         "crds": "CreateReplace",
                         "disableWait": True,
+                        "remediation": {
+                            "retries": 3,
+                        },
                     },
                     "interval": "60s",
                     "upgrade": {
                         "crds": "CreateReplace",
                         "disableWait": True,
+                        "remediation": {
+                            "retries": 3,
+                        },
                     },
                     "values": {
                         "foo": "bar",

--- a/atmosphere/tests/unit/operator/test_types.py
+++ b/atmosphere/tests/unit/operator/test_types.py
@@ -107,6 +107,13 @@ class TestHelmChartTemplate:
         assert isinstance(instance.spec, types.HelmChartTemplateSpec)
 
 
+class HelmReleaseActionRemediation:
+    @given(st.builds(types.HelmReleaseActionRemediation))
+    def test_property(self, instance):
+        assert isinstance(instance, types.HelmReleaseActionRemediation)
+        assert isinstance(instance.retries, int)
+
+
 class TestHelmReleaseActionSpec:
     @given(st.builds(types.HelmReleaseActionSpec))
     def test_property(self, instance):
@@ -114,6 +121,7 @@ class TestHelmReleaseActionSpec:
         assert isinstance(instance.crds, types.HelmReleaseActionSpecCRDsPolicy)
         assert isinstance(instance.disable_wait, bool)
         assert instance.disable_wait in [True, False]
+        assert isinstance(instance.remediation, types.HelmReleaseActionRemediation)
 
 
 class TestHelmReleaseValuesReference:

--- a/roles/openstack_helm_octavia/tasks/main.yml
+++ b/roles/openstack_helm_octavia/tasks/main.yml
@@ -201,6 +201,10 @@
     cores: -1
     ram: -1
 
+- name: Debug octavia helm values
+  debug:
+    msg: "{{ _openstack_helm_octavia_values | combine(openstack_helm_octavia_values, recursive=True) | to_nice_yaml }}"
+
 - name: Deploy Helm chart
   kubernetes.core.k8s:
     state: present

--- a/roles/openstack_helm_octavia/tasks/main.yml
+++ b/roles/openstack_helm_octavia/tasks/main.yml
@@ -201,10 +201,6 @@
     cores: -1
     ram: -1
 
-- name: Debug octavia helm values
-  debug:
-    msg: "{{ _openstack_helm_octavia_values | combine(openstack_helm_octavia_values, recursive=True) | to_nice_yaml }}"
-
 - name: Deploy Helm chart
   kubernetes.core.k8s:
     state: present

--- a/roles/openstack_helm_octavia/tasks/main.yml
+++ b/roles/openstack_helm_octavia/tasks/main.yml
@@ -84,7 +84,7 @@
 
 - name: Set controller_ip_port_list
   ansible.builtin.set_fact:
-    _openstack_helm_octavia_controller_ip_port_list: "{{ _openstack_helm_octavia_controller_ip_port_list | d([]) + [item.openstack_ports[0].fixed_ips[0].ip_address + ':5555'] | unique }}"
+    _openstack_helm_octavia_controller_ip_port_list: "{{ (_openstack_helm_octavia_controller_ip_port_list | d([]) + [item.openstack_ports[0].fixed_ips[0].ip_address + ':5555']) | unique }}"
   loop: "{{ _openstack_helm_octavia_health_manager_ports.results }}"
   loop_control:
     label: "{{ item.openstack_ports[0].name }}"

--- a/roles/openstack_helm_octavia/tasks/main.yml
+++ b/roles/openstack_helm_octavia/tasks/main.yml
@@ -84,7 +84,7 @@
 
 - name: Set controller_ip_port_list
   ansible.builtin.set_fact:
-    _openstack_helm_octavia_controller_ip_port_list: "{{ _openstack_helm_octavia_controller_ip_port_list | d([]) + [item.openstack_ports[0].fixed_ips[0].ip_address + ':5555'] }}"
+    _openstack_helm_octavia_controller_ip_port_list: "{{ _openstack_helm_octavia_controller_ip_port_list | d([]) + [item.openstack_ports[0].fixed_ips[0].ip_address + ':5555'] | unique }}"
   loop: "{{ _openstack_helm_octavia_health_manager_ports.results }}"
   loop_control:
     label: "{{ item.openstack_ports[0].name }}"

--- a/roles/openstack_helm_octavia/vars/main.yml
+++ b/roles/openstack_helm_octavia/vars/main.yml
@@ -118,7 +118,7 @@ _openstack_helm_octavia_values:
         client_cert: /etc/octavia/certs/client/tls-combined.pem
         server_ca: /etc/octavia/certs/server/ca.crt
       health_manager:
-        controller_ip_port_list: "{{ _openstack_helm_octavia_controller_ip_port_list | join(',') }}"
+        controller_ip_port_list: "{{ _openstack_helm_octavia_controller_ip_port_list | sort | join(',') }}"
         heartbeat_key: "{{ openstack_helm_octavia_heartbeat_key }}"
       oslo_messaging_notifications:
         driver: noop


### PR DESCRIPTION
This PR includes following changes;
- Set retries as 3 for helmreleases managed by atmosphere operator (relates to https://github.com/vexxhost/atmosphere/issues/240)
- Fix idempotent failure in openstack_helm_octavia role by adding unique and sort filter for `_openstack_helm_octavia_controller_ip_port_list` variable

