### PR TITLE
feat: Make atmosphere_images overrideble.

### DIFF
--- a/roles/image_manifest/README.md
+++ b/roles/image_manifest/README.md
@@ -10,6 +10,10 @@ variable, which by default will pull all of the different images from the
 internet.  You can override this variable to use your own local registry or to
 override a specific image.
 
+With `atmosphere_images_overide` you can override specific images,
+image_manifest will then copy to the local registry and merge this into
+`atmosphere_images`.
+
 Atmosphere can help you to generate this list of images (named "image manifest")
 as well as mirror them to your own registry.
 

--- a/roles/image_manifest/defaults/main.yml
+++ b/roles/image_manifest/defaults/main.yml
@@ -2,10 +2,11 @@ image_manifest_force: false
 image_manifest_registry: null
 image_manifest_mirror: false
 image_manifest_images: "{{ atmosphere_images.keys() }}"
+atmosphere_images_overide:
 image_manifest_data:
   atmosphere_images: "{{ dict(
     atmosphere_images.keys() |
       zip(
         atmosphere_images.values() | map('vexxhost.atmosphere.docker_image', 'ref', registry=image_manifest_registry)
       )
-    ) }}"
+    ) | combine(atmosphere_images_overide) }}"


### PR DESCRIPTION
Make atmosphere_images overrideble. This can be used to downgrade images  or build local images