### PR TITLE
fix: Synchronize files based on checksum in upload_helm_chart role

### DIFF
--- a/roles/upload_helm_chart/tasks/main.yml
+++ b/roles/upload_helm_chart/tasks/main.yml
@@ -4,5 +4,5 @@
     dest: "{{ upload_helm_chart_dest }}"
     archive: false
     recursive: true
-    times: true
+    checksum: true
     delete: true


### PR DESCRIPTION
Instead of using times for comparing, use checksum. It will fix idempotence issue