### PR TITLE
fix: Fix tempest helm values var name

### DIFF
--- a/roles/openstack_helm_tempest/meta/main.yml
+++ b/roles/openstack_helm_tempest/meta/main.yml
@@ -25,6 +25,7 @@ galaxy_info:
 
 dependencies:
   - role: defaults
+  - role: openstacksdk
   - role: openstack_helm_endpoints
     vars:
       openstack_helm_endpoints_chart: tempest
@@ -32,4 +33,3 @@ dependencies:
     vars:
       upload_helm_chart_src: "{{ openstack_helm_tempest_helm_chart_path }}"
       upload_helm_chart_dest: "{{ openstack_helm_tempest_helm_chart_ref }}"
-  - role: openstacksdk

--- a/roles/openstack_helm_tempest/tasks/main.yml
+++ b/roles/openstack_helm_tempest/tasks/main.yml
@@ -25,18 +25,18 @@
         cloud: atmosphere
         image: cirros
       register: _openstack_helm_tempest_test_image
-      when: openstack_helm_tempest_values.conf.tempest.compute.image_ref is not defined
+      when: openstack_helm_tempest_helm_values.conf.tempest.compute.image_ref is not defined
 
     - name: Configure test image ref
       ansible.builtin.set_fact:
-        openstack_helm_tempest_values: "{{ openstack_helm_tempest_values | default({}) | combine({item.key: item.value}, recursive=True) }}"
+        openstack_helm_tempest_helm_values: "{{ openstack_helm_tempest_helm_values | default({}) | combine({item.key: item.value}, recursive=True) }}"
       with_dict:
         conf:
           tempest:
             compute:
               image_ref: "{{ _openstack_helm_tempest_test_image.openstack_image.id }}"
       when:
-        - openstack_helm_tempest_values.conf.tempest.compute.image_ref is not defined
+        - openstack_helm_tempest_helm_values.conf.tempest.compute.image_ref is not defined
         - _openstack_helm_tempest_test_image.openstack_image.id is defined
 
     - name: Get test flavor object
@@ -44,18 +44,18 @@
         cloud: atmosphere
         name: m1.tiny
       register: _openstack_helm_tempest_test_flavor
-      when: openstack_helm_tempest_values.conf.tempest.compute.flavor_ref is not defined
+      when: openstack_helm_tempest_helm_values.conf.tempest.compute.flavor_ref is not defined
 
     - name: Set test flavor ref
       ansible.builtin.set_fact:
-        openstack_helm_tempest_values: "{{ openstack_helm_tempest_values | default({}) | combine({item.key: item.value}, recursive=True) }}"
+        openstack_helm_tempest_helm_values: "{{ openstack_helm_tempest_helm_values | default({}) | combine({item.key: item.value}, recursive=True) }}"
       with_dict:
         conf:
           tempest:
             compute:
               flavor_ref: "{{ _openstack_helm_tempest_test_flavor.openstack_flavors[0].id }}"
       when:
-        - openstack_helm_tempest_values.conf.tempest.compute.flavor_ref is not defined
+        - openstack_helm_tempest_helm_values.conf.tempest.compute.flavor_ref is not defined
         - _openstack_helm_tempest_test_flavor.openstack_flavors[0].id is defined
 
     - name: Get test network object
@@ -63,18 +63,18 @@
         cloud: atmosphere
         name: public
       register: _openstack_helm_tempest_test_network
-      when: openstack_helm_tempest_values.conf.tempest.network.public_network_id is not defined
+      when: openstack_helm_tempest_helm_values.conf.tempest.network.public_network_id is not defined
 
     - name: Set test network ref
       ansible.builtin.set_fact:
-        openstack_helm_tempest_values: "{{ openstack_helm_tempest_values | default({}) | combine({item.key: item.value}, recursive=True) }}"
+        openstack_helm_tempest_helm_values: "{{ openstack_helm_tempest_helm_values | default({}) | combine({item.key: item.value}, recursive=True) }}"
       with_dict:
         conf:
           tempest:
             network:
               public_network_id: "{{ _openstack_helm_tempest_test_network.openstack_networks[0].id }}"
       when:
-        - openstack_helm_tempest_values.conf.tempest.network.public_network_id is not defined
+        - openstack_helm_tempest_helm_values.conf.tempest.network.public_network_id is not defined
         - _openstack_helm_tempest_test_network.openstack_networks[0].id is defined
 
 - name: Deploy Helm chart


### PR DESCRIPTION
https://github.com/vexxhost/atmosphere/actions/runs/4012750185/jobs/6891450314

molecule verify step failed because tempest role was setting resource ids in wrong variable