### PR TITLE
chore: Move pre-commit action to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 jobs:
-  images:
+  Golang:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,3 +30,15 @@ jobs:
           name: test-log
           path: /tmp/gotest.log
           if-no-files-found: error
+
+  Pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+
+      - name: Setup pre-commit
+        uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,18 +38,6 @@ jobs:
           tags: |
             quay.io/vexxhost/ethtool-exporter:${{ env.PROJECT_REF }}
 
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v3
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-
-      - name: Setup pre-commit
-        uses: pre-commit/action@v3.0.0
-
   molecule:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
GH doesn't provide cancellation per action, but per workflow.
It will ease cancellation of molecule test.