### PR TITLE
fix: Add bmemcached

### DIFF
--- a/internal/pkg/image_repositories/build_workflow.go
+++ b/internal/pkg/image_repositories/build_workflow.go
@@ -62,7 +62,7 @@ func NewBuildWorkflow(project string) *GithubWorkflow {
 		distPackages = val
 	}
 
-	pipPackages := "cryptography"
+	pipPackages := "cryptography python-binary-memcached"
 	if val, ok := PIP_PACKAGES[project]; ok {
 		pipPackages += fmt.Sprintf(" %s", val)
 	}


### PR DESCRIPTION
oslo.cache requires bmemcached for oslo_cache.memcache_pool backend type from Zed https://github.com/openstack/oslo.cache/commit/7c6effd10e7c09f75fe0c644dab418ada4dc5e8a