### PR TITLE
feat: always disable swap on node startup

### DIFF
--- a/roles/kubernetes/files/noswap.service
+++ b/roles/kubernetes/files/noswap.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Disable swap
+Before=kubelet.service
+After=local-fs.target
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/sbin/swapoff -a
+
+[Install]
+WantedBy=default.target

--- a/roles/kubernetes/handlers/main.yml
+++ b/roles/kubernetes/handlers/main.yml
@@ -1,0 +1,20 @@
+# Copyright (c) 2023 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Enable noswap service
+  ansible.builtin.systemd:
+    name: noswap
+    state: started
+    enabled: true
+    daemon_reload: true

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -89,6 +89,15 @@
     - swap
     - none
 
+- name: Create noswap systemd service config file
+  ansible.builtin.copy:
+    src: noswap.service
+    dest: /etc/systemd/system/noswap.service
+    owner: root
+    group: root
+    mode: 0644
+  notify: Enable noswap service
+
 - name: Configure short hostname
   ansible.builtin.hostname:
     name: "{{ inventory_hostname_short }}"


### PR DESCRIPTION
Current bootstrap configuration for swap does not survive after node reboot. This change introduces new `systemd` service which runs `swapoff` before `kubelet` start.