### PR TITLE
feat: add crictl.yaml config

### DIFF
--- a/roles/kubernetes/defaults/main.yml
+++ b/roles/kubernetes/defaults/main.yml
@@ -24,6 +24,12 @@ kubernetes_version: 1.22.17
 kubernetes_cri_tools_version: 1.25.0
 
                                                                    # ]]]
+# .. envvar:: kubernetes_cri_socket [[[
+#
+# CRI socket path
+kubernetes_cri_socket: /run/containerd/containerd.sock
+
+                                                                   # ]]]
 # .. envvar:: kubernetes_kernel_modules [[[
 #
 # List of kernel modules to be automatically loaded

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -41,12 +41,18 @@
 - name: Install packages
   ansible.builtin.apt:
     name:
-      - "containerd"
       - "cri-tools={{ kubernetes_cri_tools_version }}-00"
       - "kubeadm={{ kubernetes_version }}-00"
       - "kubectl={{ kubernetes_version }}-00"
       - "kubelet={{ kubernetes_version }}-00"
     state: present
+
+- name: Create crictl config
+  ansible.builtin.template:
+    src: crictl.yaml.j2
+    dest: /etc/crictl.yaml
+    owner: root
+    mode: 0644
 
 - name: Enable kernel modules on-boot
   ansible.builtin.template:

--- a/roles/kubernetes/templates/crictl.yaml.j2
+++ b/roles/kubernetes/templates/crictl.yaml.j2
@@ -1,0 +1,4 @@
+runtime-endpoint: unix://{{ kubernetes_cri_socket }}
+image-endpoint: unix://{{ kubernetes_cri_socket }}
+timeout: 30
+debug: false

--- a/roles/kubernetes/templates/kubeadm.yaml.j2
+++ b/roles/kubernetes/templates/kubeadm.yaml.j2
@@ -9,7 +9,7 @@ nodeRegistration:
     enforce-node-allocatable: ""
     node-ip: "{{ ansible_default_ipv4.address }}"
     container-runtime: "remote"
-    container-runtime-endpoint: "/run/containerd/containerd.sock"
+    container-runtime-endpoint: "{{ kubernetes_cri_socket }}"
 ---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: JoinConfiguration
@@ -19,7 +19,7 @@ nodeRegistration:
     enforce-node-allocatable: ""
     node-ip: "{{ ansible_default_ipv4.address }}"
     container-runtime: "remote"
-    container-runtime-endpoint: "/run/containerd/containerd.sock"
+    container-runtime-endpoint: "{{ kubernetes_cri_socket }}"
 {% if (_kubernetes_bootstrap_node is not defined) or (_kubernetes_bootstrap_node is defined and inventory_hostname != _kubernetes_bootstrap_node) %}
 discovery:
   bootstrapToken:


### PR DESCRIPTION
Without configuration crictl complains about deprecation:

```
# crictl images
WARN[0000] image connect using default endpoints: [unix:///var/run/dockershim.sock unix:///run/containerd/containerd.sock unix:///run/crio/crio.sock unix:///var/run/cri-dockerd.sock]. As the default settings are now deprecated, you should set the endpoint instead.
ERRO[0000] unable to determine image API version: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial unix /var/run/dockershim.sock: connect: no such file or directory
```