### PR TITLE
Update percona backup image

### DIFF
--- a/roles/percona_xtradb_cluster/README.md
+++ b/roles/percona_xtradb_cluster/README.md
@@ -27,7 +27,7 @@ example below.
 ```yaml
 percona_xtradb_cluster_spec:
   backup:
-    image: perconalab/percona-xtradb-cluster-operator:main-pxc8.0-backup
+    image: percona/percona-xtradb-cluster-operator:1.12.0-pxc5.7-backup
     storages:
       fs-pvc:
         type: filesystem

--- a/roles/percona_xtradb_cluster/README.md
+++ b/roles/percona_xtradb_cluster/README.md
@@ -27,7 +27,7 @@ example below.
 ```yaml
 percona_xtradb_cluster_spec:
   backup:
-    image: percona/percona-xtradb-cluster-operator:1.12.0-pxc5.7-backup
+    image: percona/percona-xtradb-cluster-operator:1.10.0-pxc5.7-backup
     storages:
       fs-pvc:
         type: filesystem


### PR DESCRIPTION
With the 8.0 image you can create backups, but you can not restore the backups.

Atmosphere uses Percona 5.7. With a 8.0 backup you can not restore to a 5.7 Percona cluster.