### PR TITLE
fix: disallow embedded of horizon in iframe

### DIFF
--- a/roles/horizon/vars/main.yml
+++ b/roles/horizon/vars/main.yml
@@ -23,6 +23,7 @@ _horizon_helm_values:
     horizon:
       local_settings:
         config:
+          disallow_iframe_embed: "True"
           secure_proxy_ssl_header: "True"
           horizon_images_upload_mode: direct
           openstack_enable_password_retrieve: "True"


### PR DESCRIPTION
OpenStack Helm enables the Horizon service to be embedded in an iframe
by default. This is a security risk and should be disabled.

This patch disables the embedding of Horizon in an iframe.
