### PR TITLE
chore: Update capo version to 0.7.1

### DIFF
--- a/roles/magnum/tasks/main.yml
+++ b/roles/magnum/tasks/main.yml
@@ -62,7 +62,7 @@
       --core cluster-api:v1.3.3 \
       --bootstrap kubeadm:v1.3.3 \
       --control-plane kubeadm:v1.3.3 \
-      --infrastructure openstack:v0.7.0
+      --infrastructure openstack:v0.7.1
   environment:
     CLUSTER_TOPOLOGY: "true"
     EXP_CLUSTER_RESOURCE_SET: "true"


### PR DESCRIPTION
To include https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1493