### PR TITLE
feat: override CAPO

### DIFF
--- a/roles/defaults/defaults/main.yml
+++ b/roles/defaults/defaults/main.yml
@@ -27,7 +27,7 @@ atmosphere_images:
   cluster_api_controller: registry.k8s.io/cluster-api/cluster-api-controller:v1.3.3
   cluster_api_kubeadm_bootstrap_controller: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.3.3
   cluster_api_kubeadm_control_plane_controller: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.3.3
-  cluster_api_openstack_controller: registry.k8s.io/capi-openstack/capi-openstack-controller:v0.7.0
+  cluster_api_openstack_controller: quay.io/vexxhost/capi-openstack-controller:v0.7.1-1
   csi_node_driver_registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
   csi_rbd_attacher: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
   csi_rbd_plugin: quay.io/cephcsi/cephcsi:v3.5.1

--- a/roles/magnum/defaults/main.yml
+++ b/roles/magnum/defaults/main.yml
@@ -40,6 +40,10 @@ magnum_clusterctl_config:
     infrastructure-openstack/capi-openstack-controller:
       repository: "{{ atmosphere_images['cluster_api_openstack_controller'] | vexxhost.atmosphere.docker_image('prefix') }}"
       tag: "{{ atmosphere_images['cluster_api_openstack_controller'] | vexxhost.atmosphere.docker_image('tag') }}"
+  providers:
+    - name: "openstack"
+      url: "https://github.com/vexxhost/cluster-api-provider-openstack/releases/latest/infrastructure-components.yaml"
+      type: "InfrastructureProvider"
 
 # List of images to load into OpenStack for Magnum
 magnum_image_container_format: bare

--- a/roles/magnum/tasks/main.yml
+++ b/roles/magnum/tasks/main.yml
@@ -62,7 +62,7 @@
       --core cluster-api:v1.3.3 \
       --bootstrap kubeadm:v1.3.3 \
       --control-plane kubeadm:v1.3.3 \
-      --infrastructure openstack:v0.7.1
+      --infrastructure openstack:v0.7.1-1
   environment:
     CLUSTER_TOPOLOGY: "true"
     EXP_CLUSTER_RESOURCE_SET: "true"


### PR DESCRIPTION
We decied to maintain our own forked version of CAPO https://github.com/vexxhost/cluster-api-provider-openstack. Ofc, this will be synced with upstream.

This PR overrides the default CAPO in cluster-api deployment.

https://github.com/vexxhost/cluster-api-provider-openstack/releases/tag/v0.7.1-1