### PR TITLE
feat: enable autoscaler for magnum

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,7 +16,7 @@ dependencies:
   kubernetes.core: 2.3.2
   openstack.cloud: 1.7.0
   community.mysql: 3.6.0
-  vexxhost.kubernetes: 1.3.3
+  vexxhost.kubernetes: 1.4.0
 tags:
   - application
   - cloud

--- a/internal/pkg/image_repositories/build_workflow.go
+++ b/internal/pkg/image_repositories/build_workflow.go
@@ -40,7 +40,7 @@ var PIP_PACKAGES map[string]string = map[string]string{
 	"glance":        "glance_store[cinder]",
 	"horizon":       "git+https://github.com/openstack/designate-dashboard.git@stable/${{ matrix.release }} git+https://github.com/openstack/heat-dashboard.git@stable/${{ matrix.release }} git+https://github.com/openstack/ironic-ui.git@stable/${{ matrix.release }} git+https://github.com/vexxhost/magnum-ui.git@stable/${{ matrix.release }} git+https://github.com/openstack/neutron-vpnaas-dashboard.git@stable/${{ matrix.release }} git+https://github.com/openstack/octavia-dashboard.git@stable/${{ matrix.release }} git+https://github.com/openstack/senlin-dashboard.git@stable/${{ matrix.release }} git+https://github.com/openstack/monasca-ui.git@stable/${{ matrix.release }} git+https://github.com/openstack/manila-ui.git@stable/${{ matrix.release }}",
 	"ironic":        "python-dracclient sushy",
-	"magnum":        "magnum-cluster-api==0.3.4",
+	"magnum":        "magnum-cluster-api==0.4.0",
 	"monasca-agent": "libvirt-python python-glanceclient python-neutronclient python-novaclient py3nvml",
 	"neutron":       "neutron-vpnaas",
 	"placement":     "httplib2",

--- a/internal/pkg/image_repositories/template/Dockerfile
+++ b/internal/pkg/image_repositories/template/Dockerfile
@@ -30,5 +30,6 @@ RUN <<EOF /bin/bash
   rm -rf /var/lib/apt/lists/*
 EOF
 {{- else if eq .Project "magnum" }}
+COPY --from=docker.io/alpine/helm:3.11.2 /usr/bin/helm /usr/local/bin/helm
 COPY --from=gcr.io/go-containerregistry/crane /ko-app/crane /usr/local/bin/crane
 {{- end }}

--- a/playbooks/kubernetes.yml
+++ b/playbooks/kubernetes.yml
@@ -36,7 +36,6 @@
     kubernetes_image_repository: "{{ atmosphere_images['kube_apiserver'] | vexxhost.kubernetes.docker_image('prefix') }}"
     cilium_node_image: "{{ atmosphere_images['cilium_node'] }}"
     cilium_operator_image: "{{ atmosphere_images['cilium_operator'] }}"
-    flux_image_registry: "{{ atmosphere_images['flux_helm_controller'] | vexxhost.kubernetes.docker_image('prefix') }}"
 
 - hosts: "{{ target | default('all') }}"
   become: true

--- a/roles/defaults/defaults/main.yml
+++ b/roles/defaults/defaults/main.yml
@@ -60,10 +60,6 @@ atmosphere_images:
   designate_producer: quay.io/vexxhost/designate:zed
   designate_sink: quay.io/vexxhost/designate:zed
   designate_worker: quay.io/vexxhost/designate:zed
-  flux_helm_controller: ghcr.io/fluxcd/helm-controller:v0.22.2
-  flux_kustomize_controller: ghcr.io/fluxcd/kustomize-controller:v0.27.0
-  flux_notification_controller: ghcr.io/fluxcd/notification-controller:v0.25.1
-  flux_source_controller: ghcr.io/fluxcd/source-controller:v0.26.1
   glance_api: quay.io/vexxhost/glance:zed
   glance_db_sync: quay.io/vexxhost/glance:zed
   glance_metadefs_load: quay.io/vexxhost/glance:zed


### PR DESCRIPTION
To remove flux dependency from magnum cluster-api driver, we are gonna use helm to install cluster autoscaler and it requires helm cli.