### PR TITLE
Add bastion host to molecule build env

### DIFF
--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -31,6 +31,7 @@
     instance_type: "{{ lookup('env', 'ATMOSPHERE_INSTANCE_TYPE') | default('v3-standard-4', True) }}"
     nameservers: "{{ lookup('env', 'ATMOSPHERE_NAMESERVERS') | default('1.1.1.1', True) }}"
     boot_from_volume: "{{ lookup('env', 'ATMOSPHERE_BOOT_FROM_VOLUME') | bool }}"
+    create_bastion_host: "{{ lookup('env', 'ATMOSPHERE_CREATE_BASTION_HOST') | bool }}"
   tasks:
     - name: create stack
       openstack.cloud.stack:
@@ -42,6 +43,7 @@
           instance_type: "{{ instance_type }}"
           nameservers: "{{ nameservers }}"
           boot_from_volume: "{{  boot_from_volume }}"
+          create_bastion_host: "{{ create_bastion_host }}"
       register: _os_stack
     - debug:
         msg: "{{ _os_stack.stack }}"

--- a/molecule/default/heat/server.yaml
+++ b/molecule/default/heat/server.yaml
@@ -112,7 +112,7 @@ resources:
     properties:
       name:
         yaql:
-          expression: concat($.data.name, str($.data.index + 1))
+          expression: concat($.data.name, str($.data.index + 1)).replace("0", "")
           data:
             name: { get_param: name }
             index: { get_param: index }

--- a/molecule/default/heat/stack.yaml
+++ b/molecule/default/heat/stack.yaml
@@ -44,10 +44,20 @@ parameters:
     type: boolean
     default: false
 
+  create_bastion_host:
+    type: boolean
+    default: false
+
   instance_type:
     type: string
     constraints:
       - custom_constraint: nova.flavor
+
+conditions:
+  create_bastion_host:
+    equals:
+      - get_param: create_bastion_host
+      - true
 
 resources:
   router:
@@ -109,6 +119,21 @@ resources:
     properties:
       name: { get_param: OS::stack_id }
       save_private_key: true
+
+  bastion_host:
+    type: server.yaml
+    condition: create_bastion_host
+    properties:
+      name: bastion
+      index: -1
+      image: { get_param: image }
+      instance_type: { get_param: instance_type }
+      key_name: { get_resource: key_pair }
+      internal_network: { get_resource: internal_network }
+      public_network: { get_param: public_network }
+      external_network: { get_resource: external_network }
+      boot_volumes_size: 40
+      boot_from_volume: { get_param: boot_from_volume  }
 
   controller:
     type: OS::Heat::ResourceGroup


### PR DESCRIPTION
Use environment variable `ATMOSPHERE_CREATE_BASTION_HOST` to create another host that attach direct to public network and to floating ip so it can play an bastion host for environment build by molecule