### PR TITLE
Add NodeNonLTSKernel alert

### DIFF
--- a/roles/kube_prometheus_stack/files/jsonnet/legacy.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/legacy.libsonnet
@@ -159,6 +159,13 @@
               severity: 'warning',
             },
           },
+          {
+            alert: 'NodeNonLTSKernel',
+            expr: 'node_uname_info{release!~"^5.(4|15).*"}',
+            labels: {
+              severity: 'warning',
+            },
+          },
         ],
       },
       {


### PR DESCRIPTION
This alrert will check if node using non LTS kernel. We added this alert as non LTS kernel could be problematic like in https://github.com/vexxhost/atmosphere/issues/401

Related: https://github.com/vexxhost/atmosphere/issues/402