### PR TITLE
fix: Remove old mcapi RBAC resources

### DIFF
--- a/roles/magnum/tasks/main.yml
+++ b/roles/magnum/tasks/main.yml
@@ -69,6 +69,30 @@
     CLUSTER_TOPOLOGY: "true"
     EXP_CLUSTER_RESOURCE_SET: "true"
 
+
+# NOTE(okozachenko1203): We should get rid of this task eventually as it is removing
+#               the old RBAC resources.
+- name: Remove the legacy mcapi RBAC resources
+  run_once: true
+  block:
+    - name: Remove the Role
+      failed_when: false
+      kubernetes.core.k8s:
+        state: absent
+        api_version: rbac.authorization.k8s.io/v1
+        kind: Role
+        name: magnum-cluster-api
+        namespace: magnum-system
+
+    - name: Remove the RoleBinding
+      failed_when: false
+      kubernetes.core.k8s:
+        state: absent
+        api_version: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: magnum-cluster-api
+        namespace: magnum-system
+
 - name: Deploy Cluster API for Magnum RBAC
   kubernetes.core.k8s:
     state: present

--- a/roles/vsphere_csi/README.md
+++ b/roles/vsphere_csi/README.md
@@ -1,0 +1,1 @@
+# `vsphere_csi`

--- a/roles/vsphere_csi/meta/main.yml
+++ b/roles/vsphere_csi/meta/main.yml
@@ -1,0 +1,27 @@
+# Copyright (c) 2022 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+galaxy_info:
+  author: VEXXHOST, Inc.
+  description: Ansible role for vSphere CSI
+  license: Apache-2.0
+  min_ansible_version: 5.5.0
+  standalone: false
+  platforms:
+    - name: Ubuntu
+      versions:
+        - focal
+
+dependencies:
+  - role: defaults

--- a/roles/vsphere_csi/tasks/main.yml
+++ b/roles/vsphere_csi/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+- name: Clone PowerStore CSI from GitHub
+  ansible.builtin.git:
+    repo: https://github.com/dell/csi-powerstore.git
+    dest: /var/lib/csi-powerstore
+    version: v2.3.0
+
+- name: Create Secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: csi-powerstore-config
+        namespace: kube-system
+      stringData:
+        config: "{{ powerstore_csi_config | to_yaml }}"
+
+- name: Create StorageClass
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: general
+        annotations:
+          storageclass.kubernetes.io/is-default-class: "true"
+      provisioner: csi-powerstore.dellemc.com
+      reclaimPolicy: Delete
+      allowVolumeExpansion: true
+      volumeBindingMode: Immediate
+
+- name: Deploy Helm chart
+  kubernetes.core.helm:
+    name: csi-powerstore
+    chart_ref: /var/lib/csi-powerstore/helm/csi-powerstore
+    release_namespace: kube-system
+    kubeconfig: /etc/kubernetes/admin.conf
+    values:
+      # NOTE(mnaser): The newer versions of the Helm charts automatically detect
+      #               these values so we can drop them once we move to v2.4.0
+      images:
+        attacher: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+        driver: dellemc/csi-powerstore:v2.3.0
+        externalhealthmonitorcontroller: gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.5.0
+        metadataretriever: dellemc/csi-metadata-retriever:v1.0.0
+        provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+        registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+        snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1


### PR DESCRIPTION
fix: https://github.com/vexxhost/atmosphere/issues/400

Some users have been facing authorization issues because the old RBAC resources were keeping in the cluster after https://github.com/vexxhost/atmosphere/commit/158823643ded6811eba712e293c104d798b7e599 change applied.

This PR will remove the old RBAC resources which breaks the auth.