### PR TITLE
fix(auth): Define service_type in keystone_authtoken

### DIFF
--- a/roles/barbican/vars/main.yml
+++ b/roles/barbican/vars/main.yml
@@ -23,14 +23,14 @@ _barbican_helm_values:
     barbican:
       DEFAULT:
         log_config_append: null
+      keystone_authtoken:
+        # NOTE(okozachenko1203): We can remove it once the following is merged:
+        #                        https://review.opendev.org/883066
+        service_type: key-manager
       oslo_messaging_notifications:
         driver: noop
       simple_crypto_plugin:
         kek: "{{ barbican_kek }}"
-      # NOTE(okozachenko1203): We can remove it once
-      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
-      keystone_authtoken:
-        service_type: key-manager
     simple_crypto_kek_rewrap:
       old_kek: "{{ barbican_kek }}"
 

--- a/roles/barbican/vars/main.yml
+++ b/roles/barbican/vars/main.yml
@@ -27,6 +27,10 @@ _barbican_helm_values:
         driver: noop
       simple_crypto_plugin:
         kek: "{{ barbican_kek }}"
+      # NOTE(okozachenko1203): We can remove it once
+      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
+      keystone_authtoken:
+        service_type: key-manager
     simple_crypto_kek_rewrap:
       old_kek: "{{ barbican_kek }}"
 

--- a/roles/cinder/vars/main.yml
+++ b/roles/cinder/vars/main.yml
@@ -40,12 +40,12 @@ _cinder_helm_values:
         barbican_endpoint_type: internal
       cors:
         allowed_origins: "*"
+      keystone_authtoken:
+        # NOTE(okozachenko1203): We can remove it once the following is merged:
+        #                        https://review.opendev.org/883066
+        service_type: volumev3
       oslo_messaging_notifications:
         driver: noop
-      # NOTE(okozachenko1203): We can remove it once
-      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
-      keystone_authtoken:
-        service_type: volumev3
   manifests:
     ingress_api: false
     job_clean: false

--- a/roles/cinder/vars/main.yml
+++ b/roles/cinder/vars/main.yml
@@ -42,6 +42,10 @@ _cinder_helm_values:
         allowed_origins: "*"
       oslo_messaging_notifications:
         driver: noop
+      # NOTE(okozachenko1203): We can remove it once
+      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
+      keystone_authtoken:
+        service_type: volumev3
   manifests:
     ingress_api: false
     job_clean: false

--- a/roles/designate/vars/main.yml
+++ b/roles/designate/vars/main.yml
@@ -20,6 +20,10 @@ _designate_helm_values:
     designate:
       service:central:
         managed_resource_tenant_id: "{{ _designate_project_info.openstack_projects[0].id }}"
+      # NOTE(okozachenko1203): We can remove it once
+      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
+      keystone_authtoken:
+        service_type: dns
     pools: "{{ designate_pools | to_yaml }}"
   pod:
     replicas:

--- a/roles/designate/vars/main.yml
+++ b/roles/designate/vars/main.yml
@@ -18,12 +18,12 @@ _designate_helm_values:
     tags: "{{ atmosphere_images | vexxhost.atmosphere.openstack_helm_image_tags('designate') }}"
   conf:
     designate:
+      keystone_authtoken:
+        # NOTE(okozachenko1203): We can remove it once the following is merged:
+        #                        https://review.opendev.org/883066
+        service_type: dns
       service:central:
         managed_resource_tenant_id: "{{ _designate_project_info.openstack_projects[0].id }}"
-      # NOTE(okozachenko1203): We can remove it once
-      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
-      keystone_authtoken:
-        service_type: dns
     pools: "{{ designate_pools | to_yaml }}"
   pod:
     replicas:

--- a/roles/glance/vars/main.yml
+++ b/roles/glance/vars/main.yml
@@ -47,6 +47,10 @@ _glance_helm_values:
         disk_formats: "qcow2,raw"
       oslo_messaging_notifications:
         driver: noop
+      # NOTE(okozachenko1203): We can remove it once
+      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
+      keystone_authtoken:
+        service_type: image
   manifests:
     ingress_api: false
     service_ingress_api: false

--- a/roles/glance/vars/main.yml
+++ b/roles/glance/vars/main.yml
@@ -45,12 +45,12 @@ _glance_helm_values:
         allowed_origins: "*"
       image_format:
         disk_formats: "qcow2,raw"
+      keystone_authtoken:
+        # NOTE(okozachenko1203): We can remove it once the following is merged:
+        #                        https://review.opendev.org/883066
+        service_type: image
       oslo_messaging_notifications:
         driver: noop
-      # NOTE(okozachenko1203): We can remove it once
-      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
-      keystone_authtoken:
-        service_type: image
   manifests:
     ingress_api: false
     service_ingress_api: false

--- a/roles/heat/vars/main.yml
+++ b/roles/heat/vars/main.yml
@@ -43,12 +43,12 @@ _heat_helm_values:
         workers: 8
       heat_api_cloudwatch:
         workers: 8
+      keystone_authtoken:
+        # NOTE(okozachenko1203): We can remove it once the following is merged:
+        #                        https://review.opendev.org/883066
+        service_type: orchestration
       oslo_messaging_notifications:
         driver: noop
-      # NOTE(okozachenko1203): We can remove it once
-      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
-      keystone_authtoken:
-        service_type: orchestration
   manifests:
     ingress_api: false
     ingress_cfn: false

--- a/roles/heat/vars/main.yml
+++ b/roles/heat/vars/main.yml
@@ -45,6 +45,10 @@ _heat_helm_values:
         workers: 8
       oslo_messaging_notifications:
         driver: noop
+      # NOTE(okozachenko1203): We can remove it once
+      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
+      keystone_authtoken:
+        service_type: orchestration
   manifests:
     ingress_api: false
     ingress_cfn: false

--- a/roles/magnum/vars/main.yml
+++ b/roles/magnum/vars/main.yml
@@ -51,6 +51,9 @@ _magnum_helm_values:
         # NOTE(mnaser): Magnum does not allow changing the interface to internal
         #               so we workaround with this for now.
         insecure: true
+      # NOTE(okozachenko1203): We can remove it once
+      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
+        service_type: container-infra
       magnum_client:
         region_name: "{{ openstack_helm_endpoints_magnum_region_name }}"
       neutron_client:

--- a/roles/magnum/vars/main.yml
+++ b/roles/magnum/vars/main.yml
@@ -51,8 +51,8 @@ _magnum_helm_values:
         # NOTE(mnaser): Magnum does not allow changing the interface to internal
         #               so we workaround with this for now.
         insecure: true
-      # NOTE(okozachenko1203): We can remove it once
-      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
+        # NOTE(okozachenko1203): We can remove it once the following is merged:
+        #                        https://review.opendev.org/883066
         service_type: container-infra
       magnum_client:
         region_name: "{{ openstack_helm_endpoints_magnum_region_name }}"

--- a/roles/manila/vars/main.yml
+++ b/roles/manila/vars/main.yml
@@ -55,6 +55,10 @@ _manila_helm_values:
         service_instance_flavor_id: "{{ _manila_flavor.id }}"
       oslo_messaging_no tifications:
         driver: noop
+      # NOTE(okozachenko1203): We can remove it once
+      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
+      keystone_authtoken:
+        service_type: sharev2
   manifests:
     ingress_api: false
     service_ingress_api: false

--- a/roles/manila/vars/main.yml
+++ b/roles/manila/vars/main.yml
@@ -53,12 +53,12 @@ _manila_helm_values:
         path_to_public_key: /etc/manila/ssh-keys/id_rsa.pub
         service_image_name: "{{ manila_image_name }}"
         service_instance_flavor_id: "{{ _manila_flavor.id }}"
+      keystone_authtoken:
+        # NOTE(okozachenko1203): We can remove it once the following is merged:
+        #                        https://review.opendev.org/883066
+        service_type: sharev2
       oslo_messaging_no tifications:
         driver: noop
-      # NOTE(okozachenko1203): We can remove it once
-      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
-      keystone_authtoken:
-        service_type: sharev2
   manifests:
     ingress_api: false
     service_ingress_api: false

--- a/roles/neutron/vars/main.yml
+++ b/roles/neutron/vars/main.yml
@@ -37,12 +37,12 @@ _neutron_helm_values:
         live_migration_events: true
       oslo_messaging_notifications:
         driver: noop
+      keystone_authtoken:
+        # NOTE(okozachenko1203): We can remove it once the following is merged:
+        #                        https://review.opendev.org/883066
+        service_type: network
       service_providers:
         service_provider: VPN:strongswan:neutron_vpnaas.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default
-      # NOTE(okozachenko1203): We can remove it once
-      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
-      keystone_authtoken:
-        service_type: network
     dhcp_agent:
       DEFAULT:
         dnsmasq_dns_servers: "{{ neutron_coredns_cluster_ip | default('10.96.0.20') }}"

--- a/roles/neutron/vars/main.yml
+++ b/roles/neutron/vars/main.yml
@@ -39,6 +39,10 @@ _neutron_helm_values:
         driver: noop
       service_providers:
         service_provider: VPN:strongswan:neutron_vpnaas.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default
+      # NOTE(okozachenko1203): We can remove it once
+      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
+      keystone_authtoken:
+        service_type: network
     dhcp_agent:
       DEFAULT:
         dnsmasq_dns_servers: "{{ neutron_coredns_cluster_ip | default('10.96.0.20') }}"

--- a/roles/nova/vars/main.yml
+++ b/roles/nova/vars/main.yml
@@ -80,16 +80,16 @@ _nova_helm_values:
         max_instances_per_host: 200
       glance:
         enable_rbd_download: true
+      keystone_authtoken:
+        # NOTE(okozachenko1203): We can remove it once the following is merged:
+        #                        https://review.opendev.org/883066
+        service_type: compute
       neutron:
         metadata_proxy_shared_secret: "{{ openstack_helm_endpoints['compute_metadata']['secret'] }}"
       oslo_messaging_notifications:
         driver: noop
       scheduler:
         workers: 8
-      # NOTE(okozachenko1203): We can remove it once
-      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
-      keystone_authtoken:
-        service_type: compute
     nova_ironic:
       DEFAULT:
         log_config_append: null

--- a/roles/nova/vars/main.yml
+++ b/roles/nova/vars/main.yml
@@ -86,6 +86,10 @@ _nova_helm_values:
         driver: noop
       scheduler:
         workers: 8
+      # NOTE(okozachenko1203): We can remove it once
+      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
+      keystone_authtoken:
+        service_type: compute
     nova_ironic:
       DEFAULT:
         log_config_append: null

--- a/roles/octavia/vars/main.yml
+++ b/roles/octavia/vars/main.yml
@@ -114,6 +114,10 @@ _octavia_helm_values:
         endpoint_type: internalURL
       service_auth:
         endpoint_type: internalURL
+      # NOTE(okozachenko1203): We can remove it once
+      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
+      keystone_authtoken:
+        service_type: load-balancer
   manifests:
     ingress_api: false
     service_ingress_api: false

--- a/roles/octavia/vars/main.yml
+++ b/roles/octavia/vars/main.yml
@@ -106,6 +106,10 @@ _octavia_helm_values:
       health_manager:
         controller_ip_port_list: "{{ _octavia_controller_ip_port_list | sort | join(',') }}"
         heartbeat_key: "{{ octavia_heartbeat_key }}"
+      keystone_authtoken:
+        # NOTE(okozachenko1203): We can remove it once the following is merged:
+        #                        https://review.opendev.org/883066
+        service_type: load-balancer
       oslo_messaging_notifications:
         driver: noop
       neutron:
@@ -114,10 +118,6 @@ _octavia_helm_values:
         endpoint_type: internalURL
       service_auth:
         endpoint_type: internalURL
-      # NOTE(okozachenko1203): We can remove it once
-      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
-      keystone_authtoken:
-        service_type: load-balancer
   manifests:
     ingress_api: false
     service_ingress_api: false

--- a/roles/placement/vars/main.yml
+++ b/roles/placement/vars/main.yml
@@ -25,6 +25,10 @@ _placement_helm_values:
         log_config_append: null
       oslo_messaging_notifications:
         driver: noop
+      # NOTE(okozachenko1203): We can remove it once
+      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
+      keystone_authtoken:
+        service_type: placement
   manifests:
     ingress: false
     service_ingress: false

--- a/roles/placement/vars/main.yml
+++ b/roles/placement/vars/main.yml
@@ -23,12 +23,12 @@ _placement_helm_values:
     placement:
       DEFAULT:
         log_config_append: null
+      keystone_authtoken:
+        # NOTE(okozachenko1203): We can remove it once the following is merged:
+        #                        https://review.opendev.org/883066
+        service_type: placement
       oslo_messaging_notifications:
         driver: noop
-      # NOTE(okozachenko1203): We can remove it once
-      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
-      keystone_authtoken:
-        service_type: placement
   manifests:
     ingress: false
     service_ingress: false

--- a/roles/senlin/vars/main.yml
+++ b/roles/senlin/vars/main.yml
@@ -26,12 +26,12 @@ _senlin_helm_values:
     senlin:
       DEFAULT:
         log_config_append: null
+      keystone_authtoken:
+        # NOTE(okozachenko1203): We can remove it once the following is merged:
+        #                        https://review.opendev.org/883066
+        service_type: clustering
       oslo_messaging_notifications:
         driver: noop
-      # NOTE(okozachenko1203): We can remove it once
-      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
-      keystone_authtoken:
-        service_type: clustering
   manifests:
     ingress_api: false
     service_ingress_api: false

--- a/roles/senlin/vars/main.yml
+++ b/roles/senlin/vars/main.yml
@@ -28,6 +28,10 @@ _senlin_helm_values:
         log_config_append: null
       oslo_messaging_notifications:
         driver: noop
+      # NOTE(okozachenko1203): We can remove it once
+      # https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged
+      keystone_authtoken:
+        service_type: clustering
   manifests:
     ingress_api: false
     service_ingress_api: false


### PR DESCRIPTION
If application credentials with access rules are required, an OpenStack service using keystonemiddleware to authenticate with keystone, needs to define service_type in its configuration file.

Once https://review.opendev.org/c/openstack/openstack-helm/+/883066 is merged, we can revert this PR.

fix: https://github.com/vexxhost/atmosphere/issues/409