### PR TITLE
fix(nova): Set barbican_endpoint_type as internal

### DIFF
--- a/roles/nova/vars/main.yml
+++ b/roles/nova/vars/main.yml
@@ -50,6 +50,8 @@ _nova_helm_values:
         resume_guests_state_on_host_boot: true
         osapi_compute_workers: 8
         metadata_workers: 8
+      barbican:
+        barbican_endpoint_type: internal
       cache:
         backend: oslo_cache.memcache_pool
       cinder:


### PR DESCRIPTION
This avoid nova-barbican communication go cross ingress

fix https://github.com/vexxhost/atmosphere/issues/428