### PR TITLE
fix(manila): use sg name for manila

### DIFF
--- a/roles/manila/vars/main.yml
+++ b/roles/manila/vars/main.yml
@@ -53,7 +53,7 @@ _manila_helm_values:
         path_to_public_key: /etc/manila/ssh-keys/id_rsa.pub
         service_image_name: "{{ manila_image_name }}"
         service_instance_flavor_id: "{{ _manila_flavor.id }}"
-        service_instance_security_group: "{{ _manila_service_security_group.id }}"
+        service_instance_security_group: "{{ _manila_service_security_group.name }}"
       keystone_authtoken:
         # NOTE(okozachenko1203): We can remove it once the following is merged:
         #                        https://review.opendev.org/883066


### PR DESCRIPTION
This patch switch to use security group name for
`service_instance_security_group` instead of id.

fix https://github.com/vexxhost/atmosphere/issues/393