### PR TITLE
fix(manila): Improve service_instance_security_group

### DIFF
--- a/roles/manila/vars/main.yml
+++ b/roles/manila/vars/main.yml
@@ -53,7 +53,7 @@ _manila_helm_values:
         path_to_public_key: /etc/manila/ssh-keys/id_rsa.pub
         service_image_name: "{{ manila_image_name }}"
         service_instance_flavor_id: "{{ _manila_flavor.id }}"
-        service_instance_security_group: "{{ _manila_service_security_group.name }}"
+        service_instance_security_group: manila-service-security-group
       keystone_authtoken:
         # NOTE(okozachenko1203): We can remove it once the following is merged:
         #                        https://review.opendev.org/883066


### PR DESCRIPTION
As the name for security group manila-service-security-group are fixed, we can directly using the name.