### PR TITLE
chore(role:neutron): Use the deprecated policy for create_subnet

### DIFF
--- a/roles/neutron/vars/main.yml
+++ b/roles/neutron/vars/main.yml
@@ -20,6 +20,10 @@ _neutron_helm_values:
     replicas:
       server: 3
   conf:
+    # NOTE(okozachenko1203): We use the deprecated policy
+    # untill https://bugs.launchpad.net/neutron/+bug/2023679 is fixed
+    policy:
+      "create_subnet": "rule:admin_or_network_owner"
     neutron:
       DEFAULT:
         api_workers: 8
@@ -34,10 +38,6 @@ _neutron_helm_values:
         live_migration_events: true
       oslo_messaging_notifications:
         driver: noop
-      keystone_authtoken:
-        # NOTE(okozachenko1203): We can remove it once the following is merged:
-        #                        https://review.opendev.org/883066
-        service_type: network
       service_providers:
         service_provider: VPN:strongswan:neutron_vpnaas.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default
     dhcp_agent:


### PR DESCRIPTION
https://bugs.launchpad.net/neutron/+bug/2023679

fix: https://github.com/vexxhost/atmosphere/issues/399