### PR TITLE
feat(ci): Add a debug job for molecule ceph workflow

### DIFF
--- a/.github/workflows/ceph.yml
+++ b/.github/workflows/ceph.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   debug:
     runs-on: ubuntu-20.04-16-cores
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+    if: github.event_name == 'workflow_dispatch' && inputs.debug_enabled
     steps:
       - name: Checkout project
         uses: actions/checkout@v3
@@ -66,7 +66,7 @@ jobs:
 
   test:
     runs-on: ubuntu-20.04-16-cores
-    if: ! ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+    if: !(github.event_name == 'workflow_dispatch' && inputs.debug_enabled)
     steps:
       - name: Checkout project
         uses: actions/checkout@v3

--- a/.github/workflows/ceph.yml
+++ b/.github/workflows/ceph.yml
@@ -19,10 +19,54 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
 
 jobs:
+  debug:
+    runs-on: ubuntu-20.04-16-cores
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          cache: poetry
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --with dev
+
+      # NOTE(mnaser): LVM commands take a long time if there are any existing
+      #               loop devices created by "snapd", so we uninstall it.
+      - name: Uninstall "snapd"
+        run: sudo apt-get purge -y snapd
+
+      - name: Turn off swap
+        run: sudo swapoff -a
+
+      - name: Run Molecule Converge
+        run: poetry run molecule converge -s ceph
+
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
+      - name: Run Molecule Destroy
+        run: poetry run molecule destroy -s ceph
+
   test:
     runs-on: ubuntu-20.04-16-cores
+    if: ! ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v3

--- a/.github/workflows/ceph.yml
+++ b/.github/workflows/ceph.yml
@@ -66,7 +66,7 @@ jobs:
 
   test:
     runs-on: ubuntu-20.04-16-cores
-    if: !(github.event_name == 'workflow_dispatch' && inputs.debug_enabled)
+    if: github.event_name != 'workflow_dispatch' || !inputs.debug_enabled
     steps:
       - name: Checkout project
         uses: actions/checkout@v3


### PR DESCRIPTION
It will give a path to jump in to the gh runner instance to troubleshoot the errors of molecule converge whenever we need it.
Put another way, normally it will not create a tmate session to runner instance and run `molecule test` without interruption.
If we need a debug session, we can run the `ceph` workflow manually in a dispatch mode, setting `debug_enabled` value as true.