### PR TITLE
chore: Upgrade cilium version

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -17,7 +17,7 @@ dependencies:
   openstack.cloud: 1.7.0
   community.mysql: 3.6.0
   vexxhost.ceph: 2.0.1
-  vexxhost.kubernetes: 1.5.2
+  vexxhost.kubernetes: 1.6.0
 tags:
   - application
   - cloud

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -17,7 +17,7 @@ dependencies:
   openstack.cloud: 1.7.0
   community.mysql: 3.6.0
   vexxhost.ceph: 2.0.1
-  vexxhost.kubernetes: 1.4.0
+  vexxhost.kubernetes: 1.5.2
 tags:
   - application
   - cloud

--- a/roles/defaults/defaults/main.yml
+++ b/roles/defaults/defaults/main.yml
@@ -29,8 +29,8 @@ atmosphere_images:
   cert_manager_controller: quay.io/jetstack/cert-manager-controller:v1.7.1
   cert_manager_webhook: quay.io/jetstack/cert-manager-webhook:v1.7.1
   ceph: quay.io/ceph/ceph:v16.2.11
-  cilium_node: quay.io/cilium/cilium:v1.10.20@sha256:c9b3af1f9c405cc8dcb163af0e0ea0a376a9f62304501c9392d26e91178d7869
-  cilium_operator: quay.io/cilium/operator-generic:v1.10.20@sha256:f7a07e674687fc4be01168409eeed0986ed7cb19c8d966501507fd24b9f6bd98
+  cilium_node: quay.io/cilium/cilium:v1.13.3@sha256:77176464a1e11ea7e89e984ac7db365e7af39851507e94f137dcf56c87746314
+  cilium_operator: quay.io/cilium/operator-generic:v1.13.3@sha256:fa7003cbfdf8358cb71786afebc711b26e5e44a2ed99bd4944930bba915b8910
   cinder_api: quay.io/vexxhost/cinder@sha256:875bc983a9c2a2d1fb6a952d147f2474a169dc77eb9dff4741f3a185c28753fb # image-source: quay.io/vexxhost/cinder:zed
   cinder_backup_storage_init: quay.io/vexxhost/cinder@sha256:875bc983a9c2a2d1fb6a952d147f2474a169dc77eb9dff4741f3a185c28753fb # image-source: quay.io/vexxhost/cinder:zed
   cinder_backup: quay.io/vexxhost/cinder@sha256:875bc983a9c2a2d1fb6a952d147f2474a169dc77eb9dff4741f3a185c28753fb # image-source: quay.io/vexxhost/cinder:zed


### PR DESCRIPTION
by bumping k8s collection version

fix: https://github.com/vexxhost/atmosphere/issues/423 https://github.com/vexxhost/atmosphere/issues/453

depends-on: https://github.com/vexxhost/ansible-collection-kubernetes/pull/26