### PR TITLE
fix: bump capi to enable smoother autoscaling

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -17,7 +17,7 @@ dependencies:
   kubernetes.core: 2.3.2
   openstack.cloud: 1.7.0
   vexxhost.ceph: 2.0.1
-  vexxhost.kubernetes: 1.6.0
+  vexxhost.kubernetes: 1.7.0
 tags:
   - application
   - cloud

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -97,10 +97,10 @@ _atmosphere_images:
   local_path_provisioner: docker.io/rancher/local-path-provisioner:v0.0.24
   loki: docker.io/grafana/loki:2.7.3
   loki_gateway: docker.io/nginxinc/nginx-unprivileged:1.19-alpine
-  magnum_api: quay.io/vexxhost/magnum-cluster-api@sha256:c452dad4d6ffb04e0fd40a8a77b2d4f542d5ed110cdebb9aec191cdc3dd067e4 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
-  magnum_cluster_api_proxy: quay.io/vexxhost/magnum-cluster-api@sha256:c452dad4d6ffb04e0fd40a8a77b2d4f542d5ed110cdebb9aec191cdc3dd067e4 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
-  magnum_conductor: quay.io/vexxhost/magnum-cluster-api@sha256:c452dad4d6ffb04e0fd40a8a77b2d4f542d5ed110cdebb9aec191cdc3dd067e4 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
-  magnum_db_sync: quay.io/vexxhost/magnum-cluster-api@sha256:c452dad4d6ffb04e0fd40a8a77b2d4f542d5ed110cdebb9aec191cdc3dd067e4 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_api: quay.io/vexxhost/magnum-cluster-api@sha256:ed5c0e9b5577cc79de77c4b1baed53e8d3c9cc1704f258a75244cc6a1f080125 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_cluster_api_proxy: quay.io/vexxhost/magnum-cluster-api@sha256:ed5c0e9b5577cc79de77c4b1baed53e8d3c9cc1704f258a75244cc6a1f080125 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_conductor: quay.io/vexxhost/magnum-cluster-api@sha256:ed5c0e9b5577cc79de77c4b1baed53e8d3c9cc1704f258a75244cc6a1f080125 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_db_sync: quay.io/vexxhost/magnum-cluster-api@sha256:ed5c0e9b5577cc79de77c4b1baed53e8d3c9cc1704f258a75244cc6a1f080125 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
   magnum_registry: docker.io/library/registry:2.7.1
   manila_api: quay.io/vexxhost/manila@sha256:78a258f0a632b0778d91767c4ec7b6f84e6ef1de7cf1e51e726374caa295b8f6 # image-source: quay.io/vexxhost/manila:zed
   manila_data: quay.io/vexxhost/manila@sha256:78a258f0a632b0778d91767c4ec7b6f84e6ef1de7cf1e51e726374caa295b8f6 # image-source: quay.io/vexxhost/manila:zed

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -97,10 +97,10 @@ _atmosphere_images:
   local_path_provisioner: docker.io/rancher/local-path-provisioner:v0.0.24
   loki: docker.io/grafana/loki:2.7.3
   loki_gateway: docker.io/nginxinc/nginx-unprivileged:1.19-alpine
-  magnum_api: quay.io/vexxhost/magnum-cluster-api@sha256:ed5c0e9b5577cc79de77c4b1baed53e8d3c9cc1704f258a75244cc6a1f080125 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
-  magnum_cluster_api_proxy: quay.io/vexxhost/magnum-cluster-api@sha256:ed5c0e9b5577cc79de77c4b1baed53e8d3c9cc1704f258a75244cc6a1f080125 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
-  magnum_conductor: quay.io/vexxhost/magnum-cluster-api@sha256:ed5c0e9b5577cc79de77c4b1baed53e8d3c9cc1704f258a75244cc6a1f080125 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
-  magnum_db_sync: quay.io/vexxhost/magnum-cluster-api@sha256:ed5c0e9b5577cc79de77c4b1baed53e8d3c9cc1704f258a75244cc6a1f080125 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_api: quay.io/vexxhost/magnum-cluster-api@sha256:e0be0ebfba578821d7a0025ae049df7a6a7d7fa4100586428a2fdf83cce8dbd3 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_cluster_api_proxy: quay.io/vexxhost/magnum-cluster-api@sha256:e0be0ebfba578821d7a0025ae049df7a6a7d7fa4100586428a2fdf83cce8dbd3 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_conductor: quay.io/vexxhost/magnum-cluster-api@sha256:e0be0ebfba578821d7a0025ae049df7a6a7d7fa4100586428a2fdf83cce8dbd3 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_db_sync: quay.io/vexxhost/magnum-cluster-api@sha256:e0be0ebfba578821d7a0025ae049df7a6a7d7fa4100586428a2fdf83cce8dbd3 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
   magnum_registry: docker.io/library/registry:2.7.1
   manila_api: quay.io/vexxhost/manila@sha256:78a258f0a632b0778d91767c4ec7b6f84e6ef1de7cf1e51e726374caa295b8f6 # image-source: quay.io/vexxhost/manila:zed
   manila_data: quay.io/vexxhost/manila@sha256:78a258f0a632b0778d91767c4ec7b6f84e6ef1de7cf1e51e726374caa295b8f6 # image-source: quay.io/vexxhost/manila:zed

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -97,10 +97,10 @@ _atmosphere_images:
   local_path_provisioner: docker.io/rancher/local-path-provisioner:v0.0.24
   loki: docker.io/grafana/loki:2.7.3
   loki_gateway: docker.io/nginxinc/nginx-unprivileged:1.19-alpine
-  magnum_api: quay.io/vexxhost/magnum-cluster-api@sha256:e0be0ebfba578821d7a0025ae049df7a6a7d7fa4100586428a2fdf83cce8dbd3 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
-  magnum_cluster_api_proxy: quay.io/vexxhost/magnum-cluster-api@sha256:e0be0ebfba578821d7a0025ae049df7a6a7d7fa4100586428a2fdf83cce8dbd3 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
-  magnum_conductor: quay.io/vexxhost/magnum-cluster-api@sha256:e0be0ebfba578821d7a0025ae049df7a6a7d7fa4100586428a2fdf83cce8dbd3 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
-  magnum_db_sync: quay.io/vexxhost/magnum-cluster-api@sha256:e0be0ebfba578821d7a0025ae049df7a6a7d7fa4100586428a2fdf83cce8dbd3 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_api: quay.io/vexxhost/magnum-cluster-api@sha256:99dedbbe201303a0379c4e93b3ed569e60ef73a41811470bfac3f75625703629 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_cluster_api_proxy: quay.io/vexxhost/magnum-cluster-api@sha256:99dedbbe201303a0379c4e93b3ed569e60ef73a41811470bfac3f75625703629 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_conductor: quay.io/vexxhost/magnum-cluster-api@sha256:99dedbbe201303a0379c4e93b3ed569e60ef73a41811470bfac3f75625703629 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_db_sync: quay.io/vexxhost/magnum-cluster-api@sha256:99dedbbe201303a0379c4e93b3ed569e60ef73a41811470bfac3f75625703629 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
   magnum_registry: docker.io/library/registry:2.7.1
   manila_api: quay.io/vexxhost/manila@sha256:78a258f0a632b0778d91767c4ec7b6f84e6ef1de7cf1e51e726374caa295b8f6 # image-source: quay.io/vexxhost/manila:zed
   manila_data: quay.io/vexxhost/manila@sha256:78a258f0a632b0778d91767c4ec7b6f84e6ef1de7cf1e51e726374caa295b8f6 # image-source: quay.io/vexxhost/manila:zed

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -33,9 +33,9 @@ _atmosphere_images:
   cinder_storage_init: quay.io/vexxhost/cinder@sha256:875bc983a9c2a2d1fb6a952d147f2474a169dc77eb9dff4741f3a185c28753fb # image-source: quay.io/vexxhost/cinder:zed
   cinder_volume_usage_audit: quay.io/vexxhost/cinder@sha256:875bc983a9c2a2d1fb6a952d147f2474a169dc77eb9dff4741f3a185c28753fb # image-source: quay.io/vexxhost/cinder:zed
   cinder_volume: quay.io/vexxhost/cinder@sha256:875bc983a9c2a2d1fb6a952d147f2474a169dc77eb9dff4741f3a185c28753fb # image-source: quay.io/vexxhost/cinder:zed
-  cluster_api_controller: registry.k8s.io/cluster-api/cluster-api-controller:v1.3.3
-  cluster_api_kubeadm_bootstrap_controller: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.3.3
-  cluster_api_kubeadm_control_plane_controller: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.3.3
+  cluster_api_controller: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.4
+  cluster_api_kubeadm_bootstrap_controller: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.4.4
+  cluster_api_kubeadm_control_plane_controller: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.4.4
   cluster_api_openstack_controller: quay.io/vexxhost/capi-openstack-controller:v0.7.1-1
   csi_node_driver_registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.4.0
   csi_rbd_attacher: registry.k8s.io/sig-storage/csi-attacher:v3.4.0


### PR DESCRIPTION
The changes in 1.4 CAPI allow for changing the annotations without causing a full rollout.  We need those fixes in order to be able to deliver a smoother way of managing node groups min/max labels.