### PR TITLE
Bump images for _atmosphere_images

### DIFF
--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -109,21 +109,21 @@ _atmosphere_images:
   manila_share: quay.io/vexxhost/manila@sha256:78a258f0a632b0778d91767c4ec7b6f84e6ef1de7cf1e51e726374caa295b8f6 # image-source: quay.io/vexxhost/manila:zed
   memcached: docker.io/library/memcached:1.6.17
   netoffload: ghcr.io/vexxhost/netoffload:v1.0.1
-  neutron_bagpipe_bgp: quay.io/vexxhost/neutron@sha256:1f7e7d9d3db9100b55243b33bd215aebec89939b8249411153fc4035db62ba93 # image-source: quay.io/vexxhost/neutron:zed
+  neutron_bagpipe_bgp: quay.io/vexxhost/neutron@sha256:ab7bebc32aebd7fdb698656959eca85bdd12b091cf175c47493f7cbc83ef8ec0 # image-source: quay.io/vexxhost/neutron:zed
   neutron_coredns: docker.io/coredns/coredns:1.9.3
-  neutron_db_sync: quay.io/vexxhost/neutron@sha256:1f7e7d9d3db9100b55243b33bd215aebec89939b8249411153fc4035db62ba93 # image-source: quay.io/vexxhost/neutron:zed
-  neutron_dhcp: quay.io/vexxhost/neutron@sha256:1f7e7d9d3db9100b55243b33bd215aebec89939b8249411153fc4035db62ba93 # image-source: quay.io/vexxhost/neutron:zed
-  neutron_ironic_agent: quay.io/vexxhost/neutron@sha256:1f7e7d9d3db9100b55243b33bd215aebec89939b8249411153fc4035db62ba93 # image-source: quay.io/vexxhost/neutron:zed
-  neutron_l2gw: quay.io/vexxhost/neutron@sha256:1f7e7d9d3db9100b55243b33bd215aebec89939b8249411153fc4035db62ba93 # image-source: quay.io/vexxhost/neutron:zed
-  neutron_l3: quay.io/vexxhost/neutron@sha256:1f7e7d9d3db9100b55243b33bd215aebec89939b8249411153fc4035db62ba93 # image-source: quay.io/vexxhost/neutron:zed
-  neutron_linuxbridge_agent: quay.io/vexxhost/neutron@sha256:1f7e7d9d3db9100b55243b33bd215aebec89939b8249411153fc4035db62ba93 # image-source: quay.io/vexxhost/neutron:zed
-  neutron_metadata: quay.io/vexxhost/neutron@sha256:1f7e7d9d3db9100b55243b33bd215aebec89939b8249411153fc4035db62ba93 # image-source: quay.io/vexxhost/neutron:zed
-  neutron_netns_cleanup_cron: quay.io/vexxhost/neutron@sha256:1f7e7d9d3db9100b55243b33bd215aebec89939b8249411153fc4035db62ba93 # image-source: quay.io/vexxhost/neutron:zed
-  neutron_openvswitch_agent: quay.io/vexxhost/neutron@sha256:1f7e7d9d3db9100b55243b33bd215aebec89939b8249411153fc4035db62ba93 # image-source: quay.io/vexxhost/neutron:zed
-  neutron_ovn_metadata: quay.io/vexxhost/neutron@sha256:1f7e7d9d3db9100b55243b33bd215aebec89939b8249411153fc4035db62ba93 # image-source: quay.io/vexxhost/neutron:zed
-  neutron_server: quay.io/vexxhost/neutron@sha256:1f7e7d9d3db9100b55243b33bd215aebec89939b8249411153fc4035db62ba93 # image-source: quay.io/vexxhost/neutron:zed
-  neutron_sriov_agent_init: quay.io/vexxhost/neutron@sha256:1f7e7d9d3db9100b55243b33bd215aebec89939b8249411153fc4035db62ba93 # image-source: quay.io/vexxhost/neutron:zed
-  neutron_sriov_agent: quay.io/vexxhost/neutron@sha256:1f7e7d9d3db9100b55243b33bd215aebec89939b8249411153fc4035db62ba93 # image-source: quay.io/vexxhost/neutron:zed
+  neutron_db_sync: quay.io/vexxhost/neutron@sha256:ab7bebc32aebd7fdb698656959eca85bdd12b091cf175c47493f7cbc83ef8ec0 # image-source: quay.io/vexxhost/neutron:zed
+  neutron_dhcp: quay.io/vexxhost/neutron@sha256:ab7bebc32aebd7fdb698656959eca85bdd12b091cf175c47493f7cbc83ef8ec0 # image-source: quay.io/vexxhost/neutron:zed
+  neutron_ironic_agent: quay.io/vexxhost/neutron@sha256:ab7bebc32aebd7fdb698656959eca85bdd12b091cf175c47493f7cbc83ef8ec0 # image-source: quay.io/vexxhost/neutron:zed
+  neutron_l2gw: quay.io/vexxhost/neutron@sha256:ab7bebc32aebd7fdb698656959eca85bdd12b091cf175c47493f7cbc83ef8ec0 # image-source: quay.io/vexxhost/neutron:zed
+  neutron_l3: quay.io/vexxhost/neutron@sha256:ab7bebc32aebd7fdb698656959eca85bdd12b091cf175c47493f7cbc83ef8ec0 # image-source: quay.io/vexxhost/neutron:zed
+  neutron_linuxbridge_agent: quay.io/vexxhost/neutron@sha256:ab7bebc32aebd7fdb698656959eca85bdd12b091cf175c47493f7cbc83ef8ec0 # image-source: quay.io/vexxhost/neutron:zed
+  neutron_metadata: quay.io/vexxhost/neutron@sha256:ab7bebc32aebd7fdb698656959eca85bdd12b091cf175c47493f7cbc83ef8ec0 # image-source: quay.io/vexxhost/neutron:zed
+  neutron_netns_cleanup_cron: quay.io/vexxhost/neutron@sha256:ab7bebc32aebd7fdb698656959eca85bdd12b091cf175c47493f7cbc83ef8ec0 # image-source: quay.io/vexxhost/neutron:zed
+  neutron_openvswitch_agent: quay.io/vexxhost/neutron@sha256:ab7bebc32aebd7fdb698656959eca85bdd12b091cf175c47493f7cbc83ef8ec0 # image-source: quay.io/vexxhost/neutron:zed
+  neutron_ovn_metadata: quay.io/vexxhost/neutron@sha256:ab7bebc32aebd7fdb698656959eca85bdd12b091cf175c47493f7cbc83ef8ec0 # image-source: quay.io/vexxhost/neutron:zed
+  neutron_server: quay.io/vexxhost/neutron@sha256:ab7bebc32aebd7fdb698656959eca85bdd12b091cf175c47493f7cbc83ef8ec0 # image-source: quay.io/vexxhost/neutron:zed
+  neutron_sriov_agent_init: quay.io/vexxhost/neutron@sha256:ab7bebc32aebd7fdb698656959eca85bdd12b091cf175c47493f7cbc83ef8ec0 # image-source: quay.io/vexxhost/neutron:zed
+  neutron_sriov_agent: quay.io/vexxhost/neutron@sha256:ab7bebc32aebd7fdb698656959eca85bdd12b091cf175c47493f7cbc83ef8ec0 # image-source: quay.io/vexxhost/neutron:zed
   node_feature_discovery: registry.k8s.io/nfd/node-feature-discovery:v0.11.2
   nova_api: quay.io/vexxhost/nova@sha256:bd4a877013053e134a33edc18546f99923a2057072328a4323683eb315acd308 # image-source: quay.io/vexxhost/nova:zed
   nova_archive_deleted_rows: quay.io/vexxhost/nova@sha256:bd4a877013053e134a33edc18546f99923a2057072328a4323683eb315acd308 # image-source: quay.io/vexxhost/nova:zed


### PR DESCRIPTION
This introduce fixes for public subnet.

fix https://github.com/vexxhost/atmosphere/issues/399

So after this fix, only member in admin project (where public network created) can add subnets to `public`
