### PR TITLE
feat(libvirt): add tls for vnc+live migration

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -45,16 +45,16 @@ build.collections:
 
 image:
   FROM python:3.10-slim
-  COPY +build.venv.runtime/venv /venv
-  COPY +build.collections/ /usr/share/ansible
   ENV ANSIBLE_PIPELINING=True
-  ENV PATH=/venv/bin:$PATH
   RUN \
     apt-get update && \
     apt-get install --no-install-recommends -y rsync openssh-client && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
   CMD ["/bin/bash"]
+  COPY +build.venv.runtime/venv /venv
+  ENV PATH=/venv/bin:$PATH
+  COPY +build.collections/ /usr/share/ansible
   ARG tag=latest
   SAVE IMAGE --push ghcr.io/vexxhost/atmosphere:${tag}
 

--- a/build/pin-images.py
+++ b/build/pin-images.py
@@ -29,14 +29,20 @@ def get_pinned_image(image_src):
         # Get token for docker.io
         r = requests.get(
             "https://auth.docker.io/token",
-            params={"service": "registry.docker.io", "scope": f"repository:{image_ref.path()}:pull"},
+            params={
+                "service": "registry.docker.io",
+                "scope": f"repository:{image_ref.path()}:pull",
+            },
         )
         r.raise_for_status()
         token = r.json()["token"]
 
         r = requests.get(
             f"https://registry-1.docker.io/v2/{image_ref.path()}/manifests/{image_ref['tag']}",
-            headers={"Accept": "application/vnd.docker.distribution.manifest.v2+json", "Authorization": f"Bearer {token}"},
+            headers={
+                "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+                "Authorization": f"Bearer {token}",
+            },
         )
         r.raise_for_status()
         digest = r.headers["Docker-Content-Digest"]

--- a/build/pin-images.py
+++ b/build/pin-images.py
@@ -25,6 +25,22 @@ def get_pinned_image(image_src):
         r.raise_for_status()
         digest = r.json()["tags"][0]["manifest_digest"]
 
+    if image_ref.domain() == "docker.io":
+        # Get token for docker.io
+        r = requests.get(
+            "https://auth.docker.io/token",
+            params={"service": "registry.docker.io", "scope": f"repository:{image_ref.path()}:pull"},
+        )
+        r.raise_for_status()
+        token = r.json()["token"]
+
+        r = requests.get(
+            f"https://registry-1.docker.io/v2/{image_ref.path()}/manifests/{image_ref['tag']}",
+            headers={"Accept": "application/vnd.docker.distribution.manifest.v2+json", "Authorization": f"Bearer {token}"},
+        )
+        r.raise_for_status()
+        digest = r.headers["Docker-Content-Digest"]
+
     return f"{image_ref.domain()}/{image_ref.path()}@{digest}"
 
 

--- a/charts/libvirt/templates/bin/_cert-init.sh.tpl
+++ b/charts/libvirt/templates/bin/_cert-init.sh.tpl
@@ -29,6 +29,7 @@ metadata:
       uid: ${POD_UID}
 spec:
   secretName: ${POD_NAME}-${TYPE}
+  commonName: ${POD_IP}
   usages:
   - client auth
   - server auth

--- a/charts/libvirt/templates/bin/_cert-init.sh.tpl
+++ b/charts/libvirt/templates/bin/_cert-init.sh.tpl
@@ -43,6 +43,6 @@ EOF
 kubectl -n ${POD_NAMESPACE} wait --for=condition=Ready --timeout=300s \
   certificate/${POD_NAME}-${TYPE}
 
-kubectl -n ${POD_NAMESPACE} get secret ${POD_NAME}-${TYPE} -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/${POD_NAME}-${TYPE}.crt
-kubectl -n ${POD_NAMESPACE} get secret ${POD_NAME}-${TYPE} -o jsonpath='{.data.tls\.key}' | base64 -d > /tmp/${POD_NAME}-${TYPE}.key
-kubectl -n ${POD_NAMESPACE} get secret ${POD_NAME}-${TYPE} -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/${POD_NAME}-${TYPE}.ca.crt
+kubectl -n ${POD_NAMESPACE} get secret ${POD_NAME}-${TYPE} -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/${TYPE}.crt
+kubectl -n ${POD_NAMESPACE} get secret ${POD_NAME}-${TYPE} -o jsonpath='{.data.tls\.key}' | base64 -d > /tmp/${TYPE}.key
+kubectl -n ${POD_NAMESPACE} get secret ${POD_NAME}-${TYPE} -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/${TYPE}-ca.crt

--- a/charts/libvirt/templates/bin/_cert-init.sh.tpl
+++ b/charts/libvirt/templates/bin/_cert-init.sh.tpl
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+{{/*
+Copyright (c) 2023 VEXXHOST, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+cat <<EOF | kubectl apply -f -
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${POD_NAME}-${TYPE}
+  namespace: ${POD_NAMESPACE}
+  ownerReferences:
+    - apiVersion: v1
+      kind: Pod
+      name: ${POD_NAME}
+      uid: ${POD_UID}
+spec:
+  secretName: ${POD_NAME}-${TYPE}
+  usages:
+  - server auth
+  dnsNames:
+  - ${HOSTNAME}
+  ipAddresses:
+  - ${POD_IP}
+  issuerRef:
+    kind: Issuer
+    name: libvirt-${TYPE}
+EOF
+
+kubectl -n ${POD_NAMESPACE} wait --for=condition=Ready --timeout=300s \
+  certificate/${POD_NAME}-${TYPE}

--- a/charts/libvirt/templates/bin/_cert-init.sh.tpl
+++ b/charts/libvirt/templates/bin/_cert-init.sh.tpl
@@ -30,6 +30,7 @@ metadata:
 spec:
   secretName: ${POD_NAME}-${TYPE}
   usages:
+  - client auth
   - server auth
   dnsNames:
   - ${HOSTNAME}

--- a/charts/libvirt/templates/bin/_cert-init.sh.tpl
+++ b/charts/libvirt/templates/bin/_cert-init.sh.tpl
@@ -42,3 +42,7 @@ EOF
 
 kubectl -n ${POD_NAMESPACE} wait --for=condition=Ready --timeout=300s \
   certificate/${POD_NAME}-${TYPE}
+
+kubectl -n ${POD_NAMESPACE} get secret ${POD_NAME}-${TYPE} -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/${POD_NAME}-${TYPE}.crt
+kubectl -n ${POD_NAMESPACE} get secret ${POD_NAME}-${TYPE} -o jsonpath='{.data.tls\.key}' | base64 -d > /tmp/${POD_NAME}-${TYPE}.key
+kubectl -n ${POD_NAMESPACE} get secret ${POD_NAME}-${TYPE} -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/${POD_NAME}-${TYPE}.ca.crt

--- a/charts/libvirt/templates/bin/_libvirt.sh.tpl
+++ b/charts/libvirt/templates/bin/_libvirt.sh.tpl
@@ -16,6 +16,22 @@ limitations under the License.
 
 set -ex
 
+# NOTE(mnaser): This will move the API certificates into the expected location.
+if [ -f /tmp/api.crt ]; then
+  mkdir -p /etc/pki/libvirt/private
+  mv /tmp/api.key {{ .Values.conf.libvirt.key_file }}
+  mv /tmp/api.crt {{ .Values.conf.libvirt.cert_file }}
+  mv /tmp/api-ca.crt {{ .Values.conf.libvirt.ca_file }}
+fi
+
+# TODO(mnaser): This will move the VNC certificates into the expected location.
+# if [ -f /tmp/vnc.crt ]; then
+#   mkdir -p /etc/pki/libvirt/private
+#   mv /tmp/vnc.key {{ .Values.conf.libvirt.vnc_key_file }}
+#   mv /tmp/vnc.crt {{ .Values.conf.libvirt.vnc_cert_file }}
+#   mv /tmp/vnc-ca.crt {{ .Values.conf.libvirt.vnc_ca_file }}
+# fi
+
 if [ -n "$(cat /proc/*/comm 2>/dev/null | grep -w libvirtd)" ]; then
   set +x
   for proc in $(ls /proc/*/comm 2>/dev/null); do

--- a/charts/libvirt/templates/bin/_libvirt.sh.tpl
+++ b/charts/libvirt/templates/bin/_libvirt.sh.tpl
@@ -18,19 +18,19 @@ set -ex
 
 # NOTE(mnaser): This will move the API certificates into the expected location.
 if [ -f /tmp/api.crt ]; then
-  mkdir -p /etc/pki/libvirt/private
+  mkdir -p /etc/pki/CA /etc/pki/libvirt/private
   mv /tmp/api.key {{ .Values.conf.libvirt.key_file }}
   mv /tmp/api.crt {{ .Values.conf.libvirt.cert_file }}
   mv /tmp/api-ca.crt {{ .Values.conf.libvirt.ca_file }}
 fi
 
-# TODO(mnaser): This will move the VNC certificates into the expected location.
-# if [ -f /tmp/vnc.crt ]; then
-#   mkdir -p /etc/pki/libvirt/private
-#   mv /tmp/vnc.key {{ .Values.conf.libvirt.vnc_key_file }}
-#   mv /tmp/vnc.crt {{ .Values.conf.libvirt.vnc_cert_file }}
-#   mv /tmp/vnc-ca.crt {{ .Values.conf.libvirt.vnc_ca_file }}
-# fi
+# NOTE(mnaser): This will move the VNC certificates into the expected location.
+if [ -f /tmp/vnc.crt ]; then
+  mkdir -p /etc/pki/libvirt-vnc
+  mv /tmp/vnc.key /etc/pki/libvirt-vnc/server-key.pem
+  mv /tmp/vnc.crt /etc/pki/libvirt-vnc/server-cert.pem
+  mv /tmp/vnc-ca.crt /etc/pki/libvirt-vnc/ca-cert.pem
+fi
 
 if [ -n "$(cat /proc/*/comm 2>/dev/null | grep -w libvirtd)" ]; then
   set +x

--- a/charts/libvirt/templates/bin/_libvirt.sh.tpl
+++ b/charts/libvirt/templates/bin/_libvirt.sh.tpl
@@ -18,7 +18,7 @@ set -ex
 
 # NOTE(mnaser): This will move the API certificates into the expected location.
 if [ -f /tmp/api.crt ]; then
-  mkdir -p /etc/pki/CA /etc/pki/qemu /etc/pki/libvirt/private
+  mkdir -p /etc/pki/CA /etc/pki/libvirt/private
 
   cp /tmp/api-ca.crt {{ .Values.conf.libvirt.ca_file }}
   cp /tmp/api-ca.crt /etc/pki/qemu/ca-cert.pem

--- a/charts/libvirt/templates/bin/_libvirt.sh.tpl
+++ b/charts/libvirt/templates/bin/_libvirt.sh.tpl
@@ -18,10 +18,20 @@ set -ex
 
 # NOTE(mnaser): This will move the API certificates into the expected location.
 if [ -f /tmp/api.crt ]; then
-  mkdir -p /etc/pki/CA /etc/pki/libvirt/private
-  mv /tmp/api.key {{ .Values.conf.libvirt.key_file }}
-  mv /tmp/api.crt {{ .Values.conf.libvirt.cert_file }}
-  mv /tmp/api-ca.crt {{ .Values.conf.libvirt.ca_file }}
+  mkdir -p /etc/pki/CA /etc/pki/qemu /etc/pki/libvirt/private
+
+  cp /tmp/api-ca.crt {{ .Values.conf.libvirt.ca_file }}
+  cp /tmp/api-ca.crt /etc/pki/qemu/ca-cert.pem
+
+  cp /tmp/api.crt {{ .Values.conf.libvirt.cert_file }}
+  cp /tmp/api.crt /etc/pki/libvirt/clientcert.pem
+  cp /tmp/api.crt /etc/pki/qemu/server-cert.pem
+  cp /tmp/api.crt /etc/pki/qemu/client-cert.pem
+
+  cp /tmp/api.key {{ .Values.conf.libvirt.key_file }}
+  cp /tmp/api.key /etc/pki/libvirt/private/clientkey.pem
+  cp /tmp/api.key /etc/pki/qemu/server-key.pem
+  cp /tmp/api.key /etc/pki/qemu/client-key.pem
 fi
 
 # NOTE(mnaser): This will move the VNC certificates into the expected location.

--- a/charts/libvirt/templates/certificate-ca.yaml
+++ b/charts/libvirt/templates/certificate-ca.yaml
@@ -1,0 +1,58 @@
+{{/*
+Copyright (c) 2023 VEXXHOST, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if eq .Values.conf.libvirt.listen_tls "1" }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-api-ca
+  namespace: {{ .Release.Namespace }}
+spec:
+  commonName: {{ .Release.Name }}
+  duration: 87600h0m0s
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: self-signed
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  renewBefore: 720h0m0s
+  secretName: {{ .Release.Name }}-api-ca
+{{- end -}}
+{{- if eq .Values.conf.qemu.vnc_tls "1" }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-vnc-ca
+  namespace: {{ .Release.Namespace }}
+spec:
+  commonName: {{ .Release.Name }}
+  duration: 87600h0m0s
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: self-signed
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  renewBefore: 720h0m0s
+  secretName: {{ .Release.Name }}-vnc-ca
+{{- end -}}

--- a/charts/libvirt/templates/configmap-bin.yaml
+++ b/charts/libvirt/templates/configmap-bin.yaml
@@ -26,6 +26,10 @@ data:
 {{- end }}
   libvirt.sh: |
 {{ tuple "bin/_libvirt.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
+{{- if or (eq .Values.conf.libvirt.listen_tls "1") (eq .Values.conf.qemu.vnc_tls "1") }}
+  cert-init.sh: |
+{{ tuple "bin/_cert-init.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
+{{- end }}
 {{- if .Values.conf.ceph.enabled }}
   ceph-keyring.sh: |
 {{ tuple "bin/_ceph-keyring.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}

--- a/charts/libvirt/templates/daemonset-libvirt.yaml
+++ b/charts/libvirt/templates/daemonset-libvirt.yaml
@@ -93,6 +93,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           volumeMounts:
             - name: libvirt-bin
               mountPath: /tmp/cert-init.sh
@@ -120,6 +124,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           volumeMounts:
             - name: libvirt-bin
               mountPath: /tmp/cert-init.sh

--- a/charts/libvirt/templates/daemonset-libvirt.yaml
+++ b/charts/libvirt/templates/daemonset-libvirt.yaml
@@ -89,7 +89,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: POD_NAMESPACE:
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
@@ -116,7 +116,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: POD_NAMESPACE:
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace

--- a/charts/libvirt/templates/daemonset-libvirt.yaml
+++ b/charts/libvirt/templates/daemonset-libvirt.yaml
@@ -240,6 +240,10 @@ spec:
               readOnly: true
             - name: etc-libvirt-qemu
               mountPath: /etc/libvirt/qemu
+{{- if eq .Values.conf.libvirt.listen_tls "1" }}
+            - name: etc-pki-qemu
+              mountPath: /etc/pki/qemu
+{{- end }}
             - mountPath: /lib/modules
               name: libmodules
               readOnly: true
@@ -341,6 +345,11 @@ spec:
         - name: etc-libvirt-qemu
           hostPath:
             path: /etc/libvirt/qemu
+{{- if eq .Values.conf.libvirt.listen_tls "1" }}
+        - name: etc-pki-qemu
+          hostPath:
+            path: /etc/pki/qemu
+{{- end }}
 {{ dict "envAll" $envAll "component" "libvirt" "requireSys" true | include "helm-toolkit.snippets.kubernetes_apparmor_volumes" | indent 8 }}
 {{ if $mounts_libvirt.volumes }}{{ toYaml $mounts_libvirt.volumes | indent 8 }}{{ end }}
 {{- end }}

--- a/charts/libvirt/templates/daemonset-libvirt.yaml
+++ b/charts/libvirt/templates/daemonset-libvirt.yaml
@@ -32,10 +32,6 @@ exec:
 {{- $configMapName := index . 1 }}
 {{- $serviceAccountName := index . 2 }}
 {{- $envAll := index . 3 }}
-{{- $ssl_enabled := false }}
-{{- if eq $envAll.Values.conf.libvirt.listen_tls "1" }}
-{{- $ssl_enabled = true }}
-{{- end }}
 {{- with $envAll }}
 
 {{- $mounts_libvirt := .Values.pod.mounts.libvirt.libvirt }}
@@ -216,10 +212,6 @@ spec:
                   - |-
                     kill $(cat /var/run/libvirtd.pid)
           volumeMounts:
-            {{ dict "enabled" $ssl_enabled "name" "ssl-client" "path" "/etc/pki/libvirt" "certs" (tuple "clientcert.pem" "clientkey.pem" ) | include "helm-toolkit.snippets.tls_volume_mount" | indent 12 }}
-            {{ dict "enabled" $ssl_enabled "name" "ssl-server-cert" "path" "/etc/pki/libvirt" "certs" (tuple "servercert.pem" ) | include "helm-toolkit.snippets.tls_volume_mount" | indent 12 }}
-            {{ dict "enabled" $ssl_enabled "name" "ssl-server-key" "path" "/etc/pki/libvirt/private" "certs" (tuple "serverkey.pem" ) | include "helm-toolkit.snippets.tls_volume_mount" | indent 12 }}
-            {{ dict "enabled" $ssl_enabled "name" "ssl-ca-cert" "path" "/etc/pki/CA" "certs" (tuple "cacert.pem" ) | include "helm-toolkit.snippets.tls_volume_mount" | indent 12 }}
             - name: pod-tmp
               mountPath: /tmp
             - name: libvirt-bin
@@ -281,10 +273,6 @@ spec:
             {{- end }}
 {{ if $mounts_libvirt.volumeMounts }}{{ toYaml $mounts_libvirt.volumeMounts | indent 12 }}{{ end }}
       volumes:
-        {{ dict "enabled" $ssl_enabled "secretName" $envAll.Values.secrets.tls.client "name" "ssl-client" "path" "/etc/pki/libvirt" "certs" (tuple "clientcert.pem" "clientkey.pem" ) | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
-        {{ dict "enabled" $ssl_enabled "secretName" $envAll.Values.secrets.tls.server "name" "ssl-server-cert" "path" "/etc/pki/libvirt" "certs" (tuple "servercert.pem" ) | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
-        {{ dict "enabled" $ssl_enabled "secretName" $envAll.Values.secrets.tls.server "name" "ssl-server-key" "path" "/etc/pki/libvirt/private" "certs" (tuple "serverkey.pem" ) | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
-        {{ dict "enabled" $ssl_enabled "secretName" $envAll.Values.secrets.tls.server "name" "ssl-ca-cert" "path" "/etc/pki/CA" "certs" (tuple "cacert.pem" ) | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
         - name: pod-tmp
           emptyDir: {}
         - name: libvirt-bin

--- a/charts/libvirt/templates/daemonset-libvirt.yaml
+++ b/charts/libvirt/templates/daemonset-libvirt.yaml
@@ -98,6 +98,8 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           volumeMounts:
+            - name: pod-tmp
+              mountPath: /tmp
             - name: libvirt-bin
               mountPath: /tmp/cert-init.sh
               subPath: cert-init.sh
@@ -129,6 +131,8 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           volumeMounts:
+            - name: pod-tmp
+              mountPath: /tmp
             - name: libvirt-bin
               mountPath: /tmp/cert-init.sh
               subPath: cert-init.sh

--- a/charts/libvirt/templates/daemonset-libvirt.yaml
+++ b/charts/libvirt/templates/daemonset-libvirt.yaml
@@ -281,6 +281,10 @@ spec:
             {{- end }}
 {{ if $mounts_libvirt.volumeMounts }}{{ toYaml $mounts_libvirt.volumeMounts | indent 12 }}{{ end }}
       volumes:
+        {{ dict "enabled" $ssl_enabled "secretName" $envAll.Values.secrets.tls.client "name" "ssl-client" "path" "/etc/pki/libvirt" "certs" (tuple "clientcert.pem" "clientkey.pem" ) | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
+        {{ dict "enabled" $ssl_enabled "secretName" $envAll.Values.secrets.tls.server "name" "ssl-server-cert" "path" "/etc/pki/libvirt" "certs" (tuple "servercert.pem" ) | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
+        {{ dict "enabled" $ssl_enabled "secretName" $envAll.Values.secrets.tls.server "name" "ssl-server-key" "path" "/etc/pki/libvirt/private" "certs" (tuple "serverkey.pem" ) | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
+        {{ dict "enabled" $ssl_enabled "secretName" $envAll.Values.secrets.tls.server "name" "ssl-ca-cert" "path" "/etc/pki/CA" "certs" (tuple "cacert.pem" ) | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
         - name: pod-tmp
           emptyDir: {}
         - name: libvirt-bin

--- a/charts/libvirt/templates/daemonset-libvirt.yaml
+++ b/charts/libvirt/templates/daemonset-libvirt.yaml
@@ -76,6 +76,60 @@ spec:
       initContainers:
 {{ tuple $envAll "pod_dependency" $mounts_libvirt_init | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
 {{ dict "envAll" $envAll | include "helm-toolkit.snippets.kubernetes_apparmor_loader_init_container" | indent 8 }}
+{{- if eq .Values.conf.libvirt.listen_tls "1" }}
+        - name: cert-init-api
+{{ tuple $envAll "kubectl" | include "helm-toolkit.snippets.image" | indent 10 }}
+{{ dict "envAll" $envAll "application" "libvirt" "container" "cert_init" | include "helm-toolkit.snippets.kubernetes_container_security_context" | indent 10 }}
+          command:
+            - /tmp/cert-init.sh
+          env:
+            - name: TYPE
+              value: api
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE:
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: libvirt-bin
+              mountPath: /tmp/cert-init.sh
+              subPath: cert-init.sh
+              readOnly: true
+{{- end }}
+{{- if eq .Values.conf.qemu.vnc_tls "1" }}
+        - name: cert-init-vnc
+{{ tuple $envAll "kubectl" | include "helm-toolkit.snippets.image" | indent 10 }}
+{{ dict "envAll" $envAll "application" "libvirt" "container" "cert_init" | include "helm-toolkit.snippets.kubernetes_container_security_context" | indent 10 }}
+          command:
+            - /tmp/cert-init.sh
+          env:
+            - name: TYPE
+              value: vnc
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE:
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: libvirt-bin
+              mountPath: /tmp/cert-init.sh
+              subPath: cert-init.sh
+              readOnly: true
+{{- end }}
 {{- if .Values.conf.ceph.enabled }}
         {{- if empty .Values.conf.ceph.cinder.keyring }}
         - name: ceph-admin-keyring-placement
@@ -227,10 +281,6 @@ spec:
             {{- end }}
 {{ if $mounts_libvirt.volumeMounts }}{{ toYaml $mounts_libvirt.volumeMounts | indent 12 }}{{ end }}
       volumes:
-        {{ dict "enabled" $ssl_enabled "secretName" $envAll.Values.secrets.tls.client "name" "ssl-client" "path" "/etc/pki/libvirt" "certs" (tuple "clientcert.pem" "clientkey.pem" ) | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
-        {{ dict "enabled" $ssl_enabled "secretName" $envAll.Values.secrets.tls.server "name" "ssl-server-cert" "path" "/etc/pki/libvirt" "certs" (tuple "servercert.pem" ) | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
-        {{ dict "enabled" $ssl_enabled "secretName" $envAll.Values.secrets.tls.server "name" "ssl-server-key" "path" "/etc/pki/libvirt/private" "certs" (tuple "serverkey.pem" ) | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
-        {{ dict "enabled" $ssl_enabled "secretName" $envAll.Values.secrets.tls.server "name" "ssl-ca-cert" "path" "/etc/pki/CA" "certs" (tuple "cacert.pem" ) | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
         - name: pod-tmp
           emptyDir: {}
         - name: libvirt-bin

--- a/charts/libvirt/templates/issuer.yaml
+++ b/charts/libvirt/templates/issuer.yaml
@@ -14,34 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if or (eq .Values.conf.libvirt.listen_tls "1") (eq .Values.conf.qemu.vnc_tls "1") }}
+{{- if eq .Values.conf.libvirt.listen_tls "1" }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+apiVersion: cert-manager.io/v1
+kind: Issuer
 metadata:
-  name: {{ .Release.Name }}-cert-manager
+  name: {{ .Release.Name }}-api-ca
   namespace: {{ .Release.Namespace }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ .Release.Name }}-cert-manager
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}
-    namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: {{ .Release.Name }}-api-ca
+{{- end -}}
+{{- if eq .Values.conf.qemu.vnc_tls "1" }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+apiVersion: cert-manager.io/v1
+kind: Issuer
 metadata:
-  name: {{ .Release.Name }}-cert-manager
+  name: {{ .Release.Name }}-vnc-ca
   namespace: {{ .Release.Namespace }}
-rules:
-  - apiGroups:
-      - cert-manager.io
-    verbs:
-      - get
-      - list
-      - create
-    resources:
-      - certificates
+spec:
+  ca:
+    secretName: {{ .Release.Name }}-vnc-ca
 {{- end -}}

--- a/charts/libvirt/templates/issuer.yaml
+++ b/charts/libvirt/templates/issuer.yaml
@@ -19,7 +19,7 @@ limitations under the License.
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ .Release.Name }}-api-ca
+  name: {{ .Release.Name }}-api
   namespace: {{ .Release.Namespace }}
 spec:
   ca:
@@ -30,7 +30,7 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ .Release.Name }}-vnc-ca
+  name: {{ .Release.Name }}-vnc
   namespace: {{ .Release.Namespace }}
 spec:
   ca:

--- a/charts/libvirt/templates/role-cert-manager.yaml
+++ b/charts/libvirt/templates/role-cert-manager.yaml
@@ -48,6 +48,7 @@ rules:
       - ""
     verbs:
       - get
+      - patch
     resources:
       - secrets
 {{- end -}}

--- a/charts/libvirt/templates/role-cert-manager.yaml
+++ b/charts/libvirt/templates/role-cert-manager.yaml
@@ -44,4 +44,10 @@ rules:
       - create
     resources:
       - certificates
+  - apiGroups:
+      - ""
+    verbs:
+      - get
+    resources:
+      - secrets
 {{- end -}}

--- a/charts/libvirt/templates/role-cert-manager.yaml
+++ b/charts/libvirt/templates/role-cert-manager.yaml
@@ -1,0 +1,43 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if or (eq .Values.conf.libvirt.listen_tls "1") (eq .Values.conf.qemu.vnc_tls "1") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-cert-manager
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-cert-manager
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-cert-manager
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - cert-manager.io
+    verbs:
+      - get
+    resources:
+      - certificates
+{{- end -}}

--- a/charts/libvirt/values.yaml
+++ b/charts/libvirt/values.yaml
@@ -208,18 +208,13 @@ dependencies:
         - endpoint: internal
           service: local_image_registry
 
+tls:
+  enabled: false
+
 manifests:
   configmap_bin: true
   configmap_etc: true
   daemonset_libvirt: true
   job_image_repo_sync: true
   network_policy: false
-
-tls:
-  enabled: false
-
-secrets:
-  tls:
-    server: libvirt-tls-server
-    client: libvirt-tls-client
 ...

--- a/charts/libvirt/values.yaml
+++ b/charts/libvirt/values.yaml
@@ -26,6 +26,7 @@ labels:
 
 images:
   tags:
+    kubectl: docker.io/bitnami/kubectl:latest
     libvirt: docker.io/openstackhelm/libvirt:latest-ubuntu_bionic
     ceph_config_helper: 'docker.io/openstackhelm/ceph-config-helper:ubuntu_bionic-20200217'
     dep_check: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
@@ -213,6 +214,9 @@ manifests:
   daemonset_libvirt: true
   job_image_repo_sync: true
   network_policy: false
+
+tls:
+  enabled: false
 
 secrets:
   tls:

--- a/charts/nova/templates/certificate-novnc.yaml
+++ b/charts/nova/templates/certificate-novnc.yaml
@@ -1,0 +1,31 @@
+{{/*
+Copyright (c) 2023 VEXXHOST, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if (contains "vencrypt" .Values.conf.nova.vnc.auth_schemes) -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nova-novncproxy-vencrypt
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: nova-novncproxy-vencrypt
+  commonName: nova-novncproxy
+  usages:
+  - client auth
+  issuerRef:
+    kind: Issuer
+    name: libvirt-vnc
+{{- end -}}

--- a/charts/nova/templates/configmap-etc.yaml
+++ b/charts/nova/templates/configmap-etc.yaml
@@ -85,6 +85,18 @@ limitations under the License.
 {{- $_ := set $envAll.Values.conf.nova.wsgi "api_paste_config" "/var/lib/openstack/etc/nova/api-paste.ini" -}}
 {{- end }}
 
+{{- if (contains "vencrypt" .Values.conf.nova.vnc.auth_schemes) -}}
+{{- if empty .Values.conf.nova.vnc.vencrypt_client_key }}
+{{- $_ := set $envAll.Values.conf.nova.vnc "vencrypt_client_key" "/etc/pki/nova-novncproxy/tls.key" -}}
+{{- end }}
+{{- if empty .Values.conf.nova.vnc.vencrypt_client_cert }}
+{{- $_ := set $envAll.Values.conf.nova.vnc "vencrypt_client_cert" "/etc/pki/nova-novncproxy/tls.crt" -}}
+{{- end }}
+{{- if empty .Values.conf.nova.vnc.vencrypt_ca_certs }}
+{{- $_ := set $envAll.Values.conf.nova.vnc "vencrypt_ca_certs" "/etc/pki/nova-novncproxy/ca.crt" -}}
+{{- end }}
+{{- end }}
+
 {{- if empty .Values.conf.nova.database.connection -}}
 {{- $connection := tuple "oslo_db" "internal" "nova" "mysql" . | include "helm-toolkit.endpoints.authenticated_endpoint_uri_lookup" -}}
 {{- if .Values.manifests.certificates -}}

--- a/charts/nova/templates/deployment-novncproxy.yaml
+++ b/charts/nova/templates/deployment-novncproxy.yaml
@@ -133,7 +133,7 @@ spec:
               mountPath: /etc/nova/nova.conf
               subPath: nova.conf
               readOnly: true
-{{- if (contains "vencrypt" .Values.conf.nova.vnc.auth_schemes) -}}
+{{- if (contains "vencrypt" .Values.conf.nova.vnc.auth_schemes) }}
             - name: vencrypt-certs
               mountPath: /etc/pki/nova-novncproxy
               readOnly: true
@@ -166,7 +166,7 @@ spec:
           emptyDir: {}
         - name: pod-shared
           emptyDir: {}
-{{- if (contains "vencrypt" .Values.conf.nova.vnc.auth_schemes) -}}
+{{- if (contains "vencrypt" .Values.conf.nova.vnc.auth_schemes) }}
         - name: vencrypt-certs
           secret:
             secretName: nova-novncproxy-vencrypt

--- a/charts/nova/templates/deployment-novncproxy.yaml
+++ b/charts/nova/templates/deployment-novncproxy.yaml
@@ -133,6 +133,11 @@ spec:
               mountPath: /etc/nova/nova.conf
               subPath: nova.conf
               readOnly: true
+{{- if (contains "vencrypt" .Values.conf.nova.vnc.auth_schemes) -}}
+            - name: vencrypt-certs
+              mountPath: /etc/pki/nova-novncproxy
+              readOnly: true
+{{- end }}
             - name: nova-etc
               mountPath: /etc/nova/logging.conf
               subPath: logging.conf
@@ -161,6 +166,12 @@ spec:
           emptyDir: {}
         - name: pod-shared
           emptyDir: {}
+{{- if (contains "vencrypt" .Values.conf.nova.vnc.auth_schemes) -}}
+        - name: vencrypt-certs
+          secret:
+            secretName: nova-novncproxy-vencrypt
+            defaultMode: 0444
+{{- end }}
 {{- dict "enabled" .Values.manifests.certificates "name" .Values.endpoints.oslo_db.auth.admin.secret.tls.internal | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
 {{- dict "enabled" .Values.manifests.certificates "name" .Values.secrets.tls.compute_novnc_proxy.novncproxy.internal | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
 {{- dict "enabled" $envAll.Values.manifests.certificates "name" $envAll.Values.endpoints.oslo_messaging.auth.admin.secret.tls.internal | include "helm-toolkit.snippets.tls_volume" | indent 8 }}

--- a/charts/nova/values.yaml
+++ b/charts/nova/values.yaml
@@ -1312,6 +1312,7 @@ conf:
       instance_usage_audit_period: hour
       resume_guests_state_on_host_boot: True
     vnc:
+      auth_schemes: none
       novncproxy_host: 0.0.0.0
       server_listen: 0.0.0.0
       # This would be set by each compute nodes's ip

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -85,6 +85,7 @@ _atmosphere_images:
   ks_endpoints: quay.io/vexxhost/heat@sha256:755225f9a63c0968f1ceeda3a2f06c66dd8d247ff00308f549e66496aa8f59d0 # image-source: quay.io/vexxhost/heat:zed
   ks_service: quay.io/vexxhost/heat@sha256:755225f9a63c0968f1ceeda3a2f06c66dd8d247ff00308f549e66496aa8f59d0 # image-source: quay.io/vexxhost/heat:zed
   ks_user: quay.io/vexxhost/heat@sha256:755225f9a63c0968f1ceeda3a2f06c66dd8d247ff00308f549e66496aa8f59d0 # image-source: quay.io/vexxhost/heat:zed
+  kubectl: docker.io/bitnami/kubectl@sha256:f59ccdfedf272a89983abe62ca277b86c8b0b3fcf913c4b7f637db08f4b21682 # image-source: docker.io/bitnami/kubectl:latest
   kube_apiserver: registry.k8s.io/kube-apiserver:v1.22.17
   kube_controller_manager: registry.k8s.io/kube-controller-manager:v1.22.17
   kube_coredns: registry.k8s.io/coredns/coredns:v1.8.4

--- a/roles/libvirt/vars/main.yml
+++ b/roles/libvirt/vars/main.yml
@@ -20,4 +20,9 @@ _libvirt_helm_values:
     ceph:
       enabled: "{{ atmosphere_ceph_enabled | default(true) | bool }}"
     libvirt:
+      listen_tcp: "0"
+      listen_tls: "1"
       listen_addr: 0.0.0.0
+    qemu:
+      vnc_tls: "1"
+      vnc_tls_x509_verify: "1"

--- a/roles/libvirt/vars/main.yml
+++ b/roles/libvirt/vars/main.yml
@@ -24,5 +24,6 @@ _libvirt_helm_values:
       listen_tls: "1"
       listen_addr: 0.0.0.0
     qemu:
+      default_tls_x509_cert_dir: /etc/pki/qemu
+      default_tls_x509_verify: "1"
       vnc_tls: "1"
-      vnc_tls_x509_verify: "1"

--- a/roles/nova/vars/main.yml
+++ b/roles/nova/vars/main.yml
@@ -87,6 +87,8 @@ _nova_helm_values:
         driver: noop
       scheduler:
         workers: 8
+      vnc:
+        auth_schemes: vencrypt,none
     nova_ironic:
       DEFAULT:
         log_config_append: null

--- a/roles/nova/vars/main.yml
+++ b/roles/nova/vars/main.yml
@@ -82,8 +82,10 @@ _nova_helm_values:
         #                        https://review.opendev.org/883066
         service_type: compute
       libvirt:
-        live_migration_with_native_tls: true
         live_migration_scheme: tls
+        # TODO(mnaser): We should enable this once we figure out how to "inject"
+        #               the certificates into the existing "qemu-kvm" processes.
+        # live_migration_with_native_tls: true
       neutron:
         metadata_proxy_shared_secret: "{{ openstack_helm_endpoints['compute_metadata']['secret'] }}"
       oslo_messaging_notifications:

--- a/roles/nova/vars/main.yml
+++ b/roles/nova/vars/main.yml
@@ -81,6 +81,9 @@ _nova_helm_values:
         # NOTE(okozachenko1203): We can remove it once the following is merged:
         #                        https://review.opendev.org/883066
         service_type: compute
+      libvirt:
+        live_migration_with_native_tls: true
+        live_migration_scheme: tls
       neutron:
         metadata_proxy_shared_secret: "{{ openstack_helm_endpoints['compute_metadata']['secret'] }}"
       oslo_messaging_notifications:


### PR DESCRIPTION
- chore(libvirt): enable tls cert issuance
- chore(images): add kubectl image
- chore(libvirt): enable tls
- chore(libvirt): revert tls change
- chore(libvirt): refactor to dynamic certs
- chore(libvirt): remove extra colon
- chore(libvirt): add POD_IP and rolebinding
- chore(libvirt): add ca and issuer
- fix: use correct issuer name
- chore: save libvirt certs to pod-tmp
- chore(libvirt): start using certs
- chore: added vnc certs
- chore(libvirt): add secret clean-up
- chore(libvirt): add nova tls support for vnc
- chore(libvirt): enable vencrypt
- chore(libvirt): fix yaml indents
- chore(libvirt): enable tls live migration
- chore(libvirt): switch back to tunnelled
