### PR TITLE
Remove old version of kubernetes

### DIFF
--- a/roles/magnum/README.md
+++ b/roles/magnum/README.md
@@ -3,13 +3,13 @@
 ## Creating cluster templates
 
 By default, Atmosphere deploys a set of images for Kubernetes. These cover a
-range of Kubernetes versions, from 1.23.13 to 1.25.3.   You can create the
+range of Kubernetes versions, from 1.25.11 to 1.27.3. You can create the
 cluster templates for them with the following command:
 
 ```shell
-for version in v1.23.13 v1.24.7 v1.25.3; do
+for version in v1.25.11 v1.26.6 v1.27.3; do
   openstack coe cluster template create \
-        --image $(openstack image show ubuntu-2004-${version} -c id -f value) \
+        --image $(openstack image show ubuntu-2204-kube-${version} -c id -f value) \
         --external-network public \
         --dns-nameserver 8.8.8.8 \
         --master-lb-enabled \

--- a/roles/magnum/defaults/main.yml
+++ b/roles/magnum/defaults/main.yml
@@ -43,12 +43,6 @@ magnum_clusterctl_config:
 magnum_image_container_format: bare
 magnum_image_disk_format: raw
 magnum_images:
-  - name: ubuntu-2204-kube-v1.23.17
-    url: https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.23.17.qcow2
-    distro: ubuntu
-  - name: ubuntu-2204-kube-v1.24.15
-    url: https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.24.15.qcow2
-    distro: ubuntu
   - name: ubuntu-2204-kube-v1.25.11
     url: https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.25.11.qcow2
     distro: ubuntu


### PR DESCRIPTION
v1.23 is already at EOL
v1.24.15 is almost to reach it's EOL (2023-07-28)
As we're hitting Ceph space fillup issue, let's remove those support so we can avoid upload images for those deprecated version.