### PR TITLE
Bump magnum image to support magnum rbac

### DIFF
--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -98,10 +98,10 @@ _atmosphere_images:
   local_path_provisioner: docker.io/rancher/local-path-provisioner:v0.0.24
   loki: docker.io/grafana/loki:2.7.3
   loki_gateway: docker.io/nginxinc/nginx-unprivileged:1.19-alpine
-  magnum_api: quay.io/vexxhost/magnum-cluster-api@sha256:e83a885a9c9597ce50fef0d2eaab71dd74858a8aab999dc5de673438c243d400 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
-  magnum_cluster_api_proxy: quay.io/vexxhost/magnum-cluster-api@sha256:e83a885a9c9597ce50fef0d2eaab71dd74858a8aab999dc5de673438c243d400 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
-  magnum_conductor: quay.io/vexxhost/magnum-cluster-api@sha256:e83a885a9c9597ce50fef0d2eaab71dd74858a8aab999dc5de673438c243d400 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
-  magnum_db_sync: quay.io/vexxhost/magnum-cluster-api@sha256:e83a885a9c9597ce50fef0d2eaab71dd74858a8aab999dc5de673438c243d400 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_api: quay.io/vexxhost/magnum-cluster-api@sha256:898fc5aa14e44deba26b864477be7ca18d81b3d7e15a63728cf4e45814a2e392 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_cluster_api_proxy: quay.io/vexxhost/magnum-cluster-api@sha256:898fc5aa14e44deba26b864477be7ca18d81b3d7e15a63728cf4e45814a2e392 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_conductor: quay.io/vexxhost/magnum-cluster-api@sha256:898fc5aa14e44deba26b864477be7ca18d81b3d7e15a63728cf4e45814a2e392 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
+  magnum_db_sync: quay.io/vexxhost/magnum-cluster-api@sha256:898fc5aa14e44deba26b864477be7ca18d81b3d7e15a63728cf4e45814a2e392 # image-source: quay.io/vexxhost/magnum-cluster-api:zed
   magnum_registry: quay.io/vexxhost/magnum-cluster-api-registry@sha256:7b87ffbaf18ad3c08221f940f4346abed4a1b195db333d33cab1fcd94c7286e1 # image-source: quay.io/vexxhost/magnum-cluster-api-registry:latest
   manila_api: quay.io/vexxhost/manila@sha256:78a258f0a632b0778d91767c4ec7b6f84e6ef1de7cf1e51e726374caa295b8f6 # image-source: quay.io/vexxhost/manila:zed
   manila_data: quay.io/vexxhost/manila@sha256:78a258f0a632b0778d91767c4ec7b6f84e6ef1de7cf1e51e726374caa295b8f6 # image-source: quay.io/vexxhost/manila:zed


### PR DESCRIPTION
This introduce magnum rbac to atmoshpere, to enable it add follow config to magnum:
```
conf:
  magnum:
    oslo_policy:
      enforce_new_defaults: True
      enforce_scope: True
````

[1] was added to vexxhost/magnum. But notice the magnum image only usable for vexxhost/magnum-cluster-api driver user.
fix https://github.com/vexxhost/atmosphere/issues/471

[1] https://review.opendev.org/c/openstack/magnum/+/875625/14