### PR TITLE
fix(nova): set list_records_by_skipping_down_cells to false

### DIFF
--- a/roles/nova/vars/main.yml
+++ b/roles/nova/vars/main.yml
@@ -50,6 +50,8 @@ _nova_helm_values:
         resume_guests_state_on_host_boot: true
         osapi_compute_workers: 8
         metadata_workers: 8
+      api:
+        list_records_by_skipping_down_cells: false
       barbican:
         barbican_endpoint_type: internal
       cache:


### PR DESCRIPTION
If a cell is down, OpenStack responds with a 200 OK but the instances
missing when using the older micro-versions.  This is very confusing
for users and most of the time there is only a single cell anyways
that is in place.

It makes sense to just give a 500 error instead, the user will
work much better.
