### PR TITLE
fix(nova): drop tenant_id from url

### DIFF
--- a/roles/openstack_helm_endpoints/vars/main.yml
+++ b/roles/openstack_helm_endpoints/vars/main.yml
@@ -222,6 +222,8 @@ _openstack_helm_endpoints_compute:
     host_fqdn_override:
       public:
         host: "{{ openstack_helm_endpoints_nova_api_host }}"
+    path:
+      default: "/v2.1"
     port:
       api:
         public: 443


### PR DESCRIPTION
Many years ago (almost 7!), Nova dropped using the project ID,
which is historically called tenant ID in the service catalog[0].

Let's do the same so that we can make it much easier for users
to take advantage of access rules and be more consistent.

[0]: https://github.com/openstack/devstack/commit/7f87efdd21e92721fe2bf8bb493deb4822e32f1b
