### PR TITLE
chore: Use upstream cinder to build container images

### DIFF
--- a/internal/pkg/image_repositories/build_workflow.go
+++ b/internal/pkg/image_repositories/build_workflow.go
@@ -6,7 +6,6 @@ import (
 )
 
 var FORKED_PROJECTS map[string]bool = map[string]bool{
-	"cinder":   true,
 	"horizon":  true,
 	"keystone": true,
 	"magnum":   true,


### PR DESCRIPTION
Since all patches have been merged upstream, there is no longer a need to use the forked repository. To reduce technical debt, we can remove Cinder from the list of forked repositories.

related issue: https://github.com/vexxhost/atmosphere/issues/529