### PR TITLE
feat: Rollout horizon deployment whenever logo changed

### DIFF
--- a/charts/horizon/Chart.yaml
+++ b/charts/horizon/Chart.yaml
@@ -9,4 +9,4 @@ name: horizon
 sources:
 - https://opendev.org/openstack/horizon
 - https://opendev.org/openstack/openstack-helm
-version: 0.3.8
+version: 0.3.10

--- a/charts/horizon/Chart.yaml
+++ b/charts/horizon/Chart.yaml
@@ -9,4 +9,4 @@ name: horizon
 sources:
 - https://opendev.org/openstack/horizon
 - https://opendev.org/openstack/openstack-helm
-version: 0.3.10
+version: 0.3.11

--- a/charts/horizon/charts/helm-toolkit/Chart.yaml
+++ b/charts/horizon/charts/helm-toolkit/Chart.yaml
@@ -9,4 +9,4 @@ name: helm-toolkit
 sources:
 - https://opendev.org/openstack/openstack-helm-infra
 - https://opendev.org/openstack/openstack-helm
-version: 0.2.53
+version: 0.2.54

--- a/charts/horizon/charts/helm-toolkit/templates/utils/_dependency_resolver.tpl
+++ b/charts/horizon/charts/helm-toolkit/templates/utils/_dependency_resolver.tpl
@@ -27,8 +27,10 @@ limitations under the License.
 {{- else if kindIs "slice" $dependencyMixinParam }}
 {{- $_ := set $envAll.Values "__deps" ( index $envAll.Values.dependencies.static $dependencyKey ) }}
 {{- range $k, $v := $dependencyMixinParam -}}
+{{- if ( index $envAll.Values.dependencies.dynamic.targeted $v ) }}
 {{- $_ := include "helm-toolkit.utils.merge" (tuple $envAll.Values.pod_dependency $envAll.Values.__deps ( index $envAll.Values.dependencies.dynamic.targeted $v $dependencyKey ) ) -}}
 {{- $_ := set $envAll.Values "__deps" $envAll.Values.pod_dependency -}}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- else -}}

--- a/charts/horizon/requirements.lock
+++ b/charts/horizon/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: helm-toolkit
   repository: file://../../openstack-helm-infra/helm-toolkit
-  version: 0.2.53
-digest: sha256:f8f4fbba6f638b79447f7e458933b07deb792ae30a14df5900bde542cf0e64a6
-generated: "2023-05-28T07:16:29.89639214Z"
+  version: 0.2.54
+digest: sha256:337a0f1ffb3eae591150b305c22293d85fb8c18abec78f56672de4f3ada2faae
+generated: "2023-08-15T23:24:18.673274171Z"

--- a/charts/horizon/requirements.lock
+++ b/charts/horizon/requirements.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://../../openstack-helm-infra/helm-toolkit
   version: 0.2.54
 digest: sha256:337a0f1ffb3eae591150b305c22293d85fb8c18abec78f56672de4f3ada2faae
-generated: "2023-08-15T23:24:18.673274171Z"
+generated: "2023-09-01T14:09:26.530528728Z"

--- a/charts/horizon/templates/deployment.yaml
+++ b/charts/horizon/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
 {{ tuple $envAll | include "helm-toolkit.snippets.release_uuid" | indent 8 }}
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "helm-toolkit.utils.hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "helm-toolkit.utils.hash" }}
+{{- if .Values.manifests.configmap_logo }}
+        configmap-logo-hash: {{ tuple "configmap-logo.yaml" . | include "helm-toolkit.utils.hash" }}
+{{- end }}
 {{ dict "envAll" $envAll "podName" "horizon" "containerNames" (list "horizon" "init" ) | include "helm-toolkit.snippets.kubernetes_mandatory_access_control_annotation" | indent 8 }}
     spec:
       serviceAccountName: {{ $serviceAccountName }}

--- a/hack/sync-charts.sh
+++ b/hack/sync-charts.sh
@@ -170,9 +170,15 @@ MAGNUM_VERSION=0.2.9
 curl -sL https://tarballs.opendev.org/openstack/openstack-helm/magnum-${MAGNUM_VERSION}.tgz \
   | tar -xz -C ${ATMOSPHERE}/charts
 
-HORIZON_VERSION=0.3.8
+HORIZON_VERSION=0.3.10
 curl -sL https://tarballs.opendev.org/openstack/openstack-helm/horizon-${HORIZON_VERSION}.tgz \
   | tar -xz -C ${ATMOSPHERE}/charts
+curl 'https://review.opendev.org/changes/openstack%2Fopenstack-helm~891987/revisions/1/patch?download' \
+  | base64 --decode \
+  | filterdiff -p1 -x 'releasenotes/*' \
+  | filterdiff -p2 -x 'Chart.yaml' \
+  | filterdiff -p1 -i 'horizon/*' \
+  | patch -p2 -d ${ATMOSPHERE}/charts/horizon
 
 TEMPEST_VERSION=0.2.7
 curl -sL https://tarballs.opendev.org/openstack/openstack-helm/tempest-${TEMPEST_VERSION}.tgz \

--- a/hack/sync-charts.sh
+++ b/hack/sync-charts.sh
@@ -170,15 +170,9 @@ MAGNUM_VERSION=0.2.9
 curl -sL https://tarballs.opendev.org/openstack/openstack-helm/magnum-${MAGNUM_VERSION}.tgz \
   | tar -xz -C ${ATMOSPHERE}/charts
 
-HORIZON_VERSION=0.3.10
+HORIZON_VERSION=0.3.11
 curl -sL https://tarballs.opendev.org/openstack/openstack-helm/horizon-${HORIZON_VERSION}.tgz \
   | tar -xz -C ${ATMOSPHERE}/charts
-curl 'https://review.opendev.org/changes/openstack%2Fopenstack-helm~891987/revisions/1/patch?download' \
-  | base64 --decode \
-  | filterdiff -p1 -x 'releasenotes/*' \
-  | filterdiff -p2 -x 'Chart.yaml' \
-  | filterdiff -p1 -i 'horizon/*' \
-  | patch -p2 -d ${ATMOSPHERE}/charts/horizon
 
 TEMPEST_VERSION=0.2.7
 curl -sL https://tarballs.opendev.org/openstack/openstack-helm/tempest-${TEMPEST_VERSION}.tgz \


### PR DESCRIPTION
drive-by: Bump horizon chart version from 0.3.8 to 0.3.10

Apply https://review.opendev.org/c/openstack/openstack-helm/+/891987

fix https://github.com/vexxhost/atmosphere/issues/531