### PR TITLE
chore(keystone): Sync keystone image sha

### DIFF
--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -74,14 +74,14 @@ _atmosphere_images:
   ingress_nginx_default_backend: registry.k8s.io/defaultbackend-amd64:1.5
   ingress_nginx_kube_webhook_certgen: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660 # noqa: yaml[line-length]
   keepalived: us-docker.pkg.dev/vexxhost-infra/openstack/keepalived:2.0.19
-  keystone_api: quay.io/vexxhost/keystone@sha256:8214ccc92d7973451509701c5728d5af614762be3b2b89b29e486f28eb68167f # image-source: quay.io/vexxhost/keystone:zed
+  keystone_api: quay.io/vexxhost/keystone@sha256:4c63257d75c72137454690ad8cef600742e20b07ab31d873b88fa382ce659d17 # image-source: quay.io/vexxhost/keystone:zed
   keystone_credential_cleanup: quay.io/vexxhost/heat@sha256:755225f9a63c0968f1ceeda3a2f06c66dd8d247ff00308f549e66496aa8f59d0 # image-source: quay.io/vexxhost/heat:zed
-  keystone_credential_rotate: quay.io/vexxhost/keystone@sha256:8214ccc92d7973451509701c5728d5af614762be3b2b89b29e486f28eb68167f # image-source: quay.io/vexxhost/keystone:zed
-  keystone_credential_setup: quay.io/vexxhost/keystone@sha256:8214ccc92d7973451509701c5728d5af614762be3b2b89b29e486f28eb68167f # image-source: quay.io/vexxhost/keystone:zed
-  keystone_db_sync: quay.io/vexxhost/keystone@sha256:8214ccc92d7973451509701c5728d5af614762be3b2b89b29e486f28eb68167f # image-source: quay.io/vexxhost/keystone:zed
+  keystone_credential_rotate: quay.io/vexxhost/keystone@sha256:4c63257d75c72137454690ad8cef600742e20b07ab31d873b88fa382ce659d17 # image-source: quay.io/vexxhost/keystone:zed
+  keystone_credential_setup: quay.io/vexxhost/keystone@sha256:4c63257d75c72137454690ad8cef600742e20b07ab31d873b88fa382ce659d17 # image-source: quay.io/vexxhost/keystone:zed
+  keystone_db_sync: quay.io/vexxhost/keystone@sha256:4c63257d75c72137454690ad8cef600742e20b07ab31d873b88fa382ce659d17 # image-source: quay.io/vexxhost/keystone:zed
   keystone_domain_manage: quay.io/vexxhost/heat@sha256:755225f9a63c0968f1ceeda3a2f06c66dd8d247ff00308f549e66496aa8f59d0 # image-source: quay.io/vexxhost/heat:zed
-  keystone_fernet_rotate: quay.io/vexxhost/keystone@sha256:8214ccc92d7973451509701c5728d5af614762be3b2b89b29e486f28eb68167f # image-source: quay.io/vexxhost/keystone:zed
-  keystone_fernet_setup: quay.io/vexxhost/keystone@sha256:8214ccc92d7973451509701c5728d5af614762be3b2b89b29e486f28eb68167f # image-source: quay.io/vexxhost/keystone:zed
+  keystone_fernet_rotate: quay.io/vexxhost/keystone@sha256:4c63257d75c72137454690ad8cef600742e20b07ab31d873b88fa382ce659d17 # image-source: quay.io/vexxhost/keystone:zed
+  keystone_fernet_setup: quay.io/vexxhost/keystone@sha256:4c63257d75c72137454690ad8cef600742e20b07ab31d873b88fa382ce659d17 # image-source: quay.io/vexxhost/keystone:zed
   ks_endpoints: quay.io/vexxhost/heat@sha256:755225f9a63c0968f1ceeda3a2f06c66dd8d247ff00308f549e66496aa8f59d0 # image-source: quay.io/vexxhost/heat:zed
   ks_service: quay.io/vexxhost/heat@sha256:755225f9a63c0968f1ceeda3a2f06c66dd8d247ff00308f549e66496aa8f59d0 # image-source: quay.io/vexxhost/heat:zed
   ks_user: quay.io/vexxhost/heat@sha256:755225f9a63c0968f1ceeda3a2f06c66dd8d247ff00308f549e66496aa8f59d0 # image-source: quay.io/vexxhost/heat:zed


### PR DESCRIPTION
Keystone is failing because we remove the old build keystone image (sha 8214ccc92d7973451509701c5728d5af614762be3b2b89b29e486f28eb68167f) 
Which block jobs for PRs (like https://github.com/vexxhost/atmosphere/actions/runs/5891949296/job/15980160551?pr=530#step:6:169)