### PR TITLE
fix: Explict uses 2.87 nova api for openstack_exporter

### DIFF
--- a/roles/openstack_exporter/tasks/main.yml
+++ b/roles/openstack_exporter/tasks/main.yml
@@ -92,6 +92,9 @@
                   ports:
                     - name: metrics
                       containerPort: 9180
+                  env:
+                    - name: OS_COMPUTE_API_VERSION
+                      value: "2.87"
                   volumeMounts:
                     - name: openstack-config
                       mountPath: /etc/openstack


### PR DESCRIPTION
fix https://github.com/vexxhost/atmosphere/issues/534