### PR TITLE
Use keep as resoruce policy for glance-images

### DIFF
--- a/charts/glance/templates/pvc-images.yaml
+++ b/charts/glance/templates/pvc-images.yaml
@@ -20,6 +20,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: glance-images
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   accessModes: [ "ReadWriteOnce" ]
   resources:

--- a/charts/octavia/requirements.lock
+++ b/charts/octavia/requirements.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://../../openstack-helm-infra/helm-toolkit
   version: 0.2.54
 digest: sha256:337a0f1ffb3eae591150b305c22293d85fb8c18abec78f56672de4f3ada2faae
-generated: "2023-08-15T23:24:23.260721831Z"
+generated: "2023-08-19T09:33:03.94377723Z"

--- a/hack/sync-charts.sh
+++ b/hack/sync-charts.sh
@@ -105,6 +105,12 @@ curl 'https://review.opendev.org/changes/openstack%2Fopenstack-helm~883168/revis
   | filterdiff -p2 -x 'Chart.yaml' \
   | filterdiff -p1 -i 'glance/*' \
   | patch -p2 -d ${ATMOSPHERE}/charts/glance
+curl 'https://review.opendev.org/changes/openstack%2Fopenstack-helm~892704/revisions/1/patch?download' \
+  | base64 --decode \
+  | filterdiff -p1 -x 'releasenotes/*' \
+  | filterdiff -p2 -x 'Chart.yaml' \
+  | filterdiff -p1 -i 'glance/*' \
+  | patch -p2 -d ${ATMOSPHERE}/charts/glance
 
 CINDER_VERSION=0.3.10
 curl -sL https://tarballs.opendev.org/openstack/openstack-helm/cinder-${CINDER_VERSION}.tgz \


### PR DESCRIPTION
Make sure Once PVC glance-images never get deleted.
fix https://github.com/vexxhost/atmosphere/issues/518
