### PR TITLE
Enable ovn_emit_need_to_frag

### DIFF
--- a/roles/neutron/vars/main.yml
+++ b/roles/neutron/vars/main.yml
@@ -76,6 +76,7 @@ __neutron_ovn_helm_values:
         service_plugins: qos,ovn-router,segments,trunk
       ovn:
         dns_servers: "{{ neutron_coredns_cluster_ip | default('10.96.0.20') }}"
+        ovn_emit_need_to_frag: true
     ovn_metadata_agent:
       DEFAULT:
         metadata_proxy_shared_secret: "{{ openstack_helm_endpoints['compute_metadata']['secret'] }}"


### PR DESCRIPTION
Configure OVN to emit "need to frag" packets in case of MTU mismatch.

fix https://github.com/vexxhost/atmosphere/issues/546