### PR TITLE
fix: rook_ceph k8s image

### DIFF
--- a/roles/rook_ceph/vars/main.yml
+++ b/roles/rook_ceph/vars/main.yml
@@ -14,7 +14,7 @@
 
 _rook_ceph_helm_values:
   image:
-    repository: "{{ atmosphere_images['rook_ceph'] | vexxhost.kubernetes.docker_image('path') }}"
+    repository: "{{ atmosphere_images['rook_ceph'] | vexxhost.kubernetes.docker_image('name') }}"
     tag: "{{ atmosphere_images['rook_ceph'] | vexxhost.kubernetes.docker_image('tag') }}"
   nodeSelector:
     openstack-control-plane: enabled


### PR DESCRIPTION
Fix when using the rook_ceph with local repository.

With path it was only using the path without the DNS name of the image repository.