### PR TITLE
feat: introduce aarch64 support for libvirt pod

### DIFF
--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -17,7 +17,7 @@ _atmosphere_images:
   barbican_api: quay.io/vexxhost/barbican@sha256:fde302ee731cca6019feaf87400f5a377c3e38f459bc88d4c7677f2967e0939b # image-source: quay.io/vexxhost/barbican:zed
   barbican_db_sync: quay.io/vexxhost/barbican@sha256:fde302ee731cca6019feaf87400f5a377c3e38f459bc88d4c7677f2967e0939b # image-source: quay.io/vexxhost/barbican:zed
   bootstrap: quay.io/vexxhost/heat@sha256:755225f9a63c0968f1ceeda3a2f06c66dd8d247ff00308f549e66496aa8f59d0 # image-source: quay.io/vexxhost/heat:zed
-  ceph_config_helper: quay.io/vexxhost/libvirtd@sha256:d400204e0332dc815827e5902038a1c672446c58633ba97ede9e20f8ae9a2349 # image-source: quay.io/vexxhost/libvirtd:yoga-focal
+  ceph_config_helper: quay.io/vexxhost/libvirtd@sha256:4c6ce66f2b957eaf18d35c8236a038bd2289c78eec7c21addfa357b30f97b4ed # image-source: quay.io/vexxhost/libvirtd:zed-jammy
   ceph: quay.io/ceph/ceph:v16.2.11
   cert_manager_cainjector: quay.io/jetstack/cert-manager-cainjector:v1.7.1
   cert_manager_cli: quay.io/jetstack/cert-manager-ctl:v1.7.1
@@ -92,8 +92,8 @@ _atmosphere_images:
   kube_proxy: registry.k8s.io/kube-proxy:v1.22.17
   kube_scheduler: registry.k8s.io/kube-scheduler:v1.22.17
   kube_state_metrics: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2
-  kubectl: docker.io/bitnami/kubectl@sha256:bd420268ae3424b3ab3174e26b895fd8dc464589a8cd62654b9aa739d00ff280 # image-source: docker.io/bitnami/kubectl:latest
-  libvirt: quay.io/vexxhost/libvirtd@sha256:d400204e0332dc815827e5902038a1c672446c58633ba97ede9e20f8ae9a2349 # image-source: quay.io/vexxhost/libvirtd:yoga-focal
+  kubectl: docker.io/bitnami/kubectl:1.27.3
+  libvirt: quay.io/vexxhost/libvirtd@sha256:4c6ce66f2b957eaf18d35c8236a038bd2289c78eec7c21addfa357b30f97b4ed # image-source: quay.io/vexxhost/libvirtd:zed-jammy
   local_path_provisioner_helper: docker.io/library/busybox:1.36.0
   local_path_provisioner: docker.io/rancher/local-path-provisioner:v0.0.24
   loki_gateway: docker.io/nginxinc/nginx-unprivileged:1.19-alpine

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -17,7 +17,7 @@ _atmosphere_images:
   barbican_api: quay.io/vexxhost/barbican@sha256:fde302ee731cca6019feaf87400f5a377c3e38f459bc88d4c7677f2967e0939b # image-source: quay.io/vexxhost/barbican:zed
   barbican_db_sync: quay.io/vexxhost/barbican@sha256:fde302ee731cca6019feaf87400f5a377c3e38f459bc88d4c7677f2967e0939b # image-source: quay.io/vexxhost/barbican:zed
   bootstrap: quay.io/vexxhost/heat@sha256:755225f9a63c0968f1ceeda3a2f06c66dd8d247ff00308f549e66496aa8f59d0 # image-source: quay.io/vexxhost/heat:zed
-  ceph_config_helper: quay.io/vexxhost/libvirtd@sha256:4c6ce66f2b957eaf18d35c8236a038bd2289c78eec7c21addfa357b30f97b4ed # image-source: quay.io/vexxhost/libvirtd:zed-jammy
+  ceph_config_helper: quay.io/vexxhost/libvirtd@sha256:480d8736954cdc01c1d6f0c625ba147935ce4e5af25828f6d3fbcd18e6dc283a # image-source: quay.io/vexxhost/libvirtd:zed
   ceph: quay.io/ceph/ceph:v16.2.11
   cert_manager_cainjector: quay.io/jetstack/cert-manager-cainjector:v1.7.1
   cert_manager_cli: quay.io/jetstack/cert-manager-ctl:v1.7.1
@@ -93,7 +93,7 @@ _atmosphere_images:
   kube_scheduler: registry.k8s.io/kube-scheduler:v1.22.17
   kube_state_metrics: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2
   kubectl: docker.io/bitnami/kubectl:1.27.3
-  libvirt: quay.io/vexxhost/libvirtd@sha256:4c6ce66f2b957eaf18d35c8236a038bd2289c78eec7c21addfa357b30f97b4ed # image-source: quay.io/vexxhost/libvirtd:zed-jammy
+  libvirt: quay.io/vexxhost/libvirtd@sha256:480d8736954cdc01c1d6f0c625ba147935ce4e5af25828f6d3fbcd18e6dc283a # image-source: quay.io/vexxhost/libvirtd:zed
   local_path_provisioner_helper: docker.io/library/busybox:1.36.0
   local_path_provisioner: docker.io/rancher/local-path-provisioner:v0.0.24
   loki_gateway: docker.io/nginxinc/nginx-unprivileged:1.19-alpine


### PR DESCRIPTION
Closes https://github.com/vexxhost/atmosphere/issues/550

- Starting from this tag `libvirtd` build for `aarch64` was introduced.
- `bitnami/kubectl` is using different SHA per platform. Switch to TAG instead of SHA (`1.27.3` is the version which `atmoshere` is using now).