### PR TITLE
Fix: correct keycloak TLS secret with wildcard-certs

### DIFF
--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -29,3 +29,4 @@ keycloak_admin_password: "{{ undef(hint='You must specify a Keycloak admin passw
 keycloak_database_username: keycloak
 keycloak_database_password: "{{ undef('You must specify a Keycloak database password using keycloak_database_password') }}"
 keycloak_database_name: keycloak
+keycloak_host_tls_secret_name: "{{ openstack_helm_ingress_secret_name | default(keycloak_host + '-tls')}}"

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -71,7 +71,7 @@
     ingress_host: "{{ keycloak_host }}"
     ingress_service_name: "{{ keycloak_helm_release_name }}"
     ingress_service_port: 80
-    ingress_secret_name: "{{ keycloak_host }}-tls"
+    ingress_secret_name: "{{ keycloak_host_tls_secret_name }}"
     ingress_annotations:
       cert-manager.io/cluster-issuer: atmosphere
 


### PR DESCRIPTION
Fix: correct keycloak TLS secret when openstack_helm_ingress_secret_name is used for wildcard-certs.