### PR TITLE
Fix: urlencoded_issuer_from_domain

### DIFF
--- a/roles/keystone/vars/main.yml
+++ b/roles/keystone/vars/main.yml
@@ -82,7 +82,7 @@ _keystone_helm_values:
         <Location /v3/auth/OS-FEDERATION/identity_providers/{{ domain.name }}/protocols/openid/websso>
           Require valid-user
           AuthType openid-connect
-          OIDCDiscoverURL {{ keystone_oidc_redirect_uri }}?iss={{ domain | urlencoded_issuer_from_domain }}
+          OIDCDiscoverURL {{ keystone_oidc_redirect_uri }}?iss={{ domain | vexxhost.atmosphere.urlencoded_issuer_from_domain }}
         </Location>
         {% endfor %}
       </VirtualHost>


### PR DESCRIPTION
Fix: add vexxhost.atmosphere when using urlencoded_issuer_from_domain.