### PR TITLE
Switch to pxc_strict_mode to MASTER

### DIFF
--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -75,9 +75,9 @@
     ingress_annotations:
       cert-manager.io/cluster-issuer: atmosphere
 
-- name: Disable pxc strict mode
+- name: Re-enable pxc strict mode
   community.mysql.mysql_query:
     login_host: "{{ _pxc_service.resources[0].spec.clusterIP }}"
     login_user: root
     login_password: "{{ openstack_helm_endpoints.oslo_db.auth.admin.password }}"
-    query: "set global pxc_strict_mode='ENFORCING'"
+    query: "set global pxc_strict_mode='MASTER'"


### PR DESCRIPTION
This will give us sql lock support so we can use tooz with mysql backend.

Also fix task name in keycloak role

ref: https://docs.percona.com/percona-xtradb-cluster/8.0/strict-mode.html