### PR TITLE
chore: Revert "fix(auth): Define service_type in keystone_authtoken (#411)"

### DIFF
--- a/roles/barbican/vars/main.yml
+++ b/roles/barbican/vars/main.yml
@@ -23,10 +23,6 @@ _barbican_helm_values:
     barbican:
       DEFAULT:
         log_config_append: null
-      keystone_authtoken:
-        # NOTE(okozachenko1203): We can remove it once the following is merged:
-        #                        https://review.opendev.org/883066
-        service_type: key-manager
       oslo_messaging_notifications:
         driver: noop
       simple_crypto_plugin:

--- a/roles/cinder/vars/main.yml
+++ b/roles/cinder/vars/main.yml
@@ -34,10 +34,6 @@ _cinder_helm_values:
         barbican_endpoint_type: internal
       cors:
         allowed_origins: "*"
-      keystone_authtoken:
-        # NOTE(okozachenko1203): We can remove it once the following is merged:
-        #                        https://review.opendev.org/883066
-        service_type: volumev3
       oslo_messaging_notifications:
         driver: noop
   manifests:

--- a/roles/designate/vars/main.yml
+++ b/roles/designate/vars/main.yml
@@ -18,10 +18,6 @@ _designate_helm_values:
     tags: "{{ atmosphere_images | vexxhost.atmosphere.openstack_helm_image_tags('designate') }}"
   conf:
     designate:
-      keystone_authtoken:
-        # NOTE(okozachenko1203): We can remove it once the following is merged:
-        #                        https://review.opendev.org/883066
-        service_type: dns
       service:central:
         managed_resource_tenant_id: "{{ _designate_project_info.openstack_projects[0].id }}"
     pools: "{{ designate_pools | to_yaml }}"

--- a/roles/glance/vars/main.yml
+++ b/roles/glance/vars/main.yml
@@ -45,10 +45,6 @@ _glance_helm_values:
         allowed_origins: "*"
       image_format:
         disk_formats: "qcow2,raw"
-      keystone_authtoken:
-        # NOTE(okozachenko1203): We can remove it once the following is merged:
-        #                        https://review.opendev.org/883066
-        service_type: image
       oslo_messaging_notifications:
         driver: noop
   manifests:

--- a/roles/heat/vars/main.yml
+++ b/roles/heat/vars/main.yml
@@ -43,10 +43,6 @@ _heat_helm_values:
         workers: 8
       heat_api_cloudwatch:
         workers: 8
-      keystone_authtoken:
-        # NOTE(okozachenko1203): We can remove it once the following is merged:
-        #                        https://review.opendev.org/883066
-        service_type: orchestration
       oslo_messaging_notifications:
         driver: noop
   manifests:

--- a/roles/magnum/vars/main.yml
+++ b/roles/magnum/vars/main.yml
@@ -51,9 +51,6 @@ _magnum_helm_values:
         # NOTE(mnaser): Magnum does not allow changing the interface to internal
         #               so we workaround with this for now.
         insecure: true
-        # NOTE(okozachenko1203): We can remove it once the following is merged:
-        #                        https://review.opendev.org/883066
-        service_type: container-infra
       magnum_client:
         region_name: "{{ openstack_helm_endpoints_magnum_region_name }}"
       manila_client:

--- a/roles/manila/vars/main.yml
+++ b/roles/manila/vars/main.yml
@@ -54,10 +54,6 @@ _manila_helm_values:
         service_image_name: "{{ manila_image_name }}"
         service_instance_flavor_id: "{{ _manila_flavor.id }}"
         service_instance_security_group: manila-service-security-group
-      keystone_authtoken:
-        # NOTE(okozachenko1203): We can remove it once the following is merged:
-        #                        https://review.opendev.org/883066
-        service_type: sharev2
       oslo_messaging_notifications:
         driver: noop
   manifests:

--- a/roles/neutron/vars/main.yml
+++ b/roles/neutron/vars/main.yml
@@ -37,10 +37,6 @@ __neutron_helm_values:
         live_migration_events: true
       oslo_messaging_notifications:
         driver: noop
-      keystone_authtoken:
-        # NOTE(okozachenko1203): We can remove it once the following is merged:
-        #                        https://review.opendev.org/883066
-        service_type: network
       service_providers:
         service_provider: VPN:strongswan:neutron_vpnaas.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default
     dhcp_agent:

--- a/roles/nova/vars/main.yml
+++ b/roles/nova/vars/main.yml
@@ -81,10 +81,6 @@ _nova_helm_values:
         max_instances_per_host: 200
       glance:
         enable_rbd_download: true
-      keystone_authtoken:
-        # NOTE(okozachenko1203): We can remove it once the following is merged:
-        #                        https://review.opendev.org/883066
-        service_type: compute
       libvirt:
         live_migration_scheme: tls
         # TODO(mnaser): We should enable this once we figure out how to "inject"

--- a/roles/octavia/vars/main.yml
+++ b/roles/octavia/vars/main.yml
@@ -106,10 +106,6 @@ _octavia_helm_values:
       health_manager:
         controller_ip_port_list: "{{ _octavia_controller_ip_port_list | sort | join(',') }}"
         heartbeat_key: "{{ octavia_heartbeat_key }}"
-      keystone_authtoken:
-        # NOTE(okozachenko1203): We can remove it once the following is merged:
-        #                        https://review.opendev.org/883066
-        service_type: load-balancer
       oslo_messaging_notifications:
         driver: noop
       neutron:

--- a/roles/placement/vars/main.yml
+++ b/roles/placement/vars/main.yml
@@ -23,10 +23,6 @@ _placement_helm_values:
     placement:
       DEFAULT:
         log_config_append: null
-      keystone_authtoken:
-        # NOTE(okozachenko1203): We can remove it once the following is merged:
-        #                        https://review.opendev.org/883066
-        service_type: placement
       oslo_messaging_notifications:
         driver: noop
   manifests:

--- a/roles/senlin/vars/main.yml
+++ b/roles/senlin/vars/main.yml
@@ -26,10 +26,6 @@ _senlin_helm_values:
     senlin:
       DEFAULT:
         log_config_append: null
-      keystone_authtoken:
-        # NOTE(okozachenko1203): We can remove it once the following is merged:
-        #                        https://review.opendev.org/883066
-        service_type: clustering
       oslo_messaging_notifications:
         driver: noop
   manifests:


### PR DESCRIPTION
This reverts commit 72f64dc7f1c32b2fc21bf76563d87cd57137de60 as it's no longer required base on @okozachenko1203 's early comments and upstream patch