### PR TITLE
fix: Use a larger runner for keycloak CI jobs

### DIFF
--- a/.github/workflows/keycloak.yml
+++ b/.github/workflows/keycloak.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   molecule:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04-4-cores
     steps:
       - name: Checkout project
         uses: actions/checkout@v4

--- a/.github/workflows/keycloak.yml
+++ b/.github/workflows/keycloak.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   molecule:
-    runs-on: ubuntu-20.04-4-cores
+    runs-on: ubuntu-20.04-16-cores
     steps:
       - name: Checkout project
         uses: actions/checkout@v4

--- a/.github/workflows/keycloak.yml
+++ b/.github/workflows/keycloak.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   molecule:
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-latest-4-cores
     steps:
       - name: Checkout project
         uses: actions/checkout@v4


### PR DESCRIPTION
fix https://github.com/vexxhost/atmosphere/issues/613