### PR TITLE
fix: Fix VNC times out after 60 seconds of idle time

### DIFF
--- a/roles/nova/defaults/main.yml
+++ b/roles/nova/defaults/main.yml
@@ -26,4 +26,5 @@ nova_ssh_key: "{{ undef(hint='You must specifiy an SSH key for Nova.') }}"
 nova_flavors: []
 
 # List of annotations to apply to the Ingress
-nova_ingress_annotations: {}
+nova_api_ingress_annotations: {}
+nova_novnc_ingress_annotations: {}

--- a/roles/nova/tasks/main.yml
+++ b/roles/nova/tasks/main.yml
@@ -72,7 +72,7 @@
     openstack_helm_ingress_endpoint: compute
     openstack_helm_ingress_service_name: nova-api
     openstack_helm_ingress_service_port: 8774
-    openstack_helm_ingress_annotations: "{{ nova_ingress_annotations }}"
+    openstack_helm_ingress_annotations: "{{ nova_api_ingress_annotations }}"
 
 - name: Create Ingress
   ansible.builtin.include_role:
@@ -81,7 +81,7 @@
     openstack_helm_ingress_endpoint: compute_novnc_proxy
     openstack_helm_ingress_service_name: nova-novncproxy
     openstack_helm_ingress_service_port: 6080
-    openstack_helm_ingress_annotations: "{{ nova_ingress_annotations }}"
+    openstack_helm_ingress_annotations: "{{ _nova_novnc_ingress_annotations | combine(nova_novnc_ingress_annotations) }}"
 
 - name: Create flavors
   when: nova_flavors | length > 0

--- a/roles/nova/vars/main.yml
+++ b/roles/nova/vars/main.yml
@@ -119,3 +119,7 @@ _nova_helm_values:
     service_placement: false
     # NOTE(mnaser): Enable this once we've got Ironic deployed.
     statefulset_compute_ironic: false
+
+_nova_novnc_ingress_annotations:
+  nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+  nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"


### PR DESCRIPTION
Use annotations for nova api and vnc ingresses separately

fix #653