### PR TITLE
fix: OVS 2.15 changed terminology slave to member

### DIFF
--- a/charts/neutron/templates/bin/_neutron-openvswitch-agent-readiness.sh.tpl
+++ b/charts/neutron/templates/bin/_neutron-openvswitch-agent-readiness.sh.tpl
@@ -38,7 +38,7 @@ ovs-vsctl list-br | grep -q br-int
       bond={{ .name }}
       ovs-appctl -t ${OVS_CTL} bond/list | grep -q  ${bond}
       {{- range .nics }}
-        ovs-appctl -t ${OVS_CTL} bond/show ${bond} | grep -q "slave {{ .name }}"
+        ovs-appctl -t ${OVS_CTL} bond/show ${bond} | grep -q "slave {{ .name }}\|member {{ .name }}"
       {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
 with new OVS installs the ovs-agent does not become ready.  Only applies if you are enabling DPDK