### PR TITLE
docs: Allow plain certs for CA cluster issuer inventory

### DIFF
--- a/roles/cluster_issuer/tasks/type/ca/main.yml
+++ b/roles/cluster_issuer/tasks/type/ca/main.yml
@@ -22,7 +22,7 @@
           name: "{{ cluster_issuer_ca_secret_name }}"
           namespace: cert-manager
         type: kubernetes.io/tls
-        data:
+        stringData:
           tls.crt: "{{ cluster_issuer_ca_certificate }}"
           tls.key: "{{ cluster_issuer_ca_private_key }}"
 


### PR DESCRIPTION
as the doc says https://github.com/vexxhost/atmosphere/blob/main/roles/cluster_issuer/README.md#using-pre-existing-ca