### PR TITLE
fix: wait will the ingress has been created

### DIFF
--- a/roles/ingress/tasks/main.yml
+++ b/roles/ingress/tasks/main.yml
@@ -17,3 +17,4 @@
   kubernetes.core.k8s:
     state: present
     template: ingress.yml.j2
+    wait: true


### PR DESCRIPTION
fix: wait will the ingress has been created

At creating the ingress it needs to wait till it has been created. Especially when using ACME certificates this can take longer, where the next task will fail there the ingress does not exists yet.