### PR TITLE
fix(octavia): Correct port protocol

### DIFF
--- a/roles/octavia/tasks/generate_resources.yml
+++ b/roles/octavia/tasks/generate_resources.yml
@@ -40,13 +40,15 @@
     security_group: "{{ _octavia_health_manager_sg.id }}"
     direction: ingress
     ethertype: IPv4
-    protocol: tcp
-    port_range_min: "{{ item }}"
-    port_range_max: "{{ item }}"
+    protocol: "{{ item.protocol }}"
+    port_range_min: "{{ item.port }}"
+    port_range_max: "{{ item.port }}"
   loop:
-    - 5555
-    - 10514
-    - 20514
+    - { protocol: 'udp', port: 5555 }
+    - { protocol: 'udp', port: 10514 }
+    - { protocol: 'udp', port: 20514 }
+    - { protocol: 'tcp', port: 10514 }
+    - { protocol: 'tcp', port: 20514 }
 
 - name: Create health manager networking ports
   # noqa: args[module]


### PR DESCRIPTION
port 5555 usage should be udp.
For 10514 and 20514, it depends on log_protocol[1].

[1] https://docs.openstack.org/octavia/latest/configuration/configref.html#amphora_agent.log_protocol

fix https://github.com/vexxhost/atmosphere/issues/697