### PR TITLE
fix(nova): use distro supplied libvirt-python

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
         {
           devShell = pkgs.mkShell {
             buildInputs = with pkgs; [
+              earthly
               vendir
             ];
           };

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -129,23 +129,23 @@ _atmosphere_images:
   neutron_sriov_agent_init: quay.io/vexxhost/neutron@sha256:6309ca1db220338e3ea83cf637ee4c333c897a313435ef97968f75f5bbbab87d # image-source: quay.io/vexxhost/neutron:zed
   neutron_sriov_agent: quay.io/vexxhost/neutron@sha256:6309ca1db220338e3ea83cf637ee4c333c897a313435ef97968f75f5bbbab87d # image-source: quay.io/vexxhost/neutron:zed
   node_feature_discovery: registry.k8s.io/nfd/node-feature-discovery:v0.11.2
-  nova_api: quay.io/vexxhost/nova@sha256:132aec4034dd7508443cd14c7c2b7859a20917b90e17d153a84e2d8f920b5f23 # image-source: quay.io/vexxhost/nova:zed
-  nova_archive_deleted_rows: quay.io/vexxhost/nova@sha256:132aec4034dd7508443cd14c7c2b7859a20917b90e17d153a84e2d8f920b5f23 # image-source: quay.io/vexxhost/nova:zed
+  nova_api: quay.io/vexxhost/nova@sha256:7c76d40901d337bb839729519e1c1ad2add76707ef00cedd81552b6ed0b35ce2 # image-source: quay.io/vexxhost/nova:zed
+  nova_archive_deleted_rows: quay.io/vexxhost/nova@sha256:7c76d40901d337bb839729519e1c1ad2add76707ef00cedd81552b6ed0b35ce2 # image-source: quay.io/vexxhost/nova:zed
   nova_cell_setup_init: quay.io/vexxhost/heat@sha256:2413e1d669a899685d0cc89c3333222ad004c567be0d5ca605dcc6a59c12af64 # image-source: quay.io/vexxhost/heat:zed
-  nova_cell_setup: quay.io/vexxhost/nova@sha256:132aec4034dd7508443cd14c7c2b7859a20917b90e17d153a84e2d8f920b5f23 # image-source: quay.io/vexxhost/nova:zed
+  nova_cell_setup: quay.io/vexxhost/nova@sha256:7c76d40901d337bb839729519e1c1ad2add76707ef00cedd81552b6ed0b35ce2 # image-source: quay.io/vexxhost/nova:zed
   nova_compute_ironic: quay.io/openstack.kolla/nova-compute-ironic:zed-ubuntu-jammy
   nova_compute_ssh: quay.io/vexxhost/nova-ssh:latest
-  nova_compute: quay.io/vexxhost/nova@sha256:132aec4034dd7508443cd14c7c2b7859a20917b90e17d153a84e2d8f920b5f23 # image-source: quay.io/vexxhost/nova:zed
-  nova_conductor: quay.io/vexxhost/nova@sha256:132aec4034dd7508443cd14c7c2b7859a20917b90e17d153a84e2d8f920b5f23 # image-source: quay.io/vexxhost/nova:zed
-  nova_consoleauth: quay.io/vexxhost/nova@sha256:132aec4034dd7508443cd14c7c2b7859a20917b90e17d153a84e2d8f920b5f23 # image-source: quay.io/vexxhost/nova:zed
-  nova_db_sync: quay.io/vexxhost/nova@sha256:132aec4034dd7508443cd14c7c2b7859a20917b90e17d153a84e2d8f920b5f23 # image-source: quay.io/vexxhost/nova:zed
-  nova_novncproxy_assets: quay.io/vexxhost/nova@sha256:132aec4034dd7508443cd14c7c2b7859a20917b90e17d153a84e2d8f920b5f23 # image-source: quay.io/vexxhost/nova:zed
-  nova_novncproxy: quay.io/vexxhost/nova@sha256:132aec4034dd7508443cd14c7c2b7859a20917b90e17d153a84e2d8f920b5f23 # image-source: quay.io/vexxhost/nova:zed
-  nova_placement: quay.io/vexxhost/nova@sha256:132aec4034dd7508443cd14c7c2b7859a20917b90e17d153a84e2d8f920b5f23 # image-source: quay.io/vexxhost/nova:zed
-  nova_scheduler: quay.io/vexxhost/nova@sha256:132aec4034dd7508443cd14c7c2b7859a20917b90e17d153a84e2d8f920b5f23 # image-source: quay.io/vexxhost/nova:zed
+  nova_compute: quay.io/vexxhost/nova@sha256:7c76d40901d337bb839729519e1c1ad2add76707ef00cedd81552b6ed0b35ce2 # image-source: quay.io/vexxhost/nova:zed
+  nova_conductor: quay.io/vexxhost/nova@sha256:7c76d40901d337bb839729519e1c1ad2add76707ef00cedd81552b6ed0b35ce2 # image-source: quay.io/vexxhost/nova:zed
+  nova_consoleauth: quay.io/vexxhost/nova@sha256:7c76d40901d337bb839729519e1c1ad2add76707ef00cedd81552b6ed0b35ce2 # image-source: quay.io/vexxhost/nova:zed
+  nova_db_sync: quay.io/vexxhost/nova@sha256:7c76d40901d337bb839729519e1c1ad2add76707ef00cedd81552b6ed0b35ce2 # image-source: quay.io/vexxhost/nova:zed
+  nova_novncproxy_assets: quay.io/vexxhost/nova@sha256:7c76d40901d337bb839729519e1c1ad2add76707ef00cedd81552b6ed0b35ce2 # image-source: quay.io/vexxhost/nova:zed
+  nova_novncproxy: quay.io/vexxhost/nova@sha256:7c76d40901d337bb839729519e1c1ad2add76707ef00cedd81552b6ed0b35ce2 # image-source: quay.io/vexxhost/nova:zed
+  nova_placement: quay.io/vexxhost/nova@sha256:7c76d40901d337bb839729519e1c1ad2add76707ef00cedd81552b6ed0b35ce2 # image-source: quay.io/vexxhost/nova:zed
+  nova_scheduler: quay.io/vexxhost/nova@sha256:7c76d40901d337bb839729519e1c1ad2add76707ef00cedd81552b6ed0b35ce2 # image-source: quay.io/vexxhost/nova:zed
   nova_service_cleaner: quay.io/vexxhost/cli:latest
-  nova_spiceproxy_assets: quay.io/vexxhost/nova@sha256:132aec4034dd7508443cd14c7c2b7859a20917b90e17d153a84e2d8f920b5f23 # image-source: quay.io/vexxhost/nova:zed
-  nova_spiceproxy: quay.io/vexxhost/nova@sha256:132aec4034dd7508443cd14c7c2b7859a20917b90e17d153a84e2d8f920b5f23 # image-source: quay.io/vexxhost/nova:zed
+  nova_spiceproxy_assets: quay.io/vexxhost/nova@sha256:7c76d40901d337bb839729519e1c1ad2add76707ef00cedd81552b6ed0b35ce2 # image-source: quay.io/vexxhost/nova:zed
+  nova_spiceproxy: quay.io/vexxhost/nova@sha256:7c76d40901d337bb839729519e1c1ad2add76707ef00cedd81552b6ed0b35ce2 # image-source: quay.io/vexxhost/nova:zed
   octavia_api: quay.io/vexxhost/octavia@sha256:7a322440c8427ee8a1199268e2c34ff6d541314e7fbf8e3ce1d7f30cd827b697 # image-source: quay.io/vexxhost/octavia:zed
   octavia_db_sync: quay.io/vexxhost/octavia@sha256:7a322440c8427ee8a1199268e2c34ff6d541314e7fbf8e3ce1d7f30cd827b697 # image-source: quay.io/vexxhost/octavia:zed
   octavia_health_manager_init: quay.io/vexxhost/heat@sha256:2413e1d669a899685d0cc89c3333222ad004c567be0d5ca605dcc6a59c12af64 # image-source: quay.io/vexxhost/heat:zed


### PR DESCRIPTION
The libvirt-python published to PyPI is not compatible with the
libvirt version inside our container images. This change switches
to using the distro supplied libvirt-python package.

Fixes #741
