### PR TITLE
fix: configure ovn-bridge with netdev datapath type when dpdk is enabled

### DIFF
--- a/charts/ovn/templates/bin/_ovn-controller-init.sh.tpl
+++ b/charts/ovn/templates/bin/_ovn-controller-init.sh.tpl
@@ -118,6 +118,9 @@ ovs-vsctl set open . external-ids:ovn-encap-type="{{ .Values.conf.ovn_encap_type
 ovs-vsctl set open . external-ids:ovn-bridge="{{ .Values.conf.ovn_bridge }}"
 ovs-vsctl set open . external-ids:ovn-bridge-mappings="{{ .Values.conf.ovn_bridge_mappings }}"
 ovs-vsctl set open . external-ids:ovn-cms-options="${OVN_CMS_OPTIONS}"
+{{ if .Values.conf.ovn_bridge_datapath_type -}}
+ovs-vsctl set open . external-ids:ovn-bridge-datapath-type="{{ .Values.conf.ovn_bridge_datapath_type }}"
+{{- end }}
 
 # Configure hostname
 {{- if .Values.conf.use_fqdn.compute }}

--- a/charts/ovn/values.yaml
+++ b/charts/ovn/values.yaml
@@ -74,6 +74,8 @@ conf:
   ovn_encap_type: geneve
   ovn_bridge: br-int
   ovn_bridge_mappings: external:br-ex
+  # For DPDK enabled environments, enable netdev datapath type for br-int
+  # ovn_bridge_datapath_type: netdev
 
   # auto_bridge_add:
   #   br-private: eth0


### PR DESCRIPTION
Needing to automatically configure a netdev datapath type for ovn-bridge (default: br-int) for DPDK enabled OVN/OVS