### PR TITLE
feat: Adding option to use interface names instead of just pci_ids 

### DIFF
--- a/charts/patches/neutron/0004-nic-name-feature.patch
+++ b/charts/patches/neutron/0004-nic-name-feature.patch
@@ -1,0 +1,61 @@
+diff --git a/charts/neutron/templates/bin/_neutron-openvswitch-agent-init.sh.tpl b/charts/neutron/templates/bin/_neutron-openvswitch-agent-init.sh.tpl
+index bd0a64ac..7ba64384 100644
+--- a/charts/neutron/templates/bin/_neutron-openvswitch-agent-init.sh.tpl
++++ b/charts/neutron/templates/bin/_neutron-openvswitch-agent-init.sh.tpl
+@@ -196,6 +196,12 @@ function process_dpdk_nics {
+   while IFS= read -r nic; do
+     local port_name=$(get_dpdk_config_value ${nic} '.name')
+     local pci_id=$(get_dpdk_config_value ${nic} '.pci_id')
++    local iface=$(get_dpdk_config_value ${nic} '.iface')
++    if [ -n ${iface} ] && [ -z ${pci_id} ]; then
++      local pci_id=$(get_address_by_nicname ${iface})
++    else
++      iface=$(get_name_by_pci_id "${pci_id}")
++    fi
+     local bridge=$(get_dpdk_config_value ${nic} '.bridge')
+     local vf_index=$(get_dpdk_config_value ${nic} '.vf_index')
+ 
+@@ -203,8 +209,6 @@ function process_dpdk_nics {
+       migrate_ip "${pci_id}" "${bridge}"
+     fi
+ 
+-    iface=$(get_name_by_pci_id "${pci_id}")
+-
+     if [ -n "${iface}" ]; then
+       ip link set ${iface} promisc on
+       if [ -n "${vf_index}" ]; then
+@@ -292,6 +296,12 @@ function process_dpdk_bonds {
+     echo $bond | jq -r -c '.nics[]' > /tmp/nics_array
+     while IFS= read -r nic; do
+       local pci_id=$(get_dpdk_config_value ${nic} '.pci_id')
++      local iface=$(get_dpdk_config_value ${nic} '.iface')
++      if [ -n ${iface} ] && [ -z ${pci_id} ]; then
++        local pci_id=$(get_address_by_nicname ${iface})
++      else
++        iface=$(get_name_by_pci_id "${pci_id}")
++      fi
+       local nic_name=$(get_dpdk_config_value ${nic} '.name')
+       local pmd_rxq_affinity=$(get_dpdk_config_value ${nic} '.pmd_rxq_affinity')
+       local vf_index=$(get_dpdk_config_value ${nic} '.vf_index')
+@@ -302,8 +312,6 @@ function process_dpdk_bonds {
+         ip_migrated=true
+       fi
+ 
+-      iface=$(get_name_by_pci_id "${pci_id}")
+-
+       if [ -n "${iface}" ]; then
+         ip link set ${iface} promisc on
+         if [ -n "${vf_index}" ]; then
+@@ -407,6 +415,12 @@ function get_driver_by_address {
+   fi
+ }
+ 
++function get_address_by_nicname {
++  if [[ -e /sys/class/net/$1/device ]]; then
++    readlink -f /sys/class/net/$1/device | xargs basename
++  fi
++}
++
+ function init_ovs_dpdk_bridge {
+   bridge=$1
+   ovs-vsctl --db=unix:${OVS_SOCKET} --may-exist add-br ${bridge} \


### PR DESCRIPTION
This script change helps alleviate the issue of heterogeneous server environments having a consistent pci_id.  This change will enable usage of host interface names which can be set to a consistent value despite pci_id differing when deploying the server.  Defaults to using pci_id parameter if present for backwards compatibility.

We are using this in our environment, use it if you'd like.