### PR TITLE
fix: python3 is not installed in the base image

### DIFF
--- a/images/base/Earthfile
+++ b/images/base/Earthfile
@@ -2,3 +2,4 @@ VERSION 0.7
 
 image:
   FROM ubuntu:jammy
+  DO ../+APT_INSTALL --PACKAGES "python3"


### PR DESCRIPTION
python3 is not installed in the base image, this is requered for the +image section for Atmosphere