### PR TITLE
fix: use cloud-archive-base for Atmosphere image

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -39,7 +39,9 @@ build.collections:
   SAVE IMAGE --cache-hint
 
 image:
-  FROM ./images/base+image
+  ARG RELEASE=2023.1
+  FROM ./images/cloud-archive-base+image \
+    --RELEASE ${RELEASE}
   ENV ANSIBLE_PIPELINING=True
   DO ./images+APT_INSTALL --PACKAGES "rsync openssh-client"
   COPY +build.venv.runtime/venv /venv

--- a/Earthfile
+++ b/Earthfile
@@ -40,8 +40,7 @@ build.collections:
 
 image:
   ARG RELEASE=2023.1
-  FROM ./images/cloud-archive-base+image \
-    --RELEASE ${RELEASE}
+  FROM ./images/cloud-archive-base+image --RELEASE ${RELEASE}
   ENV ANSIBLE_PIPELINING=True
   DO ./images+APT_INSTALL --PACKAGES "rsync openssh-client"
   COPY +build.venv.runtime/venv /venv


### PR DESCRIPTION
python3 is not installed in the base image, this is requered for the +image section for Atmosphere
