### PR TITLE
fix: update upperconstraint for zed

### DIFF
--- a/images/openstack-service/Earthfile
+++ b/images/openstack-service/Earthfile
@@ -55,6 +55,7 @@ requirements:
     sed -i 's/paramiko===2.11.0/paramiko===3.4.0/' /src/upper-constraints.txt && \
     sed -i 's/paramiko===3.1.0/paramiko===3.4.0/' /src/upper-constraints.txt && \
     sed -i 's/pyOpenSSL===23.1.1/pyOpenSSL===23.3.0/' /src/upper-constraints.txt && \
+    sed -i 's/pyOpenSSL===22.0.0/pyOpenSSL===23.3.0/' /src/upper-constraints.txt && \
     sed -i 's/requests===2.28.1/requests===2.31.0/' /src/upper-constraints.txt && \
     sed -i 's/requests===2.28.2/requests===2.31.0/' /src/upper-constraints.txt && \
     sed -i 's/sqlparse===0.4.2/sqlparse===0.4.4/' /src/upper-constraints.txt && \

--- a/images/openstack-service/Earthfile
+++ b/images/openstack-service/Earthfile
@@ -54,8 +54,8 @@ requirements:
     sed -i 's/Jinja2===3.1.2/Jinja2===3.1.3/' /src/upper-constraints.txt && \
     sed -i 's/paramiko===2.11.0/paramiko===3.4.0/' /src/upper-constraints.txt && \
     sed -i 's/paramiko===3.1.0/paramiko===3.4.0/' /src/upper-constraints.txt && \
-    sed -i 's/pyOpenSSL===23.1.1/pyOpenSSL===23.3.0/' /src/upper-constraints.txt && \
     sed -i 's/pyOpenSSL===22.0.0/pyOpenSSL===23.3.0/' /src/upper-constraints.txt && \
+    sed -i 's/pyOpenSSL===23.1.1/pyOpenSSL===23.3.0/' /src/upper-constraints.txt && \
     sed -i 's/requests===2.28.1/requests===2.31.0/' /src/upper-constraints.txt && \
     sed -i 's/requests===2.28.2/requests===2.31.0/' /src/upper-constraints.txt && \
     sed -i 's/sqlparse===0.4.2/sqlparse===0.4.4/' /src/upper-constraints.txt && \


### PR DESCRIPTION
zed upperconstraint uses pyOpenSSL===22.0.0 but we need pyOpenSSL>=22.1.0 to avoid bug from pyOpenSSL.

We can remove this line once we move nova to 2023.2