### PR TITLE
fix(nova): cherry-pick windows fixes

### DIFF
--- a/images/nova/patches/nova/0000-libvirt-Stop-unconditionally-enabling-evmcs.patch
+++ b/images/nova/patches/nova/0000-libvirt-Stop-unconditionally-enabling-evmcs.patch
@@ -1,0 +1,66 @@
+From 86a35e97d286cbb6e23f8cc7bec5a05f022da0cb Mon Sep 17 00:00:00 2001
+From: Artom Lifshitz <alifshit@redhat.com>
+Date: Tue, 31 Oct 2023 22:52:50 -0400
+Subject: [PATCH] libvirt: Stop unconditionally enabling evmcs
+
+In I008841988547573878c4e06e82f0fa55084e51b5 we started enabling a
+bunch of libvirt enlightenments for Windows unconditionally. Turns
+out, the `evmcs` enlightenment only works on Intel hosts, and we broke
+the ability to run Windows guests on AMD machines. Until we become
+smarter about conditionally enabling evmcs (with something like traits
+for host CPU features), just stop enabling it at all.
+
+Change-Id: I2ff4fdecd9dc69de283f0e52e07df1aeaf0a9048
+Closes-bug: 2009280
+---
+ nova/tests/unit/virt/libvirt/test_driver.py               | 5 ++++-
+ nova/virt/libvirt/driver.py                               | 1 -
+ ...p-unconditionally-enabling-evmcs-993a825641c4b9f3.yaml | 8 ++++++++
+ 3 files changed, 12 insertions(+), 2 deletions(-)
+ create mode 100644 releasenotes/notes/libvirt-enlightenments-stop-unconditionally-enabling-evmcs-993a825641c4b9f3.yaml
+
+diff --git a/nova/tests/unit/virt/libvirt/test_driver.py b/nova/tests/unit/virt/libvirt/test_driver.py
+index d01b9c2677..ebba604ffa 100644
+--- a/nova/tests/unit/virt/libvirt/test_driver.py
++++ b/nova/tests/unit/virt/libvirt/test_driver.py
+@@ -27972,7 +27972,10 @@ class LibvirtDriverTestCase(test.NoDBTestCase, TraitsComparisonMixin):
+         self.assertTrue(hv.reenlightenment)
+         self.assertTrue(hv.tlbflush)
+         self.assertTrue(hv.ipi)
+-        self.assertTrue(hv.evmcs)
++        # NOTE(artom) evmcs only works on Intel hosts, so we can't enable it
++        # unconditionally. Until we become smarter about it, just don't enable
++        # it at all. See bug 2009280.
++        self.assertFalse(hv.evmcs)
+ 
+ 
+ class LibvirtVolumeUsageTestCase(test.NoDBTestCase):
+diff --git a/nova/virt/libvirt/driver.py b/nova/virt/libvirt/driver.py
+index d03dc5fd67..1b28e50355 100644
+--- a/nova/virt/libvirt/driver.py
++++ b/nova/virt/libvirt/driver.py
+@@ -6234,7 +6234,6 @@ class LibvirtDriver(driver.ComputeDriver):
+             hv.reenlightenment = True
+             hv.tlbflush = True
+             hv.ipi = True
+-            hv.evmcs = True
+ 
+             # NOTE(kosamara): Spoofing the vendor_id aims to allow the nvidia
+             # driver to work on windows VMs. At the moment, the nvidia driver
+diff --git a/releasenotes/notes/libvirt-enlightenments-stop-unconditionally-enabling-evmcs-993a825641c4b9f3.yaml b/releasenotes/notes/libvirt-enlightenments-stop-unconditionally-enabling-evmcs-993a825641c4b9f3.yaml
+new file mode 100644
+index 0000000000..31609f2a2d
+--- /dev/null
++++ b/releasenotes/notes/libvirt-enlightenments-stop-unconditionally-enabling-evmcs-993a825641c4b9f3.yaml
+@@ -0,0 +1,8 @@
++---
++fixes:
++  - |
++    Bug 2009280 has been fixed by no longer enabling the evmcs enlightenment in
++    the libvirt driver. evmcs only works on Intel CPUs, and domains with that
++    enlightenment cannot be started on AMD hosts. There is a possible future
++    feature to enable support for generating this enlightenment only when
++    running on Intel hosts.
+-- 
+2.34.1
+

--- a/images/nova/patches/nova/0001-libvirt-stop-enabling-hyperv-feature-reenlightenment.patch
+++ b/images/nova/patches/nova/0001-libvirt-stop-enabling-hyperv-feature-reenlightenment.patch
@@ -1,0 +1,52 @@
+From e618e78edc6293d248a5fa2eb63b3fa636250fca Mon Sep 17 00:00:00 2001
+From: songjie <songjie_yewu@cmss.chinamobile.com>
+Date: Mon, 25 Dec 2023 16:59:36 +0800
+Subject: [PATCH] libvirt: stop enabling hyperv feature reenlightenment
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The 'reenlightenment' hyperv enlightenment will cause
+instances live-migration to fail (KVM currently doesn’t
+fully support reenlightenment notifications, see
+www.qemu.org/docs/master/system/i386/hyperv.html),
+so don't enable it now.
+
+Change-Id: I6821819450bc96e4304125ea3b76a0e462e6e33f
+Closes-Bug: #2046549
+Related-Bug: #2009280
+---
+ nova/tests/unit/virt/libvirt/test_driver.py | 4 +++-
+ nova/virt/libvirt/driver.py                 | 1 -
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/nova/tests/unit/virt/libvirt/test_driver.py b/nova/tests/unit/virt/libvirt/test_driver.py
+index 868e024370..2e1d089898 100644
+--- a/nova/tests/unit/virt/libvirt/test_driver.py
++++ b/nova/tests/unit/virt/libvirt/test_driver.py
+@@ -28048,7 +28048,9 @@ class LibvirtDriverTestCase(test.NoDBTestCase, TraitsComparisonMixin):
+         self.assertTrue(hv.synic)
+         self.assertTrue(hv.reset)
+         self.assertTrue(hv.frequencies)
+-        self.assertTrue(hv.reenlightenment)
++        # NOTE(jie) reenlightenment will cause instances live-migration
++        # failure, so don't enable it now. See bug 2046549.
++        self.assertFalse(hv.reenlightenment)
+         self.assertTrue(hv.tlbflush)
+         self.assertTrue(hv.ipi)
+         # NOTE(artom) evmcs only works on Intel hosts, so we can't enable it
+diff --git a/nova/virt/libvirt/driver.py b/nova/virt/libvirt/driver.py
+index 7f5f48c047..f8e3353110 100644
+--- a/nova/virt/libvirt/driver.py
++++ b/nova/virt/libvirt/driver.py
+@@ -6262,7 +6262,6 @@ class LibvirtDriver(driver.ComputeDriver):
+             hv.synic = True
+             hv.reset = True
+             hv.frequencies = True
+-            hv.reenlightenment = True
+             hv.tlbflush = True
+             hv.ipi = True
+
+-- 
+2.34.1
+


### PR DESCRIPTION
Windows VMs are failing to live migrate when setting `os_type` to
`windows` property on images under both Intel and AMD systems due
to a lack of support inside QEMU.

In addition, running Windows VMs on AMD systems is not possible due
to the fact that an unsupported feature tries to get added by default.

This adds two upstream patches which disable both of these and make
it possible to run high performance VMs within OpenStack.

Related-Bug: https://bugs.launchpad.net/nova/+bug/2046549
Related-Bug: https://bugs.launchpad.net/nova/+bug/2009280
