### PR TITLE
fix(images): use noninteractive apt-get frontend

### DIFF
--- a/images/Earthfile
+++ b/images/Earthfile
@@ -5,7 +5,7 @@ APT_INSTALL:
   ARG PACKAGES
   RUN \
     apt-get update && \
-    apt-get install --no-install-recommends -y ${PACKAGES} && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y ${PACKAGES} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I noticed the traditional warnings about apt-get running in non-interactive terminals while building images and the fix is to tell apt-get to use the non-interactive frontend. Hopefully I added it to the right place. Nothing is broken, just a small quality of life PR to make the build logs cleaner and get my feet wet in Earthly :-)