### PR TITLE
feat: allow prefix to image names to support proxy/caching without needing to maintain separate inventory override of each and every image

### DIFF
--- a/roles/defaults/defaults/main.yml
+++ b/roles/defaults/defaults/main.yml
@@ -17,6 +17,7 @@ atmosphere_version: 1.10.4 # x-release-please-version
 # Ingress
 atmosphere_ingress_class_name: atmosphere
 atmosphere_ingress_cluster_issuer: atmosphere
+atmosphere_proxy_cache_prefix: ""
 
 # Network backend
 atmosphere_network_backend: openvswitch

--- a/roles/defaults/helpers.go
+++ b/roles/defaults/helpers.go
@@ -13,7 +13,7 @@ var (
 )
 
 func init() {
-	r, _ = regexp.Compile(`{{ atmosphere_images\['(?P<ImageName>\w+)'] \| vexxhost.kubernetes.docker_image\('ref'\) }}`)
+	r, _ = regexp.Compile(`{{ atmosphere_proxy_cache_prefix }}{{ atmosphere_images\['(?P<ImageName>\w+)'] \| vexxhost.kubernetes.docker_image\('ref'\) }}`)
 }
 
 func AssertAtmosphereImage(t *testing.T, expected string, value string) {

--- a/roles/defaults/helpers.go
+++ b/roles/defaults/helpers.go
@@ -13,7 +13,7 @@ var (
 )
 
 func init() {
-	r, _ = regexp.Compile(`{{ atmosphere_proxy_cache_prefix }}{{ atmosphere_images\['(?P<ImageName>\w+)'] \| vexxhost.kubernetes.docker_image\('ref'\) }}`)
+	r, _ = regexp.Compile(`{{ atmosphere_images\['(?P<ImageName>\w+)'] \| vexxhost.kubernetes.docker_image\('ref'\) }}`)
 }
 
 func AssertAtmosphereImage(t *testing.T, expected string, value string) {

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -13,187 +13,186 @@
 # under the License.
 
 _atmosphere_images:
-  alertmanager: quay.io/prometheus/alertmanager:v0.26.0@sha256:361db356b33041437517f1cd298462055580585f26555c317df1a3caf2868552
-  barbican_api: ghcr.io/vexxhost/atmosphere/barbican:2023.2@sha256:15080316ab9b84c46d9e4150adfad036d94d20306f88bf2a3c0216f44d431520
-  barbican_db_sync: ghcr.io/vexxhost/atmosphere/barbican:2023.2@sha256:15080316ab9b84c46d9e4150adfad036d94d20306f88bf2a3c0216f44d431520
-  bootstrap: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  ceph_config_helper: ghcr.io/vexxhost/atmosphere/libvirtd:zed@sha256:02413218a6440478a060a5339a96ec9906ba704205999771a431bc63af13bfa8
-  ceph: quay.io/ceph/ceph:v16.2.11@sha256:1b9803c8984bef8b82f05e233e8fe8ed8f0bba8e5cc2c57f6efaccbeea682add
-  cert_manager_cainjector: quay.io/jetstack/cert-manager-cainjector:v1.7.1@sha256:985743eeed2b62f68ee06e583f1d5a371e1c35af4b1980a1b2571d29174cce47
-  cert_manager_cli: quay.io/jetstack/cert-manager-ctl:v1.7.1@sha256:af84513925d86d2de456b5d67dbccd2a34d93aa6fd4e1c8fe9f84182fef1b1b1
-  cert_manager_controller: quay.io/jetstack/cert-manager-controller:v1.7.1@sha256:51027a4cc4d30e197e3506daf3a4fa2d2a0bc2826469f8a87848dfd279e031c0
-  cert_manager_webhook: quay.io/jetstack/cert-manager-webhook:v1.7.1@sha256:a926d60b6f23553ca5d11ac9cd66bcc692136e838613c8bc0d60c6c35a3cbcfc
-  cilium_node: quay.io/cilium/cilium:v1.13.3@sha256:77176464a1e11ea7e89e984ac7db365e7af39851507e94f137dcf56c87746314
-  cilium_operator: quay.io/cilium/operator-generic:v1.13.3@sha256:fa7003cbfdf8358cb71786afebc711b26e5e44a2ed99bd4944930bba915b8910
-  cinder_api: ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf
-  cinder_backup_storage_init: ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf
-  cinder_backup: ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf
-  cinder_db_sync: ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf
-  cinder_scheduler: ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf
-  cinder_storage_init: ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf
-  cinder_volume_usage_audit: ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf
-  cinder_volume: ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf
-  cluster_api_controller: registry.k8s.io/cluster-api/cluster-api-controller:v1.5.1@sha256:5210087161fdc09c98e47f847c07ed3ff93470e774cb1d5a792e2f76eaa5cf12
-  cluster_api_kubeadm_bootstrap_controller: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.5.1@sha256:6d73f991862d0df9724fab31a4a694681d9181e772c265d2c5b9b0b26b572479
-  cluster_api_kubeadm_control_plane_controller: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.5.1@sha256:8d926bcd3e0ca6be6cb9212f692f0ea6790f83862f4dc02fae0c7e0b35e76907
-  cluster_api_openstack_controller: ghcr.io/vexxhost/atmosphere/capi-openstack-controller:v0.8.0-2@sha256:6d6c4e2f9fa48e07b4471afb3699265fd0511145db3258536253c79e3388a286
-  csi_node_driver_registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.4.0@sha256:0174bf20d7ad8e9f131a045802ef1c43b4592a2ebc18ba07972b1ce8858d9cb7
-  csi_rbd_attacher: registry.k8s.io/sig-storage/csi-attacher:v3.4.0@sha256:adc2922c98c539f680c02af99042d968114746f973a49b529785d6b402134bbf
-  csi_rbd_plugin: quay.io/cephcsi/cephcsi:v3.5.1@sha256:28a674af1df2325fea415e32a7f93f083fce1f9c474912c45f025427fdc0aa10
-  csi_rbd_provisioner: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0@sha256:92107bb668a9de58a09247596c337bc5b46a1d145685eb55ef489ae16952f5bd
-  csi_rbd_resizer: registry.k8s.io/sig-storage/csi-resizer:v1.3.0@sha256:35ec0c736ec8266bd4a46f9e942315f148f3139beed99879d0ad8b8e5074d641
-  csi_rbd_snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v4.2.0@sha256:bd7dafbd0d4fe81f23f01c9a7432de067bdf085f70d61492f5ffddd9c5264358
-  db_drop: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  db_init: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  dep_check: ghcr.io/vexxhost/atmosphere/kubernetes-entrypoint:latest@sha256:87b507ae31f10ad726ca383d656dd2f27cb371568305fc02f615ff8a467e70e3
-  designate_api: ghcr.io/vexxhost/atmosphere/designate:2023.2@sha256:95f92116358e7a7d7850e3966a902163439c7bcbb42f73498992445ea940baf3
-  designate_central: ghcr.io/vexxhost/atmosphere/designate:2023.2@sha256:95f92116358e7a7d7850e3966a902163439c7bcbb42f73498992445ea940baf3
-  designate_db_sync: ghcr.io/vexxhost/atmosphere/designate:2023.2@sha256:95f92116358e7a7d7850e3966a902163439c7bcbb42f73498992445ea940baf3
-  designate_mdns: ghcr.io/vexxhost/atmosphere/designate:2023.2@sha256:95f92116358e7a7d7850e3966a902163439c7bcbb42f73498992445ea940baf3
-  designate_producer: ghcr.io/vexxhost/atmosphere/designate:2023.2@sha256:95f92116358e7a7d7850e3966a902163439c7bcbb42f73498992445ea940baf3
-  designate_sink: ghcr.io/vexxhost/atmosphere/designate:2023.2@sha256:95f92116358e7a7d7850e3966a902163439c7bcbb42f73498992445ea940baf3
-  designate_worker: ghcr.io/vexxhost/atmosphere/designate:2023.2@sha256:95f92116358e7a7d7850e3966a902163439c7bcbb42f73498992445ea940baf3
-  glance_api: ghcr.io/vexxhost/atmosphere/glance:2023.2@sha256:049d8e8e7ed2b0460e5b4447db59d5c8fa88e79c68262fbaf4d9db18d8b53d01
-  glance_db_sync: ghcr.io/vexxhost/atmosphere/glance:2023.2@sha256:049d8e8e7ed2b0460e5b4447db59d5c8fa88e79c68262fbaf4d9db18d8b53d01
-  glance_metadefs_load: ghcr.io/vexxhost/atmosphere/glance:2023.2@sha256:049d8e8e7ed2b0460e5b4447db59d5c8fa88e79c68262fbaf4d9db18d8b53d01
-  glance_registry: ghcr.io/vexxhost/atmosphere/glance:2023.2@sha256:049d8e8e7ed2b0460e5b4447db59d5c8fa88e79c68262fbaf4d9db18d8b53d01
-  glance_storage_init: ghcr.io/vexxhost/atmosphere/glance:2023.2@sha256:049d8e8e7ed2b0460e5b4447db59d5c8fa88e79c68262fbaf4d9db18d8b53d01
-  grafana_sidecar: quay.io/kiwigrid/k8s-sidecar:1.24.6@sha256:3b70b9f1a81e67c97e4cd32c9a918fa44fd2c9f66bdd0d28d8b82d7b502cb5e4
-  grafana: docker.io/grafana/grafana:10.1.0@sha256:047c1c5aa6fef257b6c2516f95c8fcd9f28707c201c6413dd78328b6cbedff6f
-  haproxy: docker.io/library/haproxy:2.5@sha256:ea38b570dd7836aa6b85ef1fb19d1e03f5322cccd62e688f0c2b79e38ac4f391
-  heat_api: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  heat_cfn: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  heat_cloudwatch: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  heat_db_sync: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  heat_engine_cleaner: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  heat_engine: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  heat_purge_deleted: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  horizon_db_sync: ghcr.io/vexxhost/atmosphere/horizon:2023.2@sha256:a7ef7af2613696563e95b62c19a9d7292a934c151a3f6428025ffd9059f4404b
-  horizon: ghcr.io/vexxhost/atmosphere/horizon:2023.2@sha256:a7ef7af2613696563e95b62c19a9d7292a934c151a3f6428025ffd9059f4404b
-  ingress_nginx_controller: registry.k8s.io/ingress-nginx/controller:v1.1.1@sha256:e16123f3932f44a2bba8bc3cf1c109cea4495ee271d6d16ab99228b58766d3ab
-  ingress_nginx_default_backend: registry.k8s.io/defaultbackend-amd64:1.5@sha256:4dc5e07c8ca4e23bddb3153737d7b8c556e5fb2f29c4558b7cd6e6df99c512c7
-  ingress_nginx_kube_webhook_certgen: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:23a03c9c381fba54043d0f6148efeaf4c1ca2ed176e43455178b5c5ebf15ad70 # noqa: yaml[line-length]
-  keepalived: us-docker.pkg.dev/vexxhost-infra/openstack/keepalived:2.0.19@sha256:4fe20cd5c200e301e1a790c9aca8c3fc651c8461afea9d37c56a462d3bfa48bb
-  keycloak: quay.io/keycloak/keycloak:22.0.1-0@sha256:5b872e841ea9e394d89bdf250146434532d9c2001404540d46621d60f87494e7
-  keystone_api: ghcr.io/vexxhost/atmosphere/keystone:2023.2@sha256:91575ae35e575cb9bc2b4ca2f24813e9832927f4c0097b0c23a72a82577dba6e
-  keystone_credential_cleanup: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  keystone_credential_rotate: ghcr.io/vexxhost/atmosphere/keystone:2023.2@sha256:91575ae35e575cb9bc2b4ca2f24813e9832927f4c0097b0c23a72a82577dba6e
-  keystone_credential_setup: ghcr.io/vexxhost/atmosphere/keystone:2023.2@sha256:91575ae35e575cb9bc2b4ca2f24813e9832927f4c0097b0c23a72a82577dba6e
-  keystone_db_sync: ghcr.io/vexxhost/atmosphere/keystone:2023.2@sha256:91575ae35e575cb9bc2b4ca2f24813e9832927f4c0097b0c23a72a82577dba6e
-  keystone_domain_manage: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  keystone_fernet_rotate: ghcr.io/vexxhost/atmosphere/keystone:2023.2@sha256:91575ae35e575cb9bc2b4ca2f24813e9832927f4c0097b0c23a72a82577dba6e
-  keystone_fernet_setup: ghcr.io/vexxhost/atmosphere/keystone:2023.2@sha256:91575ae35e575cb9bc2b4ca2f24813e9832927f4c0097b0c23a72a82577dba6e
-  ks_endpoints: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  ks_service: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  ks_user: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  kube_apiserver: registry.k8s.io/kube-apiserver:v1.22.17@sha256:d88d1c8f972e10ff4b4176f3185434e2832d3805c457fa9e8816f1da2fdf3b93
-  kube_controller_manager: registry.k8s.io/kube-controller-manager:v1.22.17@sha256:c3e041c8c8c9ffd33d421c8c1de1f42da52b616bfcf61880498e9efc9ec88005
-  kube_coredns: registry.k8s.io/coredns/coredns:v1.8.4@sha256:10683d82b024a58cc248c468c2632f9d1b260500f7cd9bb8e73f751048d7d6d4
-  kube_etcd: registry.k8s.io/etcd:3.5.6-0@sha256:b0fdb657c0bd10d8c96ed2ce762842384709a9fc54d532220d5252f1f99b4d1d
-  kube_proxy: registry.k8s.io/kube-proxy:v1.22.17@sha256:614ec43f14e16e077173afa61ee355f8a5d1cc5b1c5e8030766781dc5ccde171
-  kube_scheduler: registry.k8s.io/kube-scheduler:v1.22.17@sha256:f85dda445b7c8da197b8e39b0ca2b125b1e97a4a365d45c04d2759aefe935974
-  kube_state_metrics: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2@sha256:c30cae7072ffb03f3e7934516db89b3be6c9e5521c0d04d5bbc6e115c9bfa3a7
-  kubectl: docker.io/bitnami/kubectl:1.27.3@sha256:5fadd413886221a024f2739b859c3b1c1fa1ef527df5d18e09e35d380fc5a3f5
-  libvirt: ghcr.io/vexxhost/atmosphere/libvirtd:zed@sha256:02413218a6440478a060a5339a96ec9906ba704205999771a431bc63af13bfa8
-  libvirt_tls_sidecar: ghcr.io/vexxhost/atmosphere/libvirt-tls-sidecar:latest@sha256:1595e8fc66e92a0079ee23902b9e194658df9e856b3d1296325548b852bfd91b
-  libvirt_exporter: docker.io/vexxhost/libvirtd-exporter:latest@sha256:1a0fdf89f80060bfdbb8cf45213295c5d9fb1f7ea7dbfe2b331f0649cc98df8e
-  local_path_provisioner_helper: docker.io/library/busybox:1.36.0@sha256:9e2bbca079387d7965c3a9cee6d0c53f4f4e63ff7637877a83c4c05f2a666112
-  local_path_provisioner: docker.io/rancher/local-path-provisioner:v0.0.24@sha256:5bb33992a4ec3034c28b5e0b3c4c2ac35d3613b25b79455eb4b1a95adc82cdc0
-  loki_gateway: docker.io/nginxinc/nginx-unprivileged:1.19-alpine@sha256:bbd46452aae30a7cc7bc438f267af812c7a2b0f3b5bcd4cc55eb99669cea3f28
-  loki: docker.io/grafana/loki:2.7.3@sha256:8e3abbd89173066721fa07bddfee1c1a7a8fe59bed5b00a2fa09d2b3cef8758c
-  magnum_api: ghcr.io/vexxhost/atmosphere/magnum:2023.2@sha256:828673b68da72be063fc456fe1257d92da85cc60dc1844f5c028f2d778c0792d
-  magnum_cluster_api_proxy: ghcr.io/vexxhost/atmosphere/magnum:2023.2@sha256:828673b68da72be063fc456fe1257d92da85cc60dc1844f5c028f2d778c0792d
-  magnum_conductor: ghcr.io/vexxhost/atmosphere/magnum:2023.2@sha256:828673b68da72be063fc456fe1257d92da85cc60dc1844f5c028f2d778c0792d
-  magnum_db_sync: ghcr.io/vexxhost/atmosphere/magnum:2023.2@sha256:828673b68da72be063fc456fe1257d92da85cc60dc1844f5c028f2d778c0792d
-  magnum_registry: quay.io/vexxhost/magnum-cluster-api-registry:latest@sha256:caba380e193264f047651728cbc7905e87d7eee846d8576778b5e7d824ec609d
-  manila_api: ghcr.io/vexxhost/atmosphere/manila:2023.2@sha256:d1da7bc015fe1a85b3cc9c420a7dd7fb50e4dca5fef96d1affa0b33b40479533
-  manila_data: ghcr.io/vexxhost/atmosphere/manila:2023.2@sha256:d1da7bc015fe1a85b3cc9c420a7dd7fb50e4dca5fef96d1affa0b33b40479533
-  manila_db_sync: ghcr.io/vexxhost/atmosphere/manila:2023.2@sha256:d1da7bc015fe1a85b3cc9c420a7dd7fb50e4dca5fef96d1affa0b33b40479533
-  manila_scheduler: ghcr.io/vexxhost/atmosphere/manila:2023.2@sha256:d1da7bc015fe1a85b3cc9c420a7dd7fb50e4dca5fef96d1affa0b33b40479533
-  manila_share: ghcr.io/vexxhost/atmosphere/manila:2023.2@sha256:d1da7bc015fe1a85b3cc9c420a7dd7fb50e4dca5fef96d1affa0b33b40479533
-  memcached: docker.io/library/memcached:1.6.17@sha256:d20c577c08863b09b21ecd21d0384d0a800f39d82f37045b3608f677a0a9400f
-  netoffload: ghcr.io/vexxhost/atmosphere/netoffload:main@sha256:af4029411c97f460b396f12d884d61f5024676481d302087dc2d7161339a12f3
-  neutron_bagpipe_bgp: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  neutron_bgp_dragent: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  neutron_coredns: docker.io/coredns/coredns:1.9.3@sha256:bdb36ee882c13135669cfc2bb91c808a33926ad1a411fee07bd2dc344bb8f782
-  neutron_db_sync: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  neutron_dhcp: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  neutron_ironic_agent: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  neutron_l2gw: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  neutron_l3: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  neutron_linuxbridge_agent: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  neutron_metadata: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  neutron_netns_cleanup_cron: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  neutron_openvswitch_agent: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  neutron_ovn_metadata: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  neutron_server: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  neutron_sriov_agent_init: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  neutron_sriov_agent: ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de
-  node_feature_discovery: registry.k8s.io/nfd/node-feature-discovery:v0.11.2@sha256:24b2abfb5956b6a2a9a0f4248232838d02235d65044078c43d8bdcf29344f141
-  nova_api: ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875
-  nova_archive_deleted_rows: ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875
-  nova_cell_setup_init: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  nova_cell_setup: ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875
-  nova_compute_ironic: ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875
-  nova_compute_ssh: ghcr.io/vexxhost/atmosphere/nova-ssh:latest@sha256:8148213364b922316a3a87068ac2790d2e068849ac3566326faab822adbdffff
-  nova_compute: ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875
-  nova_conductor: ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875
-  nova_consoleauth: ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875
-  nova_db_sync: ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875
-  nova_novncproxy_assets: ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875
-  nova_novncproxy: ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875
-  nova_placement: ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875
-  nova_scheduler: ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875
-  nova_service_cleaner: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  nova_spiceproxy_assets: ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875
-  nova_spiceproxy: ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875
-  octavia_api: ghcr.io/vexxhost/atmosphere/octavia:2023.2@sha256:98db9ba10beea9c021908e310556093527597b3e212eb6dfa542ead84e763c29
-  octavia_db_sync: ghcr.io/vexxhost/atmosphere/octavia:2023.2@sha256:98db9ba10beea9c021908e310556093527597b3e212eb6dfa542ead84e763c29
-  octavia_health_manager_init: ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4
-  octavia_health_manager: ghcr.io/vexxhost/atmosphere/octavia:2023.2@sha256:98db9ba10beea9c021908e310556093527597b3e212eb6dfa542ead84e763c29
-  octavia_housekeeping: ghcr.io/vexxhost/atmosphere/octavia:2023.2@sha256:98db9ba10beea9c021908e310556093527597b3e212eb6dfa542ead84e763c29
-  octavia_worker: ghcr.io/vexxhost/atmosphere/octavia:2023.2@sha256:98db9ba10beea9c021908e310556093527597b3e212eb6dfa542ead84e763c29
-  openvswitch_db_server: ghcr.io/vexxhost/atmosphere/openvswitch:3.1.0-65@sha256:682bac2cce6fbe4a3aecc4f18a129f5102cccac34d6ac914c59b713294e50927
-  openvswitch_vswitchd: ghcr.io/vexxhost/atmosphere/openvswitch:3.1.0-65@sha256:682bac2cce6fbe4a3aecc4f18a129f5102cccac34d6ac914c59b713294e50927
-  ovn_controller: ghcr.io/vexxhost/atmosphere/ovn-host:23.03.0-69@sha256:aecac533c7ca5b365add031bf3d2c9d88c943c551a4f67f9a5ee1e270e5ab4a9
-  ovn_northd: ghcr.io/vexxhost/atmosphere/ovn-central:23.03.0-69@sha256:38fb23c01ae023496dbe4df5e37c81ad84174a97765e373a3cf7d660805f87b7
-  ovn_ovsdb_nb: ghcr.io/vexxhost/atmosphere/ovn-central:23.03.0-69@sha256:38fb23c01ae023496dbe4df5e37c81ad84174a97765e373a3cf7d660805f87b7
-  ovn_ovsdb_sb: ghcr.io/vexxhost/atmosphere/ovn-central:23.03.0-69@sha256:38fb23c01ae023496dbe4df5e37c81ad84174a97765e373a3cf7d660805f87b7
-  pause: registry.k8s.io/pause:3.8@sha256:f5944f2d1daf66463768a1503d0c8c5e8dde7c1674d3f85abc70cef9c7e32e95
-  percona_xtradb_cluster_haproxy: docker.io/percona/percona-xtradb-cluster-operator:1.13.0-haproxy@sha256:f04e4fea548bfc7cb0bfc73c75c7f2c64d299cf04125a07a8101a55f0f734fed
-  percona_xtradb_cluster_operator: docker.io/percona/percona-xtradb-cluster-operator:1.13.0@sha256:c674d63242f1af521edfbaffae2ae02fb8d010c0557a67a9c42d2b4a50db5243
-  percona_xtradb_cluster: docker.io/percona/percona-xtradb-cluster:8.0.32-24.2@sha256:1f978ab8912e1b5fc66570529cb7e7a4ec6a38adbfce1ece78159b0fcfa7d47a
-  percona_version_service: docker.io/perconalab/version-service:main-3325140@sha256:b7928130fca1e35ce7feaeec326fef836229a8b4de2f6f6ea5b6d2c7a48cd071
-  placement_db_sync: ghcr.io/vexxhost/atmosphere/placement:2023.2@sha256:65f07eb0de6f774c092e3610297957615965bd6f03d0ede1dd890c5ec1fcf3ed
-  placement: ghcr.io/vexxhost/atmosphere/placement:2023.2@sha256:65f07eb0de6f774c092e3610297957615965bd6f03d0ede1dd890c5ec1fcf3ed
-  prometheus_config_reloader: quay.io/prometheus-operator/prometheus-config-reloader:v0.67.1@sha256:0fe3cf36985e0e524801a0393f88fa4b5dd5ffdf0f091ff78ee02f2d281631b5
-  prometheus_ipmi_exporter: us-docker.pkg.dev/vexxhost-infra/openstack/ipmi-exporter:1.4.0@sha256:4898da9cc11961a56363e8b3f3437d0f45b46585b20c79e33e97fbe7232e05d2
-  prometheus_memcached_exporter: quay.io/prometheus/memcached-exporter:v0.10.0@sha256:fa5a2de1a4744da66fb369bee81232f5ea52208bc643e409a60f66d699ac27b2
-  prometheus_mysqld_exporter: quay.io/prometheus/mysqld-exporter:v0.14.0@sha256:eb6fe170738bf9181c51f5bc89f93adb26672ec49ffdcb22f55c24834003b45d
-  prometheus_node_exporter: quay.io/prometheus/node-exporter:v1.6.1@sha256:81f94e50ea37a88dfee849d0f4acad25b96b397061f59e5095905f6bc5829637
-  prometheus_openstack_exporter: ghcr.io/openstack-exporter/openstack-exporter:1.6.0@sha256:bae162b4ad50c7662b03547f27b072303268218af1fc8d9745001357f912937d
-  prometheus_operator_kube_webhook_certgen: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6@sha256:5e6fdb9b2c74ad2576dd835b389d00d18ccfee21b547d1a79efb881009664099
-  prometheus_operator: quay.io/prometheus-operator/prometheus-operator:v0.67.1@sha256:e68bff5dd72a5d1be98ec66ef1383a7d7a338f3ffbef8603d551f70dafc8d978
-  prometheus_pushgateway: docker.io/prom/pushgateway:v1.4.2@sha256:f74ff5b7ad0b8fb60c24b77eaeab025d659e46ec15f32430adb976544305c01f
-  prometheus: quay.io/prometheus/prometheus:v2.46.0@sha256:d6ead9daf2355b9923479e24d7e93f246253ee6a5eb18a61b0f607219f341a80
-  rabbit_init: docker.io/library/rabbitmq:3.10.2-management@sha256:350ab6d773e3af45183466488fe3259df36cd6ade437b4366a59e8052458cc3a
-  rabbitmq_cluster_operator: docker.io/rabbitmqoperator/cluster-operator:1.13.1@sha256:84ce21e9e2d6ceb8b93d9daf0b7cc1550b6ed86be5b3acd8b0816eddc1b87dc2
-  rabbitmq_credential_updater: docker.io/rabbitmqoperator/default-user-credential-updater:1.0.2@sha256:563908dd8d6b6ce768e463a2d9d7a9b9b4adbcd258fed02c0a8746395cfa3f0d
-  rabbitmq_server: docker.io/library/rabbitmq:3.10.2-management@sha256:350ab6d773e3af45183466488fe3259df36cd6ade437b4366a59e8052458cc3a
-  rabbitmq_topology_operator: docker.io/rabbitmqoperator/messaging-topology-operator:1.6.0@sha256:5052e8bdb26996c62315f0707c6fb291fd84492e360cca7351e2c3fdf659be43
-  rook_ceph: docker.io/rook/ceph:v1.10.10@sha256:9ae0eca578ef6e38492e5f90073050491382d8772914ddb8ffe4fca8d365b850
-  secretgen_controller: ghcr.io/carvel-dev/secretgen-controller@sha256:59ec05ce5847bfd70c8e04f08b5195e918c8f6fbb947ffc91b456494a2958fd5
-  senlin_api: ghcr.io/vexxhost/atmosphere/senlin:2023.2@sha256:9839d6227a6731abf93d29197f2cfc23fa9e476061d65f97c816be4177cb1577
-  senlin_conductor: ghcr.io/vexxhost/atmosphere/senlin:2023.2@sha256:9839d6227a6731abf93d29197f2cfc23fa9e476061d65f97c816be4177cb1577
-  senlin_db_sync: ghcr.io/vexxhost/atmosphere/senlin:2023.2@sha256:9839d6227a6731abf93d29197f2cfc23fa9e476061d65f97c816be4177cb1577
-  senlin_engine_cleaner: ghcr.io/vexxhost/atmosphere/senlin:2023.2@sha256:9839d6227a6731abf93d29197f2cfc23fa9e476061d65f97c816be4177cb1577
-  senlin_engine: ghcr.io/vexxhost/atmosphere/senlin:2023.2@sha256:9839d6227a6731abf93d29197f2cfc23fa9e476061d65f97c816be4177cb1577
-  senlin_health_manager: ghcr.io/vexxhost/atmosphere/senlin:2023.2@sha256:9839d6227a6731abf93d29197f2cfc23fa9e476061d65f97c816be4177cb1577
-  staffeln_db_sync: ghcr.io/vexxhost/atmosphere/staffeln:v2.2.3@sha256:fabb1da50ea8df7db05ca26b7ce5685132601ab8b2829599ce0a63a313e4d6fa
-  staffeln_conductor: ghcr.io/vexxhost/atmosphere/staffeln:v2.2.3@sha256:fabb1da50ea8df7db05ca26b7ce5685132601ab8b2829599ce0a63a313e4d6fa
-  staffeln_api: ghcr.io/vexxhost/atmosphere/staffeln:v2.2.3@sha256:fabb1da50ea8df7db05ca26b7ce5685132601ab8b2829599ce0a63a313e4d6fa
-  tempest_run_tests: ghcr.io/vexxhost/atmosphere/tempest:master@sha256:0d5e44c7c536ef2a1af00afd50b755683abc5e8dad13b4f166144e9fc4142f03
-  vector: docker.io/timberio/vector:0.27.0-debian@sha256:29f23dab76fa306b67b10eac3e9decdb01c906f8aa3b00a2f5b2e8ae088b84e0
+  alertmanager: "{{ atmosphere_proxy_cache_prefix }}quay.io/prometheus/alertmanager:v0.26.0@sha256:361db356b33041437517f1cd298462055580585f26555c317df1a3caf2868552"
+  barbican_api: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/barbican:2023.2@sha256:15080316ab9b84c46d9e4150adfad036d94d20306f88bf2a3c0216f44d431520"
+  barbican_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/barbican:2023.2@sha256:15080316ab9b84c46d9e4150adfad036d94d20306f88bf2a3c0216f44d431520"
+  bootstrap: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  ceph_config_helper: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/libvirtd:zed@sha256:02413218a6440478a060a5339a96ec9906ba704205999771a431bc63af13bfa8"
+  ceph: "{{ atmosphere_proxy_cache_prefix }}quay.io/ceph/ceph:v16.2.11@sha256:1b9803c8984bef8b82f05e233e8fe8ed8f0bba8e5cc2c57f6efaccbeea682add"
+  cert_manager_cainjector: "{{ atmosphere_proxy_cache_prefix }}quay.io/jetstack/cert-manager-cainjector:v1.7.1@sha256:985743eeed2b62f68ee06e583f1d5a371e1c35af4b1980a1b2571d29174cce47"
+  cert_manager_cli: "{{ atmosphere_proxy_cache_prefix }}quay.io/jetstack/cert-manager-ctl:v1.7.1@sha256:af84513925d86d2de456b5d67dbccd2a34d93aa6fd4e1c8fe9f84182fef1b1b1"
+  cert_manager_controller: "{{ atmosphere_proxy_cache_prefix }}quay.io/jetstack/cert-manager-controller:v1.7.1@sha256:51027a4cc4d30e197e3506daf3a4fa2d2a0bc2826469f8a87848dfd279e031c0"
+  cert_manager_webhook: "{{ atmosphere_proxy_cache_prefix }}quay.io/jetstack/cert-manager-webhook:v1.7.1@sha256:a926d60b6f23553ca5d11ac9cd66bcc692136e838613c8bc0d60c6c35a3cbcfc"
+  cilium_node: "{{ atmosphere_proxy_cache_prefix }}quay.io/cilium/cilium:v1.13.3@sha256:77176464a1e11ea7e89e984ac7db365e7af39851507e94f137dcf56c87746314"
+  cilium_operator: "{{ atmosphere_proxy_cache_prefix }}quay.io/cilium/operator-generic:v1.13.3@sha256:fa7003cbfdf8358cb71786afebc711b26e5e44a2ed99bd4944930bba915b8910"
+  cinder_api: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf"
+  cinder_backup_storage_init: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf"
+  cinder_backup: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf"
+  cinder_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf"
+  cinder_scheduler: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf"
+  cinder_storage_init: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf"
+  cinder_volume_usage_audit: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf"
+  cinder_volume: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/cinder:2023.2@sha256:9520002bdc865b7ac6df2aa24dd16ed471afdd8e7db777d5d0b794b480bc6cbf"
+  cluster_api_controller: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/cluster-api/cluster-api-controller:v1.5.1@sha256:5210087161fdc09c98e47f847c07ed3ff93470e774cb1d5a792e2f76eaa5cf12"
+  cluster_api_kubeadm_bootstrap_controller: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.5.1@sha256:6d73f991862d0df9724fab31a4a694681d9181e772c265d2c5b9b0b26b572479"
+  cluster_api_kubeadm_control_plane_controller: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.5.1@sha256:8d926bcd3e0ca6be6cb9212f692f0ea6790f83862f4dc02fae0c7e0b35e76907"
+  cluster_api_openstack_controller: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/capi-openstack-controller:v0.8.0-2@sha256:6d6c4e2f9fa48e07b4471afb3699265fd0511145db3258536253c79e3388a286"
+  csi_node_driver_registrar: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.4.0@sha256:0174bf20d7ad8e9f131a045802ef1c43b4592a2ebc18ba07972b1ce8858d9cb7"
+  csi_rbd_attacher: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/sig-storage/csi-attacher:v3.4.0@sha256:adc2922c98c539f680c02af99042d968114746f973a49b529785d6b402134bbf"
+  csi_rbd_plugin: "{{ atmosphere_proxy_cache_prefix }}quay.io/cephcsi/cephcsi:v3.5.1@sha256:28a674af1df2325fea415e32a7f93f083fce1f9c474912c45f025427fdc0aa10"
+  csi_rbd_provisioner: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/sig-storage/csi-provisioner:v3.1.0@sha256:92107bb668a9de58a09247596c337bc5b46a1d145685eb55ef489ae16952f5bd"
+  csi_rbd_resizer: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/sig-storage/csi-resizer:v1.3.0@sha256:35ec0c736ec8266bd4a46f9e942315f148f3139beed99879d0ad8b8e5074d641"
+  csi_rbd_snapshotter: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/sig-storage/csi-snapshotter:v4.2.0@sha256:bd7dafbd0d4fe81f23f01c9a7432de067bdf085f70d61492f5ffddd9c5264358"
+  db_drop: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  db_init: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  dep_check: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/kubernetes-entrypoint:latest@sha256:87b507ae31f10ad726ca383d656dd2f27cb371568305fc02f615ff8a467e70e3"
+  designate_api: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/designate:2023.2@sha256:95f92116358e7a7d7850e3966a902163439c7bcbb42f73498992445ea940baf3"
+  designate_central: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/designate:2023.2@sha256:95f92116358e7a7d7850e3966a902163439c7bcbb42f73498992445ea940baf3"
+  designate_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/designate:2023.2@sha256:95f92116358e7a7d7850e3966a902163439c7bcbb42f73498992445ea940baf3"
+  designate_mdns: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/designate:2023.2@sha256:95f92116358e7a7d7850e3966a902163439c7bcbb42f73498992445ea940baf3"
+  designate_producer: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/designate:2023.2@sha256:95f92116358e7a7d7850e3966a902163439c7bcbb42f73498992445ea940baf3"
+  designate_sink: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/designate:2023.2@sha256:95f92116358e7a7d7850e3966a902163439c7bcbb42f73498992445ea940baf3"
+  designate_worker: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/designate:2023.2@sha256:95f92116358e7a7d7850e3966a902163439c7bcbb42f73498992445ea940baf3"
+  glance_api: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/glance:2023.2@sha256:049d8e8e7ed2b0460e5b4447db59d5c8fa88e79c68262fbaf4d9db18d8b53d01"
+  glance_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/glance:2023.2@sha256:049d8e8e7ed2b0460e5b4447db59d5c8fa88e79c68262fbaf4d9db18d8b53d01"
+  glance_metadefs_load: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/glance:2023.2@sha256:049d8e8e7ed2b0460e5b4447db59d5c8fa88e79c68262fbaf4d9db18d8b53d01"
+  glance_registry: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/glance:2023.2@sha256:049d8e8e7ed2b0460e5b4447db59d5c8fa88e79c68262fbaf4d9db18d8b53d01"
+  glance_storage_init: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/glance:2023.2@sha256:049d8e8e7ed2b0460e5b4447db59d5c8fa88e79c68262fbaf4d9db18d8b53d01"
+  grafana_sidecar: "{{ atmosphere_proxy_cache_prefix }}quay.io/kiwigrid/k8s-sidecar:1.24.6@sha256:3b70b9f1a81e67c97e4cd32c9a918fa44fd2c9f66bdd0d28d8b82d7b502cb5e4"
+  grafana: "{{ atmosphere_proxy_cache_prefix }}docker.io/grafana/grafana:10.1.0@sha256:047c1c5aa6fef257b6c2516f95c8fcd9f28707c201c6413dd78328b6cbedff6f"
+  haproxy: "{{ atmosphere_proxy_cache_prefix }}docker.io/library/haproxy:2.5@sha256:ea38b570dd7836aa6b85ef1fb19d1e03f5322cccd62e688f0c2b79e38ac4f391"
+  heat_api: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  heat_cfn: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  heat_cloudwatch: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  heat_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  heat_engine_cleaner: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  heat_engine: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  heat_purge_deleted: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  horizon_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/horizon:2023.2@sha256:a7ef7af2613696563e95b62c19a9d7292a934c151a3f6428025ffd9059f4404b"
+  horizon: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/horizon:2023.2@sha256:a7ef7af2613696563e95b62c19a9d7292a934c151a3f6428025ffd9059f4404b"
+  ingress_nginx_controller: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/ingress-nginx/controller:v1.1.1@sha256:e16123f3932f44a2bba8bc3cf1c109cea4495ee271d6d16ab99228b58766d3ab"
+  ingress_nginx_default_backend: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/defaultbackend-amd64:1.5@sha256:4dc5e07c8ca4e23bddb3153737d7b8c556e5fb2f29c4558b7cd6e6df99c512c7"
+  ingress_nginx_kube_webhook_certgen: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:23a03c9c381fba54043d0f6148efeaf4c1ca2ed176e43455178b5c5ebf15ad70" # noqa: yaml[line-length]
+  keepalived: "{{ atmosphere_proxy_cache_prefix }}us-docker.pkg.dev/vexxhost-infra/openstack/keepalived:2.0.19@sha256:4fe20cd5c200e301e1a790c9aca8c3fc651c8461afea9d37c56a462d3bfa48bb"
+  keycloak: "{{ atmosphere_proxy_cache_prefix }}quay.io/keycloak/keycloak:22.0.1-0@sha256:5b872e841ea9e394d89bdf250146434532d9c2001404540d46621d60f87494e7"
+  keystone_api: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/keystone:2023.2@sha256:91575ae35e575cb9bc2b4ca2f24813e9832927f4c0097b0c23a72a82577dba6e"
+  keystone_credential_cleanup: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  keystone_credential_rotate: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/keystone:2023.2@sha256:91575ae35e575cb9bc2b4ca2f24813e9832927f4c0097b0c23a72a82577dba6e"
+  keystone_credential_setup: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/keystone:2023.2@sha256:91575ae35e575cb9bc2b4ca2f24813e9832927f4c0097b0c23a72a82577dba6e"
+  keystone_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/keystone:2023.2@sha256:91575ae35e575cb9bc2b4ca2f24813e9832927f4c0097b0c23a72a82577dba6e"
+  keystone_domain_manage: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  keystone_fernet_rotate: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/keystone:2023.2@sha256:91575ae35e575cb9bc2b4ca2f24813e9832927f4c0097b0c23a72a82577dba6e"
+  keystone_fernet_setup: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/keystone:2023.2@sha256:91575ae35e575cb9bc2b4ca2f24813e9832927f4c0097b0c23a72a82577dba6e"
+  ks_endpoints: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  ks_service: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  ks_user: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  kube_apiserver: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/kube-apiserver:v1.22.17@sha256:d88d1c8f972e10ff4b4176f3185434e2832d3805c457fa9e8816f1da2fdf3b93"
+  kube_controller_manager: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/kube-controller-manager:v1.22.17@sha256:c3e041c8c8c9ffd33d421c8c1de1f42da52b616bfcf61880498e9efc9ec88005"
+  kube_coredns: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/coredns/coredns:v1.8.4@sha256:10683d82b024a58cc248c468c2632f9d1b260500f7cd9bb8e73f751048d7d6d4"
+  kube_etcd: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/etcd:3.5.6-0@sha256:b0fdb657c0bd10d8c96ed2ce762842384709a9fc54d532220d5252f1f99b4d1d"
+  kube_proxy: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/kube-proxy:v1.22.17@sha256:614ec43f14e16e077173afa61ee355f8a5d1cc5b1c5e8030766781dc5ccde171"
+  kube_scheduler: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/kube-scheduler:v1.22.17@sha256:f85dda445b7c8da197b8e39b0ca2b125b1e97a4a365d45c04d2759aefe935974"
+  kube_state_metrics: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2@sha256:c30cae7072ffb03f3e7934516db89b3be6c9e5521c0d04d5bbc6e115c9bfa3a7"
+  kubectl: "{{ atmosphere_proxy_cache_prefix }}docker.io/bitnami/kubectl:1.27.3@sha256:5fadd413886221a024f2739b859c3b1c1fa1ef527df5d18e09e35d380fc5a3f5"
+  libvirt: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/libvirtd:zed@sha256:02413218a6440478a060a5339a96ec9906ba704205999771a431bc63af13bfa8"
+  libvirt_tls_sidecar: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/libvirt-tls-sidecar:latest@sha256:1595e8fc66e92a0079ee23902b9e194658df9e856b3d1296325548b852bfd91b"
+  libvirt_exporter: "{{ atmosphere_proxy_cache_prefix }}docker.io/vexxhost/libvirtd-exporter:latest@sha256:1a0fdf89f80060bfdbb8cf45213295c5d9fb1f7ea7dbfe2b331f0649cc98df8e"
+  local_path_provisioner_helper: "{{ atmosphere_proxy_cache_prefix }}docker.io/library/busybox:1.36.0@sha256:9e2bbca079387d7965c3a9cee6d0c53f4f4e63ff7637877a83c4c05f2a666112"
+  local_path_provisioner: "{{ atmosphere_proxy_cache_prefix }}docker.io/rancher/local-path-provisioner:v0.0.24@sha256:5bb33992a4ec3034c28b5e0b3c4c2ac35d3613b25b79455eb4b1a95adc82cdc0"
+  loki_gateway: "{{ atmosphere_proxy_cache_prefix }}docker.io/nginxinc/nginx-unprivileged:1.19-alpine@sha256:bbd46452aae30a7cc7bc438f267af812c7a2b0f3b5bcd4cc55eb99669cea3f28"
+  loki: "{{ atmosphere_proxy_cache_prefix }}docker.io/grafana/loki:2.7.3@sha256:8e3abbd89173066721fa07bddfee1c1a7a8fe59bed5b00a2fa09d2b3cef8758c"
+  magnum_api: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/magnum:2023.2@sha256:828673b68da72be063fc456fe1257d92da85cc60dc1844f5c028f2d778c0792d"
+  magnum_cluster_api_proxy: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/magnum:2023.2@sha256:828673b68da72be063fc456fe1257d92da85cc60dc1844f5c028f2d778c0792d"
+  magnum_conductor: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/magnum:2023.2@sha256:828673b68da72be063fc456fe1257d92da85cc60dc1844f5c028f2d778c0792d"
+  magnum_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/magnum:2023.2@sha256:828673b68da72be063fc456fe1257d92da85cc60dc1844f5c028f2d778c0792d"
+  magnum_registry: "{{ atmosphere_proxy_cache_prefix }}quay.io/vexxhost/magnum-cluster-api-registry:latest@sha256:caba380e193264f047651728cbc7905e87d7eee846d8576778b5e7d824ec609d"
+  manila_api: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/manila:2023.2@sha256:d1da7bc015fe1a85b3cc9c420a7dd7fb50e4dca5fef96d1affa0b33b40479533"
+  manila_data: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/manila:2023.2@sha256:d1da7bc015fe1a85b3cc9c420a7dd7fb50e4dca5fef96d1affa0b33b40479533"
+  manila_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/manila:2023.2@sha256:d1da7bc015fe1a85b3cc9c420a7dd7fb50e4dca5fef96d1affa0b33b40479533"
+  manila_scheduler: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/manila:2023.2@sha256:d1da7bc015fe1a85b3cc9c420a7dd7fb50e4dca5fef96d1affa0b33b40479533"
+  manila_share: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/manila:2023.2@sha256:d1da7bc015fe1a85b3cc9c420a7dd7fb50e4dca5fef96d1affa0b33b40479533"
+  memcached: "{{ atmosphere_proxy_cache_prefix }}docker.io/library/memcached:1.6.17@sha256:d20c577c08863b09b21ecd21d0384d0a800f39d82f37045b3608f677a0a9400f"
+  netoffload: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/netoffload:main@sha256:af4029411c97f460b396f12d884d61f5024676481d302087dc2d7161339a12f3"
+  neutron_bagpipe_bgp: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  neutron_bgp_dragent: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  neutron_coredns: "{{ atmosphere_proxy_cache_prefix }}docker.io/coredns/coredns:1.9.3@sha256:bdb36ee882c13135669cfc2bb91c808a33926ad1a411fee07bd2dc344bb8f782"
+  neutron_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  neutron_dhcp: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  neutron_ironic_agent: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  neutron_l2gw: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  neutron_l3: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  neutron_linuxbridge_agent: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  neutron_metadata: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  neutron_netns_cleanup_cron: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  neutron_openvswitch_agent: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  neutron_ovn_metadata: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  neutron_server: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  neutron_sriov_agent_init: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  neutron_sriov_agent: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/neutron:zed@sha256:24cf713e5fbab58ace01284e6628a8de87310a816cf5625ee7c58591e99f78de"
+  node_feature_discovery: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/nfd/node-feature-discovery:v0.11.2@sha256:24b2abfb5956b6a2a9a0f4248232838d02235d65044078c43d8bdcf29344f141"
+  nova_api: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875"
+  nova_archive_deleted_rows: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875"
+  nova_cell_setup_init: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  nova_cell_setup: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875"
+  nova_compute_ironic: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875"
+  nova_compute_ssh: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova-ssh:latest@sha256:8148213364b922316a3a87068ac2790d2e068849ac3566326faab822adbdffff"
+  nova_compute: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875"
+  nova_conductor: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875"
+  nova_consoleauth: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875"
+  nova_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875"
+  nova_novncproxy_assets: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875"
+  nova_novncproxy: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875"
+  nova_placement: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875"
+  nova_scheduler: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875"
+  nova_service_cleaner: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  nova_spiceproxy_assets: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875"
+  nova_spiceproxy: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/nova:zed@sha256:c54412db332d5ff41069624095f34ba86e6ee4afb12f9d3bf17c8b65b016f875"
+  octavia_api: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/octavia:2023.2@sha256:98db9ba10beea9c021908e310556093527597b3e212eb6dfa542ead84e763c29"
+  octavia_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/octavia:2023.2@sha256:98db9ba10beea9c021908e310556093527597b3e212eb6dfa542ead84e763c29"
+  octavia_health_manager_init: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/heat:2023.2@sha256:73457a79605766b72ebada47529f2fb9be4f0cdae503c3c7febcf3c48a2c93c4"
+  octavia_health_manager: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/octavia:2023.2@sha256:98db9ba10beea9c021908e310556093527597b3e212eb6dfa542ead84e763c29"
+  octavia_housekeeping: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/octavia:2023.2@sha256:98db9ba10beea9c021908e310556093527597b3e212eb6dfa542ead84e763c29"
+  octavia_worker: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/octavia:2023.2@sha256:98db9ba10beea9c021908e310556093527597b3e212eb6dfa542ead84e763c29"
+  openvswitch_db_server: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/openvswitch:3.1.0-65@sha256:682bac2cce6fbe4a3aecc4f18a129f5102cccac34d6ac914c59b713294e50927"
+  openvswitch_vswitchd: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/openvswitch:3.1.0-65@sha256:682bac2cce6fbe4a3aecc4f18a129f5102cccac34d6ac914c59b713294e50927"
+  ovn_controller: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/ovn-host:23.03.0-69@sha256:aecac533c7ca5b365add031bf3d2c9d88c943c551a4f67f9a5ee1e270e5ab4a9"
+  ovn_northd: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/ovn-central:23.03.0-69@sha256:38fb23c01ae023496dbe4df5e37c81ad84174a97765e373a3cf7d660805f87b7"
+  ovn_ovsdb_nb: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/ovn-central:23.03.0-69@sha256:38fb23c01ae023496dbe4df5e37c81ad84174a97765e373a3cf7d660805f87b7"
+  ovn_ovsdb_sb: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/ovn-central:23.03.0-69@sha256:38fb23c01ae023496dbe4df5e37c81ad84174a97765e373a3cf7d660805f87b7"
+  pause: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/pause:3.8@sha256:f5944f2d1daf66463768a1503d0c8c5e8dde7c1674d3f85abc70cef9c7e32e95"
+  percona_xtradb_cluster_haproxy: "{{ atmosphere_proxy_cache_prefix }}docker.io/percona/percona-xtradb-cluster-operator:1.13.0-haproxy@sha256:f04e4fea548bfc7cb0bfc73c75c7f2c64d299cf04125a07a8101a55f0f734fed"
+  percona_xtradb_cluster_operator: "{{ atmosphere_proxy_cache_prefix }}docker.io/percona/percona-xtradb-cluster-operator:1.13.0@sha256:c674d63242f1af521edfbaffae2ae02fb8d010c0557a67a9c42d2b4a50db5243"
+  percona_xtradb_cluster: "{{ atmosphere_proxy_cache_prefix }}docker.io/percona/percona-xtradb-cluster:8.0.32-24.2@sha256:1f978ab8912e1b5fc66570529cb7e7a4ec6a38adbfce1ece78159b0fcfa7d47a"
+  percona_version_service: "{{ atmosphere_proxy_cache_prefix }}docker.io/perconalab/version-service:main-3325140@sha256:b7928130fca1e35ce7feaeec326fef836229a8b4de2f6f6ea5b6d2c7a48cd071"
+  placement_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/placement:2023.2@sha256:65f07eb0de6f774c092e3610297957615965bd6f03d0ede1dd890c5ec1fcf3ed"
+  placement: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/placement:2023.2@sha256:65f07eb0de6f774c092e3610297957615965bd6f03d0ede1dd890c5ec1fcf3ed"
+  prometheus_config_reloader: "{{ atmosphere_proxy_cache_prefix }}quay.io/prometheus-operator/prometheus-config-reloader:v0.67.1@sha256:0fe3cf36985e0e524801a0393f88fa4b5dd5ffdf0f091ff78ee02f2d281631b5"
+  prometheus_ipmi_exporter: "{{ atmosphere_proxy_cache_prefix }}us-docker.pkg.dev/vexxhost-infra/openstack/ipmi-exporter:1.4.0@sha256:4898da9cc11961a56363e8b3f3437d0f45b46585b20c79e33e97fbe7232e05d2"
+  prometheus_memcached_exporter: "{{ atmosphere_proxy_cache_prefix }}quay.io/prometheus/memcached-exporter:v0.10.0@sha256:fa5a2de1a4744da66fb369bee81232f5ea52208bc643e409a60f66d699ac27b2"
+  prometheus_mysqld_exporter: "{{ atmosphere_proxy_cache_prefix }}quay.io/prometheus/mysqld-exporter:v0.14.0@sha256:eb6fe170738bf9181c51f5bc89f93adb26672ec49ffdcb22f55c24834003b45d"
+  prometheus_node_exporter: "{{ atmosphere_proxy_cache_prefix }}quay.io/prometheus/node-exporter:v1.6.1@sha256:81f94e50ea37a88dfee849d0f4acad25b96b397061f59e5095905f6bc5829637"
+  prometheus_openstack_exporter: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/openstack-exporter/openstack-exporter:1.6.0@sha256:bae162b4ad50c7662b03547f27b072303268218af1fc8d9745001357f912937d"
+  prometheus_operator_kube_webhook_certgen: "{{ atmosphere_proxy_cache_prefix }}registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6@sha256:5e6fdb9b2c74ad2576dd835b389d00d18ccfee21b547d1a79efb881009664099"
+  prometheus_operator: "{{ atmosphere_proxy_cache_prefix }}quay.io/prometheus-operator/prometheus-operator:v0.67.1@sha256:e68bff5dd72a5d1be98ec66ef1383a7d7a338f3ffbef8603d551f70dafc8d978"
+  prometheus_pushgateway: "{{ atmosphere_proxy_cache_prefix }}docker.io/prom/pushgateway:v1.4.2@sha256:f74ff5b7ad0b8fb60c24b77eaeab025d659e46ec15f32430adb976544305c01f"
+  prometheus: "{{ atmosphere_proxy_cache_prefix }}quay.io/prometheus/prometheus:v2.46.0@sha256:d6ead9daf2355b9923479e24d7e93f246253ee6a5eb18a61b0f607219f341a80"
+  rabbit_init: "{{ atmosphere_proxy_cache_prefix }}docker.io/library/rabbitmq:3.10.2-management@sha256:350ab6d773e3af45183466488fe3259df36cd6ade437b4366a59e8052458cc3a"
+  rabbitmq_cluster_operator: "{{ atmosphere_proxy_cache_prefix }}docker.io/rabbitmqoperator/cluster-operator:1.13.1@sha256:84ce21e9e2d6ceb8b93d9daf0b7cc1550b6ed86be5b3acd8b0816eddc1b87dc2"
+  rabbitmq_credential_updater: "{{ atmosphere_proxy_cache_prefix }}docker.io/rabbitmqoperator/default-user-credential-updater:1.0.2@sha256:563908dd8d6b6ce768e463a2d9d7a9b9b4adbcd258fed02c0a8746395cfa3f0d"
+  rabbitmq_server: "{{ atmosphere_proxy_cache_prefix }}docker.io/library/rabbitmq:3.10.2-management@sha256:350ab6d773e3af45183466488fe3259df36cd6ade437b4366a59e8052458cc3a"
+  rabbitmq_topology_operator: "{{ atmosphere_proxy_cache_prefix }}docker.io/rabbitmqoperator/messaging-topology-operator:1.6.0@sha256:5052e8bdb26996c62315f0707c6fb291fd84492e360cca7351e2c3fdf659be43"
+  rook_ceph: "{{ atmosphere_proxy_cache_prefix }}docker.io/rook/ceph:v1.10.10@sha256:9ae0eca578ef6e38492e5f90073050491382d8772914ddb8ffe4fca8d365b850"
+  secretgen_controller: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/carvel-dev/secretgen-controller@sha256:59ec05ce5847bfd70c8e04f08b5195e918c8f6fbb947ffc91b456494a2958fd5"
+  senlin_api: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/senlin:2023.2@sha256:9839d6227a6731abf93d29197f2cfc23fa9e476061d65f97c816be4177cb1577"
+  senlin_conductor: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/senlin:2023.2@sha256:9839d6227a6731abf93d29197f2cfc23fa9e476061d65f97c816be4177cb1577"
+  senlin_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/senlin:2023.2@sha256:9839d6227a6731abf93d29197f2cfc23fa9e476061d65f97c816be4177cb1577"
+  senlin_engine_cleaner: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/senlin:2023.2@sha256:9839d6227a6731abf93d29197f2cfc23fa9e476061d65f97c816be4177cb1577"
+  senlin_engine: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/senlin:2023.2@sha256:9839d6227a6731abf93d29197f2cfc23fa9e476061d65f97c816be4177cb1577"
+  senlin_health_manager: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/senlin:2023.2@sha256:9839d6227a6731abf93d29197f2cfc23fa9e476061d65f97c816be4177cb1577"
+  staffeln_db_sync: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/staffeln:v2.2.3@sha256:fabb1da50ea8df7db05ca26b7ce5685132601ab8b2829599ce0a63a313e4d6fa"
+  staffeln_conductor: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/staffeln:v2.2.3@sha256:fabb1da50ea8df7db05ca26b7ce5685132601ab8b2829599ce0a63a313e4d6fa"
+  staffeln_api: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/staffeln:v2.2.3@sha256:fabb1da50ea8df7db05ca26b7ce5685132601ab8b2829599ce0a63a313e4d6fa"
+  tempest_run_tests: "{{ atmosphere_proxy_cache_prefix }}ghcr.io/vexxhost/atmosphere/tempest:master@sha256:0d5e44c7c536ef2a1af00afd50b755683abc5e8dad13b4f166144e9fc4142f03"
+  vector: "{{ atmosphere_proxy_cache_prefix }}docker.io/timberio/vector:0.27.0-debian@sha256:29f23dab76fa306b67b10eac3e9decdb01c906f8aa3b00a2f5b2e8ae088b84e0"
 
-atmosphere_images: '{{ _atmosphere_images | combine(atmosphere_image_overrides, recursive=True)
-  }}'
+atmosphere_images: '{{ _atmosphere_images | combine(atmosphere_image_overrides, recursive=True) }}'


### PR DESCRIPTION
We have been maintaining in our inventory an override of each and every Atmosphere container image just so it can be proxied (and thus cached) through our image repository (Harbor). With very few exceptions, we do not need or desire to maintain pinned image tags, and would prefer to stay in-line with upstream. As such, I am introducing a `atmosphere_proxy_cache_prefix` variable into the `defaults` role with a default value of `""` that can be used as an override to prefix the image value with the value of the caching repository.