### PR TITLE
fix: update ubuntu package libssl3

### DIFF
--- a/images/base/Earthfile
+++ b/images/base/Earthfile
@@ -1,7 +1,5 @@
 VERSION 0.7
 
 image:
-  FROM ubuntu:jammy-20240125
+  FROM ubuntu:jammy-20240212
   LABEL org.opencontainers.image.source=https://github.com/vexxhost/atmosphere
-  # CVE-2023-5678, CVE-2023-6129, CVE-2023-6237, CVE-2024-0727
-  DO ../+APT_INSTALL --PACKAGES "libssl3=3.0.2-0ubuntu1.15"

--- a/images/base/Earthfile
+++ b/images/base/Earthfile
@@ -4,4 +4,4 @@ image:
   FROM ubuntu:jammy-20240125
   LABEL org.opencontainers.image.source=https://github.com/vexxhost/atmosphere
   # CVE-2023-5678, CVE-2023-6129, CVE-2023-6237, CVE-2024-0727
-  DO ../+APT_INSTALL --PACKAGES "libssl3=3.0.2-0ubuntu1.14"
+  DO ../+APT_INSTALL --PACKAGES "libssl3=3.0.2-0ubuntu1.15"

--- a/images/base/Earthfile
+++ b/images/base/Earthfile
@@ -3,3 +3,5 @@ VERSION 0.7
 image:
   FROM ubuntu:jammy-20240212
   LABEL org.opencontainers.image.source=https://github.com/vexxhost/atmosphere
+  # CVE-2023-4641
+  DO ../+APT_INSTALL --PACKAGES "login=1:4.8.1-2ubuntu2.2 passwd=1:4.8.1-2ubuntu2.2"

--- a/images/openstack-service/Earthfile
+++ b/images/openstack-service/Earthfile
@@ -47,9 +47,9 @@ requirements:
   END
   GIT CLONE --branch ${BRANCH} https://github.com/openstack/requirements /src
   RUN \
-    sed -i 's/cryptography===36.0.2/cryptography===42.0.0/' /src/upper-constraints.txt && \
-    sed -i 's/cryptography===40.0.2/cryptography===42.0.0/' /src/upper-constraints.txt && \
-    sed -i 's/cryptography===41.0.7/cryptography===42.0.0/' /src/upper-constraints.txt && \
+    sed -i 's/cryptography===36.0.2/cryptography===42.0.4/' /src/upper-constraints.txt && \
+    sed -i 's/cryptography===40.0.2/cryptography===42.0.4/' /src/upper-constraints.txt && \
+    sed -i 's/cryptography===41.0.7/cryptography===42.0.4/' /src/upper-constraints.txt && \
     sed -i 's/Django===3.2.18/Django===3.2.24/' /src/upper-constraints.txt && \
     sed -i 's/Flask===2.2.3/Flask===2.2.5/' /src/upper-constraints.txt && \
     sed -i 's/Jinja2===3.1.2/Jinja2===3.1.3/' /src/upper-constraints.txt && \


### PR DESCRIPTION
Building of the images failes with the error `Version '3.0.2-0ubuntu1.14' for 'libssl3' was not found` fixes #993