### PR TITLE
fix(uwsgi): tune settings

### DIFF
--- a/charts/cinder/values.yaml
+++ b/charts/cinder/values.yaml
@@ -1015,15 +1015,20 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
+      chunked-input-limit: 4096000
       die-on-term: true
       enable-threads: true
       exit-on-reload: false
       hook-master-start: unix_signal:15 gracefully_kill_them_all
+      http-auto-chunked: true
+      http-raw-body: true
       lazy-apps: true
       log-x-forwarded-for: true
       master: true
+      need-app: true
       procname-prefix-spaced: "cinder-api:"
       route-user-agent: '^kube-probe.* donotlog:'
+      socket-timeout: 10
       thunder-lock: true
       worker-reload-mercy: 80
       wsgi-file: /var/lib/openstack/bin/cinder-wsgi

--- a/charts/cinder/values.yaml
+++ b/charts/cinder/values.yaml
@@ -1015,7 +1015,7 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
-      chunked-input-limit: 4096000
+      chunked-input-limit: "4096000"
       die-on-term: true
       enable-threads: true
       exit-on-reload: false

--- a/charts/designate/values.yaml
+++ b/charts/designate/values.yaml
@@ -532,7 +532,7 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
-      chunked-input-limit: 4096000
+      chunked-input-limit: "4096000"
       die-on-term: true
       enable-threads: true
       exit-on-reload: false

--- a/charts/designate/values.yaml
+++ b/charts/designate/values.yaml
@@ -532,15 +532,20 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
+      chunked-input-limit: 4096000
       die-on-term: true
       enable-threads: true
       exit-on-reload: false
       hook-master-start: unix_signal:15 gracefully_kill_them_all
+      http-auto-chunked: true
+      http-raw-body: true
       lazy-apps: true
       log-x-forwarded-for: true
       master: true
+      need-app: true
       procname-prefix-spaced: "designate-api:"
       route-user-agent: '^kube-probe.* donotlog:'
+      socket-timeout: 10
       thunder-lock: true
       worker-reload-mercy: 80
       wsgi-file: /var/lib/openstack/bin/designate-api-wsgi

--- a/charts/glance/values.yaml
+++ b/charts/glance/values.yaml
@@ -393,7 +393,7 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
-      chunked-input-limit: 4096000
+      chunked-input-limit: "4096000"
       die-on-term: true
       enable-threads: true
       exit-on-reload: false

--- a/charts/glance/values.yaml
+++ b/charts/glance/values.yaml
@@ -393,15 +393,20 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
+      chunked-input-limit: 4096000
       die-on-term: true
       enable-threads: true
       exit-on-reload: false
       hook-master-start: unix_signal:15 gracefully_kill_them_all
+      http-auto-chunked: true
+      http-raw-body: true
       lazy-apps: true
       log-x-forwarded-for: true
       master: true
+      need-app: true
       procname-prefix-spaced: "glance-api:"
       route-user-agent: '^kube-probe.* donotlog:'
+      socket-timeout: 10
       thunder-lock: true
       worker-reload-mercy: 80
       wsgi-file: /var/lib/openstack/bin/glance-wsgi-api

--- a/charts/heat/values.yaml
+++ b/charts/heat/values.yaml
@@ -494,15 +494,20 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
+      chunked-input-limit: 4096000
       die-on-term: true
       enable-threads: true
       exit-on-reload: false
       hook-master-start: unix_signal:15 gracefully_kill_them_all
+      http-auto-chunked: true
+      http-raw-body: true
       lazy-apps: true
       log-x-forwarded-for: true
       master: true
+      need-app: true
       procname-prefix-spaced: "heat-api:"
       route-user-agent: '^kube-probe.* donotlog:'
+      socket-timeout: 10
       thunder-lock: true
       worker-reload-mercy: 80
       wsgi-file: /var/lib/openstack/bin/heat-wsgi-api
@@ -510,15 +515,20 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
+      chunked-input-limit: 4096000
       die-on-term: true
       enable-threads: true
       exit-on-reload: false
       hook-master-start: unix_signal:15 gracefully_kill_them_all
+      http-auto-chunked: true
+      http-raw-body: true
       lazy-apps: true
       log-x-forwarded-for: true
       master: true
+      need-app: true
       procname-prefix-spaced: "heat-api-cfn:"
       route-user-agent: '^kube-probe.* donotlog:'
+      socket-timeout: 10
       thunder-lock: true
       worker-reload-mercy: 80
       wsgi-file: /var/lib/openstack/bin/heat-wsgi-api-cfn

--- a/charts/heat/values.yaml
+++ b/charts/heat/values.yaml
@@ -494,7 +494,7 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
-      chunked-input-limit: 4096000
+      chunked-input-limit: "4096000"
       die-on-term: true
       enable-threads: true
       exit-on-reload: false

--- a/charts/magnum/values.yaml
+++ b/charts/magnum/values.yaml
@@ -161,15 +161,20 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
+      chunked-input-limit: 4096000
       die-on-term: true
       enable-threads: true
       exit-on-reload: false
       hook-master-start: unix_signal:15 gracefully_kill_them_all
+      http-auto-chunked: true
+      http-raw-body: true
       lazy-apps: true
       log-x-forwarded-for: true
       master: true
+      need-app: true
       procname-prefix-spaced: "magnum-api:"
       route-user-agent: '^kube-probe.* donotlog:'
+      socket-timeout: 10
       thunder-lock: true
       worker-reload-mercy: 80
       wsgi-file: /var/lib/openstack/bin/magnum-api-wsgi

--- a/charts/magnum/values.yaml
+++ b/charts/magnum/values.yaml
@@ -161,7 +161,7 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
-      chunked-input-limit: 4096000
+      chunked-input-limit: "4096000"
       die-on-term: true
       enable-threads: true
       exit-on-reload: false

--- a/charts/manila/values.yaml
+++ b/charts/manila/values.yaml
@@ -806,7 +806,7 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
-      chunked-input-limit: 4096000
+      chunked-input-limit: "4096000"
       die-on-term: true
       enable-threads: true
       exit-on-reload: false

--- a/charts/manila/values.yaml
+++ b/charts/manila/values.yaml
@@ -806,15 +806,20 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
+      chunked-input-limit: 4096000
       die-on-term: true
       enable-threads: true
       exit-on-reload: false
       hook-master-start: unix_signal:15 gracefully_kill_them_all
+      http-auto-chunked: true
+      http-raw-body: true
       lazy-apps: true
       log-x-forwarded-for: true
       master: true
+      need-app: true
       procname-prefix-spaced: "manila-api:"
       route-user-agent: '^kube-probe.* donotlog:'
+      socket-timeout: 10
       thunder-lock: true
       worker-reload-mercy: 80
       wsgi-file: /var/lib/openstack/bin/manila-wsgi

--- a/charts/nova/values.yaml
+++ b/charts/nova/values.yaml
@@ -1539,7 +1539,7 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
-      chunked-input-limit: 4096000
+      chunked-input-limit: "4096000"
       die-on-term: true
       enable-threads: true
       exit-on-reload: false

--- a/charts/nova/values.yaml
+++ b/charts/nova/values.yaml
@@ -1539,15 +1539,20 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
+      chunked-input-limit: 4096000
       die-on-term: true
       enable-threads: true
       exit-on-reload: false
       hook-master-start: unix_signal:15 gracefully_kill_them_all
+      http-auto-chunked: true
+      http-raw-body: true
       lazy-apps: true
       log-x-forwarded-for: true
       master: true
+      need-app: true
       procname-prefix-spaced: "nova-api:"
       route-user-agent: '^kube-probe.* donotlog:'
+      socket-timeout: 10
       thunder-lock: true
       worker-reload-mercy: 80
       wsgi-file: /var/lib/openstack/bin/nova-api-wsgi
@@ -1555,15 +1560,20 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
+      chunked-input-limit: 4096000
       die-on-term: true
       enable-threads: true
       exit-on-reload: false
       hook-master-start: unix_signal:15 gracefully_kill_them_all
+      http-auto-chunked: true
+      http-raw-body: true
       lazy-apps: true
       log-x-forwarded-for: true
       master: true
+      need-app: true
       procname-prefix-spaced: "nova-metadata:"
       route-user-agent: '^kube-probe.* donotlog:'
+      socket-timeout: 10
       thunder-lock: true
       worker-reload-mercy: 80
       wsgi-file: /var/lib/openstack/bin/nova-metadata-wsgi

--- a/charts/octavia/values.yaml
+++ b/charts/octavia/values.yaml
@@ -336,7 +336,7 @@ conf:
       processes: 4
       add-header: "Connection: close"
       buffer-size: 65535
-      chunked-input-limit: 4096000
+      chunked-input-limit: "4096000"
       die-on-term: true
       enable-threads: true
       exit-on-reload: false

--- a/charts/octavia/values.yaml
+++ b/charts/octavia/values.yaml
@@ -336,15 +336,20 @@ conf:
       processes: 4
       add-header: "Connection: close"
       buffer-size: 65535
+      chunked-input-limit: 4096000
       die-on-term: true
       enable-threads: true
       exit-on-reload: false
       hook-master-start: unix_signal:15 gracefully_kill_them_all
+      http-auto-chunked: true
+      http-raw-body: true
       lazy-apps: true
       log-x-forwarded-for: true
       master: true
+      need-app: true
       procname-prefix-spaced: "octavia-api:"
       route-user-agent: '^kube-probe.* donotlog:'
+      socket-timeout: 10
       thunder-lock: true
       worker-reload-mercy: 80
       wsgi-file: /var/lib/openstack/bin/octavia-wsgi

--- a/charts/placement/values.yaml
+++ b/charts/placement/values.yaml
@@ -141,7 +141,7 @@ conf:
       processes: 4
       add-header: "Connection: close"
       buffer-size: 65535
-      chunked-input-limit: 4096000
+      chunked-input-limit: "4096000"
       die-on-term: true
       enable-threads: true
       exit-on-reload: false

--- a/charts/placement/values.yaml
+++ b/charts/placement/values.yaml
@@ -141,15 +141,20 @@ conf:
       processes: 4
       add-header: "Connection: close"
       buffer-size: 65535
+      chunked-input-limit: 4096000
       die-on-term: true
       enable-threads: true
       exit-on-reload: false
       hook-master-start: unix_signal:15 gracefully_kill_them_all
+      http-auto-chunked: true
+      http-raw-body: true
       lazy-apps: true
       log-x-forwarded-for: true
       master: true
+      need-app: true
       procname-prefix-spaced: "placement-api:"
       route-user-agent: '^kube-probe.* donotlog:'
+      socket-timeout: 10
       thunder-lock: true
       worker-reload-mercy: 80
       wsgi-file: /var/lib/openstack/bin/placement-api

--- a/charts/senlin/values.yaml
+++ b/charts/senlin/values.yaml
@@ -208,15 +208,20 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
+      chunked-input-limit: 4096000
       die-on-term: true
       enable-threads: true
       exit-on-reload: false
       hook-master-start: unix_signal:15 gracefully_kill_them_all
+      http-auto-chunked: true
+      http-raw-body: true
       lazy-apps: true
       log-x-forwarded-for: true
       master: true
+      need-app: true
       procname-prefix-spaced: "senlin-api:"
       route-user-agent: '^kube-probe.* donotlog:'
+      socket-timeout: 10
       thunder-lock: true
       worker-reload-mercy: 80
       wsgi-file: /var/lib/openstack/bin/senlin-wsgi-api

--- a/charts/senlin/values.yaml
+++ b/charts/senlin/values.yaml
@@ -208,7 +208,7 @@ conf:
     uwsgi:
       add-header: "Connection: close"
       buffer-size: 65535
-      chunked-input-limit: 4096000
+      chunked-input-limit: "4096000"
       die-on-term: true
       enable-threads: true
       exit-on-reload: false


### PR DESCRIPTION
The current uWSGI settings that we ship are missing a few important
ones, specifically `http-raw-body` which is used by Glance in order
to enable chunked uploads.

This is the reason why a direct upload to Glance works just fine
because it goes through the ingress (which does the chunking for
us), however, it fails when creating an image from volume due to
the fact that Cinder talks directly to Glance without the ingress
being in the path.

Closes: #1046

Signed-off-by: Mohammed Naser <mnaser@vexxhost.com>
