### PR TITLE
fix(defaults): Update sandbox image to pause:3.9

### DIFF
--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -160,7 +160,7 @@ _atmosphere_images:
   ovn_northd: ghcr.io/vexxhost/atmosphere/ovn-central:23.03.0-69@sha256:171a020d3db924c25c3521844a309d5007316d07cd155111670ee291d6ffe39d
   ovn_ovsdb_nb: ghcr.io/vexxhost/atmosphere/ovn-central:23.03.0-69@sha256:171a020d3db924c25c3521844a309d5007316d07cd155111670ee291d6ffe39d
   ovn_ovsdb_sb: ghcr.io/vexxhost/atmosphere/ovn-central:23.03.0-69@sha256:171a020d3db924c25c3521844a309d5007316d07cd155111670ee291d6ffe39d
-  pause: registry.k8s.io/pause:3.8@sha256:f5944f2d1daf66463768a1503d0c8c5e8dde7c1674d3f85abc70cef9c7e32e95
+  pause: registry.k8s.io/pause:3.9@sha256:7031c1b283388d2c2e09b57badb803c05ebed362dc88d84b480cc47f72a21097
   percona_xtradb_cluster_haproxy: docker.io/percona/percona-xtradb-cluster-operator:1.13.0-haproxy@sha256:f04e4fea548bfc7cb0bfc73c75c7f2c64d299cf04125a07a8101a55f0f734fed
   percona_xtradb_cluster_operator: docker.io/percona/percona-xtradb-cluster-operator:1.13.0@sha256:c674d63242f1af521edfbaffae2ae02fb8d010c0557a67a9c42d2b4a50db5243
   percona_xtradb_cluster: docker.io/percona/percona-xtradb-cluster:8.0.32-24.2@sha256:1f978ab8912e1b5fc66570529cb7e7a4ec6a38adbfce1ece78159b0fcfa7d47a


### PR DESCRIPTION
Fix for:

```
W0403 00:49:34.034468   70448 checks.go:835] detected that the sandbox image "registry.k8s.io/pause:3.8@sha256:f5944f2d1daf66463768a1503d0c8c5e8dde7c1674d3f85abc70cef9c7e32e95" of the container runtime is inconsistent with that used by kubeadm. It is recommended that using "registry.k8s.io/pause:3.9" as the CRI sandbox image.
error execution phase wait-control-plane: couldn't initialize a Kubernetes cluster
To see the stack trace of this error execute with --v=5 or higher
```