### PR TITLE
ci: disable debug for logs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 
 [testenv:molecule-aio-{openvswitch,ovn}]
 setenv =
-  ATMOSPHERE_DEBUG = true
+  ATMOSPHERE_DEBUG = false
   openvswitch: ATMOSPHERE_NETWORK_BACKEND = openvswitch
   ovn: ATMOSPHERE_NETWORK_BACKEND = ovn
 commands =


### PR DESCRIPTION
The debug logs generate a tremendous amount of data which makes
errors cycle out when we collect logs.  Until we solve that, let
us go back to non-DEBUG logs to get more details.

Signed-off-by: Mohammed Naser <mnaser@vexxhost.com>
