### PR TITLE
fix(glance_image): introduce retries

### DIFF
--- a/roles/glance_image/tasks/main.yml
+++ b/roles/glance_image/tasks/main.yml
@@ -39,6 +39,9 @@
         dest: "{{ _workdir.path }}/{{ glance_image_url | basename }}"
         mode: "0600"
       register: _get_url
+      retries: 3
+      delay: "{{ 15 | random + 3 }}"
+      until: _get_url is not failed
 
     - name: Get image format
       changed_when: false


### PR DESCRIPTION
The internet is not reliable.  We instead introduce 3 retries for
downloading images, with a random delay of at least 3 seconds to
make sure we can retry safely.

Depends-On: https://github.com/vexxhost/atmosphere/pull/1063
Signed-off-by: Mohammed Naser <mnaser@vexxhost.com>
