### PR TITLE
ci: stop signing images all the time

### DIFF
--- a/zuul.d/playbooks/buildset-registry/run.yml
+++ b/zuul.d/playbooks/buildset-registry/run.yml
@@ -103,6 +103,18 @@
             dest: /usr/local/bin/cosign
             mode: 0755
 
+        - name: Copy the cosign public key
+          copy:
+            content: "{{ cosign_key.public }}"
+            dest: cosign.pub
+
+        - name: Verify which images are signed
+          ignore_errors: true
+          ansible.builtin.shell: |
+            cosign verify --key cosign.pub --output json {{ item }}
+          loop: "{{ images_built }}"
+          register: cosign_verify
+
         - name: Copy the cosign private key
           copy:
             content: "{{ cosign_key.private }}"
@@ -111,7 +123,7 @@
         - name: Sign images
           ansible.builtin.shell: |
             cosign sign -y --recursive --key cosign.key {{ item }}
-          loop: "{{ images_built }}"
+          loop: "{{ cosign_verify.results | selectattr('failed', 'equalto', true) | map(attribute='item') | list }}"
 
         - name: Delete the cosign private key
           file:


### PR DESCRIPTION
It seems cosign will always sign an image even if it's already
signed which means we keep getting a new `sha256` everytime we
upload new images.

By changing this behaviour, we only sign the images that are not
signed and avoid changing the SHAs for the images.
