### PR TITLE
fix(ipmi-exporter): Ignore additional sensor IDs (BP/Entity Presence)

### DIFF
--- a/roles/ipmi_exporter/defaults/main.yml
+++ b/roles/ipmi_exporter/defaults/main.yml
@@ -27,7 +27,11 @@ ipmi_exporter_config:
         - 51 # BP2 Presence (Dell PowerEdge servers)
         - 52
         - 54
+        - 57 # Entity Presence (Dell PowerEdge servers)
+        - 59 # Entity Presence (Dell PowerEdge servers)
         - 82
+        - 89 # BP Presence (Dell PowerEdge servers)
+        - 90 # BP Presence (Dell PowerEdge servers)
         - 164
         - 168
         - 178 # TPM Presence (Dell PowerEdge servers)


### PR DESCRIPTION
These sensors are returning false positives on R630/R730xd servers.