### PR TITLE
[stable/zed] fix image job dependencies

### DIFF
--- a/zuul.d/container-images/libvirt-tls-sidecar.yaml
+++ b/zuul.d/container-images/libvirt-tls-sidecar.yaml
@@ -26,6 +26,9 @@
 - job:
     name: atmosphere-build-container-image-libvirt-tls-sidecar
     parent: atmosphere-build-container-image
+    dependencies:
+      - name: atmosphere-build-container-image-ubuntu
+        soft: true
     vars: &container_image_vars
       promote_container_image_job: atmosphere-upload-container-image-libvirt-tls-sidecar
       container_images:
@@ -38,15 +41,19 @@
           tags:
             - zed
     files: &container_image_files
-      - go.mod
-      - go.sum
+      - images/ubuntu/.*
       - cmd/.*
       - internal/.*
       - Dockerfile
+      - go.mod
+      - go.sum
 
 - job:
     name: atmosphere-upload-container-image-libvirt-tls-sidecar
     parent: atmosphere-upload-container-image
+    dependencies:
+      - name: atmosphere-upload-container-image-ubuntu
+        soft: true
     vars: *container_image_vars
     files: *container_image_files
 

--- a/zuul.d/container-images/netoffload.yaml
+++ b/zuul.d/container-images/netoffload.yaml
@@ -26,6 +26,9 @@
 - job:
     name: atmosphere-build-container-image-netoffload
     parent: atmosphere-build-container-image
+    dependencies:
+      - name: atmosphere-build-container-image-ubuntu
+        soft: true
     vars: &container_image_vars
       promote_container_image_job: atmosphere-upload-container-image-netoffload
       container_images:
@@ -37,11 +40,15 @@
           tags:
             - zed
     files: &container_image_files
+      - images/ubuntu/.*
       - images/netoffload/.*
 
 - job:
     name: atmosphere-upload-container-image-netoffload
     parent: atmosphere-upload-container-image
+    dependencies:
+      - name: atmosphere-upload-container-image-ubuntu
+        soft: true
     vars: *container_image_vars
     files: *container_image_files
 


### PR DESCRIPTION
- **build: build all images + run tests using them (#1069)**
- **ci: fix promotion jobs (#1072)**
- **[stable/zed] Drop `conventional-commit` requirement (#1082)**
- **[stable/zed] fix(ipmi-exporter): Ignore additional sensor IDs (BP/Entity Presence) (#1077)**
- **[stable/zed] Implement collection release process (#1085)**
- **Release 1.11.0 (#1088)**
- **Fix dependency for certain images**
