### PR TITLE
Refactor image tags to be dynamic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+ARG RELEASE
+
 FROM golang:1.21 AS go-builder
 COPY go.mod go.sum /src/
 WORKDIR /src
@@ -22,6 +24,6 @@ COPY cmd/ /src/cmd/
 COPY internal/ /src/internal/
 RUN go build -o main ./cmd/libvirt-tls-sidecar/main.go
 
-FROM registry.atmosphere.dev/library/ubuntu:main AS libvirt-tls-sidecar
+FROM registry.atmosphere.dev/library/ubuntu:${RELEASE} AS libvirt-tls-sidecar
 COPY --from=libvirt-tls-sidecar-builder /src/main /usr/bin/libvirt-tls-sidecar
 ENTRYPOINT ["/usr/bin/libvirt-tls-sidecar"]

--- a/build/pin-images.py
+++ b/build/pin-images.py
@@ -129,12 +129,6 @@ def main():
     parser.add_argument(
         "dst", help="Path for output file", type=argparse.FileType("r+")
     )
-    parser.add_argument(
-        "-r",
-        "--registry",
-        default="ghcr.io/vexxhost/atmosphere",
-        help="Registry containing Atmosphere images",
-    )
 
     args = parser.parse_args()
 
@@ -145,15 +139,8 @@ def main():
         if image in SKIP_IMAGE_LIST:
             continue
 
-        # NOTE(mnaser): If we're in CI, only pin the Atmosphere images
-        if (
-            "registry.atmosphere.dev" in args.registry
-            and "ghcr.io/vexxhost/atmosphere" not in data["_atmosphere_images"][image]
-        ):
-            continue
-
         image_src = data["_atmosphere_images"][image].replace(
-            "ghcr.io/vexxhost/atmosphere", args.registry
+            "{{ atmosphere_release }}", data["atmosphere_release"]
         )
         pinned_image = get_pinned_image(image_src)
 

--- a/images/barbican/Dockerfile
+++ b/images/barbican/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG BARBICAN_GIT_REF=ca57ef5436e20e90cf6cd6853efe3c89a9afd986
 ADD --keep-git-dir=true https://opendev.org/openstack/barbican.git#${BARBICAN_GIT_REF} /src/barbican
 RUN git -C /src/barbican fetch --unshallow
@@ -23,5 +25,5 @@ pip3 install \
         pykmip
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 COPY --from=build --link /var/lib/openstack /var/lib/openstack

--- a/images/cinder/Dockerfile
+++ b/images/cinder/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG CINDER_GIT_REF=b0f0b9015b9dfa228dff98eeee5116d8eca1c3cc
 ADD --keep-git-dir=true https://opendev.org/openstack/cinder.git#${CINDER_GIT_REF} /src/cinder
 RUN git -C /src/cinder fetch --unshallow
@@ -25,7 +27,7 @@ pip3 install \
         purestorage
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/designate/Dockerfile
+++ b/images/designate/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG DESIGNATE_GIT_REF=097ffc6df181290eba1bcd7c492b1b505bc15434
 ADD --keep-git-dir=true https://opendev.org/openstack/designate.git#${DESIGNATE_GIT_REF} /src/designate
 RUN git -C /src/designate fetch --unshallow
@@ -24,7 +26,7 @@ pip3 install \
         /src/designate
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/glance/Dockerfile
+++ b/images/glance/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG GLANCE_GIT_REF=0bcd6cd71c09917c6734421374fd598d73e8d0cc
 ADD --keep-git-dir=true https://opendev.org/openstack/glance.git#${GLANCE_GIT_REF} /src/glance
 RUN git -C /src/glance fetch --unshallow
@@ -25,7 +27,7 @@ pip3 install \
         /src/glance_store[cinder]
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/heat/Dockerfile
+++ b/images/heat/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG HEAT_GIT_REF=80eea85194825773d1b60ecc4386b2d5ba52a066
 ADD --keep-git-dir=true https://opendev.org/openstack/heat.git#${HEAT_GIT_REF} /src/heat
 RUN git -C /src/heat fetch --unshallow
@@ -22,7 +24,7 @@ pip3 install \
         /src/heat
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/horizon/Dockerfile
+++ b/images/horizon/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG HORIZON_GIT_REF=3f1f1d46e6e47a3dbe46fb023fe69ff25d6a601b
 ADD --keep-git-dir=true https://opendev.org/openstack/horizon.git#${HORIZON_GIT_REF} /src/horizon
 RUN git -C /src/horizon fetch --unshallow
@@ -49,7 +51,7 @@ pip3 install \
         pymemcache
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/ironic/Dockerfile
+++ b/images/ironic/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG IRONIC_GIT_REF=22aa29b864eecd00bfb7c67cc2075030da1eb1d0
 ADD --keep-git-dir=true https://opendev.org/openstack/ironic.git#${IRONIC_GIT_REF} /src/ironic
 RUN git -C /src/ironic fetch --unshallow
@@ -24,7 +26,7 @@ pip3 install \
         sushy
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/keepalived/Dockerfile
+++ b/images/keepalived/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/ubuntu:main
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/ubuntu:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/keystone/Dockerfile
+++ b/images/keystone/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG KEYSTONE_GIT_REF=8ca73f758bb613a57815fbe4ae78e3d2afa4af49
 ADD --keep-git-dir=true https://opendev.org/openstack/keystone.git#${KEYSTONE_GIT_REF} /src/keystone
 RUN git -C /src/keystone fetch --unshallow
@@ -23,7 +25,7 @@ pip3 install \
         keystone-keycloak-backend==0.1.8
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/libvirtd/Dockerfile
+++ b/images/libvirtd/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-runtime:main
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-runtime:${RELEASE}
 ADD --chmod=644 https://download.ceph.com/keys/release.gpg /etc/apt/trusted.gpg.d/ceph.gpg
 COPY <<EOF /etc/apt/sources.list.d/ceph.list
 deb http://download.ceph.com/debian-reef/ jammy main

--- a/images/magnum/Dockerfile
+++ b/images/magnum/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/ubuntu:main AS helm
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/ubuntu:${RELEASE} AS helm
 ARG TARGETOS
 ARG TARGETARCH
 ARG HELM_VERSION=3.14.0
@@ -20,7 +22,7 @@ ADD https://get.helm.sh/helm-v${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz /
 RUN tar -xzf /helm.tar.gz
 RUN mv /${TARGETOS}-${TARGETARCH}/helm /usr/bin/helm
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG MAGNUM_GIT_REF=c613ea4e419edc0086116da07e93cf19206746e1
 ADD --keep-git-dir=true https://opendev.org/openstack/magnum.git#${MAGNUM_GIT_REF} /src/magnum
 RUN git -C /src/magnum fetch --unshallow
@@ -31,7 +33,7 @@ pip3 install \
         magnum-cluster-api==0.16.0
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/manila/Dockerfile
+++ b/images/manila/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG MANILA_GIT_REF=d8987589ae88ae9b2769fbe6f26d5b6994098038
 ADD --keep-git-dir=true https://opendev.org/openstack/manila.git#${MANILA_GIT_REF} /src/manila
 RUN git -C /src/manila fetch --unshallow
@@ -22,7 +24,7 @@ pip3 install \
         /src/manila
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/netoffload/Dockerfile
+++ b/images/netoffload/Dockerfile
@@ -12,13 +12,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+ARG RELEASE
+
 FROM golang:1.20 AS build
 ARG NETOFFLOAD_GIT_REF=94b8c0fdb0b83bd1b7e14b9a58077a047c78a800
 ADD https://github.com/vexxhost/netoffload.git#${NETOFFLOAD_GIT_REF} /src
 WORKDIR /src
 RUN go build -v -o offloadctl ./cmd/offloadctl/main.go
 
-FROM registry.atmosphere.dev/library/ubuntu:main
+FROM registry.atmosphere.dev/library/ubuntu:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/neutron/Dockerfile
+++ b/images/neutron/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG NEUTRON_GIT_REF=019294c71d94b788c14b23dc1da3c21f51bcdb0b
 ADD --keep-git-dir=true https://opendev.org/openstack/neutron.git#${NEUTRON_GIT_REF} /src/neutron
 RUN git -C /src/neutron fetch --unshallow
@@ -25,7 +27,7 @@ pip3 install \
         /src/neutron-vpnaas
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/nova-ssh/Dockerfile
+++ b/images/nova-ssh/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-runtime:main
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/nova/Dockerfile
+++ b/images/nova/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG NOVA_GIT_REF=c199becf52267ba37c5191f6f82e29bb5232b607
 ADD --keep-git-dir=true https://opendev.org/openstack/nova.git#${NOVA_GIT_REF} /src/nova
 RUN git -C /src/nova fetch --unshallow
@@ -22,7 +24,7 @@ pip3 install \
         /src/nova
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 ADD https://github.com/novnc/noVNC.git#v1.4.0 /usr/share/novnc
 RUN <<EOF bash -xe
 apt-get update -qq

--- a/images/octavia/Dockerfile
+++ b/images/octavia/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG OCTAVIA_GIT_REF=824b51a1dad80292b7a8ad5d61bf3ce706b1fb29
 ADD --keep-git-dir=true https://opendev.org/openstack/octavia.git#${OCTAVIA_GIT_REF} /src/octavia
 RUN git -C /src/octavia fetch --unshallow
@@ -25,7 +27,7 @@ pip3 install \
         /src/ovn-octavia-provider
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/openstack-runtime/Dockerfile
+++ b/images/openstack-runtime/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-ARG FROM=registry.atmosphere.dev/library/ubuntu-cloud-archive:main
+ARG RELEASE
+
+ARG FROM=registry.atmosphere.dev/library/ubuntu-cloud-archive:${RELEASE}
 FROM ${FROM}
 ONBUILD ARG PROJECT
 ONBUILD ARG SHELL=/usr/sbin/nologin

--- a/images/openstack-venv-builder/Dockerfile
+++ b/images/openstack-venv-builder/Dockerfile
@@ -12,14 +12,16 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/ubuntu-cloud-archive:main AS requirements
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/ubuntu-cloud-archive:${RELEASE} AS requirements
 ADD https://releases.openstack.org/constraints/upper/master /upper-constraints.txt
 RUN <<EOF sh -xe
 sed -i '/glance-store/d' /upper-constraints.txt
 sed -i '/horizon/d' /upper-constraints.txt
 EOF
 
-FROM registry.atmosphere.dev/library/python-base:main
+FROM registry.atmosphere.dev/library/python-base:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/ovn/Dockerfile
+++ b/images/ovn/Dockerfile
@@ -12,6 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+ARG RELEASE
+
 FROM golang:1.20 AS ovn-kubernetes
 ARG OVN_KUBERNETES_REF=5359e7d7f872058b6e5bf884c9f19d1922451f29
 ADD https://github.com/ovn-org/ovn-kubernetes.git#${OVN_KUBERNETES_REF} /src
@@ -22,7 +24,7 @@ cd /src/go-controller
 go build -o /usr/bin/ovn-kube-util ./cmd/ovn-kube-util
 EOF
 
-FROM registry.atmosphere.dev/library/openvswitch:main
+FROM registry.atmosphere.dev/library/openvswitch:${RELEASE}
 ADD --chmod=755 https://dl.k8s.io/release/v1.29.3/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 ARG OVN_SERIES=23.03
 ARG OVN_VERSION=${OVN_SERIES}.0-69

--- a/images/placement/Dockerfile
+++ b/images/placement/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG PLACEMENT_GIT_REF=96a9aeb3b4a6ffff5bbf247b213409395239fc7a
 ADD --keep-git-dir=true https://opendev.org/openstack/placement.git#${PLACEMENT_GIT_REF} /src/placement
 RUN git -C /src/placement fetch --unshallow
@@ -22,5 +24,5 @@ pip3 install \
         /src/placement
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 COPY --from=build --link /var/lib/openstack /var/lib/openstack

--- a/images/python-base/Dockerfile
+++ b/images/python-base/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/ubuntu-cloud-archive:main
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/ubuntu-cloud-archive:${RELEASE}
 ENV PATH=/var/lib/openstack/bin:$PATH
 RUN \
     apt-get update -qq && \

--- a/images/senlin/Dockerfile
+++ b/images/senlin/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG SENLIN_GIT_REF=ec5fae997686c64c3c1192b231b2434e6a6aeb1c
 ADD --keep-git-dir=true https://opendev.org/openstack/senlin.git#${SENLIN_GIT_REF} /src/senlin
 RUN git -C /src/senlin fetch --unshallow
@@ -22,5 +24,5 @@ pip3 install \
         /src/senlin
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 COPY --from=build --link /var/lib/openstack /var/lib/openstack

--- a/images/staffeln/Dockerfile
+++ b/images/staffeln/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG STAFFELN_GIT_REF=v2.2.3
 ADD --keep-git-dir=true https://github.com/vexxhost/staffeln.git#${STAFFELN_GIT_REF} /src/staffeln
 RUN git -C /src/staffeln fetch --unshallow
@@ -22,5 +24,5 @@ pip3 install \
         /src/staffeln
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 COPY --from=build --link /var/lib/openstack /var/lib/openstack

--- a/images/tempest/Dockerfile
+++ b/images/tempest/Dockerfile
@@ -12,6 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+ARG RELEASE
+
 FROM golang:1.18 AS octavia-test-server
 ADD --keep-git-dir=true https://opendev.org/openstack/octavia-tempest-plugin.git#master /src
 RUN GO111MODULE=off CGO_ENABLED=0 GOOS=linux go build \
@@ -19,7 +21,7 @@ RUN GO111MODULE=off CGO_ENABLED=0 GOOS=linux go build \
     -o /build/test_server.bin \
     /src/octavia_tempest_plugin/contrib/test_server/test_server.go
 
-FROM registry.atmosphere.dev/library/openstack-venv-builder:main AS build
+FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG TEMPEST_GIT_REF=c0da6e843a74c2392c8e87e8ff36d2fea12949c4
 ADD --keep-git-dir=true https://opendev.org/openstack/tempest.git#${TEMPEST_GIT_REF} /src/tempest
 RUN git -C /src/tempest fetch --unshallow
@@ -48,7 +50,7 @@ pip3 install \
         /src/octavia-tempest-plugin
 EOF
 
-FROM registry.atmosphere.dev/library/openstack-python-runtime:main
+FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \

--- a/images/ubuntu-cloud-archive/Dockerfile
+++ b/images/ubuntu-cloud-archive/Dockerfile
@@ -12,7 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM registry.atmosphere.dev/library/ubuntu:main
+ARG RELEASE
+
+FROM registry.atmosphere.dev/library/ubuntu:${RELEASE}
 COPY trusted.gpg.d/ubuntu-cloud-keyring.gpg /etc/apt/trusted.gpg.d/ubuntu-cloud-keyring.gpg
 COPY <<EOF /etc/apt/sources.list.d/cloudarchive.list
 deb http://ubuntu-cloud.archive.canonical.com/ubuntu jammy-updates/caracal main

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -12,12 +12,14 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+atmosphere_release: main
+
 _atmosphere_images:
   alertmanager: quay.io/prometheus/alertmanager:v0.27.0
-  barbican_api: registry.atmosphere.dev/library/barbican:main
-  barbican_db_sync: registry.atmosphere.dev/library/barbican:main
-  bootstrap: registry.atmosphere.dev/library/heat:main
-  ceph_config_helper: registry.atmosphere.dev/library/libvirtd:main
+  barbican_api: "registry.atmosphere.dev/library/barbican:{{ atmosphere_release }}"
+  barbican_db_sync: "registry.atmosphere.dev/library/barbican:{{ atmosphere_release }}"
+  bootstrap: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  ceph_config_helper: "registry.atmosphere.dev/library/libvirtd:{{ atmosphere_release }}"
   ceph: quay.io/ceph/ceph:v16.2.11
   cert_manager_cainjector: quay.io/jetstack/cert-manager-cainjector:v1.7.1
   cert_manager_cli: quay.io/jetstack/cert-manager-ctl:v1.7.1
@@ -25,14 +27,14 @@ _atmosphere_images:
   cert_manager_webhook: quay.io/jetstack/cert-manager-webhook:v1.7.1
   cilium_node: quay.io/cilium/cilium:v1.14.8
   cilium_operator: quay.io/cilium/operator-generic:v1.14.8
-  cinder_api: registry.atmosphere.dev/library/cinder:main
-  cinder_backup_storage_init: registry.atmosphere.dev/library/cinder:main
-  cinder_backup: registry.atmosphere.dev/library/cinder:main
-  cinder_db_sync: registry.atmosphere.dev/library/cinder:main
-  cinder_scheduler: registry.atmosphere.dev/library/cinder:main
-  cinder_storage_init: registry.atmosphere.dev/library/cinder:main
-  cinder_volume_usage_audit: registry.atmosphere.dev/library/cinder:main
-  cinder_volume: registry.atmosphere.dev/library/cinder:main
+  cinder_api: "registry.atmosphere.dev/library/cinder:{{ atmosphere_release }}"
+  cinder_backup_storage_init: "registry.atmosphere.dev/library/cinder:{{ atmosphere_release }}"
+  cinder_backup: "registry.atmosphere.dev/library/cinder:{{ atmosphere_release }}"
+  cinder_db_sync: "registry.atmosphere.dev/library/cinder:{{ atmosphere_release }}"
+  cinder_scheduler: "registry.atmosphere.dev/library/cinder:{{ atmosphere_release }}"
+  cinder_storage_init: "registry.atmosphere.dev/library/cinder:{{ atmosphere_release }}"
+  cinder_volume_usage_audit: "registry.atmosphere.dev/library/cinder:{{ atmosphere_release }}"
+  cinder_volume: "registry.atmosphere.dev/library/cinder:{{ atmosphere_release }}"
   cluster_api_controller: registry.k8s.io/cluster-api/cluster-api-controller:v1.6.0
   cluster_api_kubeadm_bootstrap_controller: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.6.0
   cluster_api_kubeadm_control_plane_controller: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.6.0
@@ -43,49 +45,49 @@ _atmosphere_images:
   csi_rbd_provisioner: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
   csi_rbd_resizer: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
   csi_rbd_snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v4.2.0
-  db_drop: registry.atmosphere.dev/library/heat:main
-  db_init: registry.atmosphere.dev/library/heat:main
-  dep_check: registry.atmosphere.dev/library/kubernetes-entrypoint:main
-  designate_api: registry.atmosphere.dev/library/designate:main
-  designate_central: registry.atmosphere.dev/library/designate:main
-  designate_db_sync: registry.atmosphere.dev/library/designate:main
-  designate_mdns: registry.atmosphere.dev/library/designate:main
-  designate_producer: registry.atmosphere.dev/library/designate:main
-  designate_sink: registry.atmosphere.dev/library/designate:main
-  designate_worker: registry.atmosphere.dev/library/designate:main
-  glance_api: registry.atmosphere.dev/library/glance:main
-  glance_db_sync: registry.atmosphere.dev/library/glance:main
-  glance_metadefs_load: registry.atmosphere.dev/library/glance:main
-  glance_registry: registry.atmosphere.dev/library/glance:main
-  glance_storage_init: registry.atmosphere.dev/library/glance:main
+  db_drop: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  db_init: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  dep_check: "registry.atmosphere.dev/library/kubernetes-entrypoint:{{ atmosphere_release }}"
+  designate_api: "registry.atmosphere.dev/library/designate:{{ atmosphere_release }}"
+  designate_central: "registry.atmosphere.dev/library/designate:{{ atmosphere_release }}"
+  designate_db_sync: "registry.atmosphere.dev/library/designate:{{ atmosphere_release }}"
+  designate_mdns: "registry.atmosphere.dev/library/designate:{{ atmosphere_release }}"
+  designate_producer: "registry.atmosphere.dev/library/designate:{{ atmosphere_release }}"
+  designate_sink: "registry.atmosphere.dev/library/designate:{{ atmosphere_release }}"
+  designate_worker: "registry.atmosphere.dev/library/designate:{{ atmosphere_release }}"
+  glance_api: "registry.atmosphere.dev/library/glance:{{ atmosphere_release }}"
+  glance_db_sync: "registry.atmosphere.dev/library/glance:{{ atmosphere_release }}"
+  glance_metadefs_load: "registry.atmosphere.dev/library/glance:{{ atmosphere_release }}"
+  glance_registry: "registry.atmosphere.dev/library/glance:{{ atmosphere_release }}"
+  glance_storage_init: "registry.atmosphere.dev/library/glance:{{ atmosphere_release }}"
   grafana_sidecar: quay.io/kiwigrid/k8s-sidecar:1.26.1
   grafana: docker.io/grafana/grafana:10.4.0
   haproxy: docker.io/library/haproxy:2.5
-  heat_api: registry.atmosphere.dev/library/heat:main
-  heat_cfn: registry.atmosphere.dev/library/heat:main
-  heat_cloudwatch: registry.atmosphere.dev/library/heat:main
-  heat_db_sync: registry.atmosphere.dev/library/heat:main
-  heat_engine_cleaner: registry.atmosphere.dev/library/heat:main
-  heat_engine: registry.atmosphere.dev/library/heat:main
-  heat_purge_deleted: registry.atmosphere.dev/library/heat:main
-  horizon_db_sync: registry.atmosphere.dev/library/horizon:main
-  horizon: registry.atmosphere.dev/library/horizon:main
+  heat_api: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  heat_cfn: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  heat_cloudwatch: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  heat_db_sync: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  heat_engine_cleaner: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  heat_engine: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  heat_purge_deleted: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  horizon_db_sync: "registry.atmosphere.dev/library/horizon:{{ atmosphere_release }}"
+  horizon: "registry.atmosphere.dev/library/horizon:{{ atmosphere_release }}"
   ingress_nginx_controller: registry.k8s.io/ingress-nginx/controller:v1.1.1
   ingress_nginx_default_backend: registry.k8s.io/defaultbackend-amd64:1.5
   ingress_nginx_kube_webhook_certgen: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
-  keepalived: registry.atmosphere.dev/library/keepalived:main
+  keepalived: "registry.atmosphere.dev/library/keepalived:{{ atmosphere_release }}"
   keycloak: quay.io/keycloak/keycloak:22.0.1-0
-  keystone_api: registry.atmosphere.dev/library/keystone:main
-  keystone_credential_cleanup: registry.atmosphere.dev/library/heat:main
-  keystone_credential_rotate: registry.atmosphere.dev/library/keystone:main
-  keystone_credential_setup: registry.atmosphere.dev/library/keystone:main
-  keystone_db_sync: registry.atmosphere.dev/library/keystone:main
-  keystone_domain_manage: registry.atmosphere.dev/library/heat:main
-  keystone_fernet_rotate: registry.atmosphere.dev/library/keystone:main
-  keystone_fernet_setup: registry.atmosphere.dev/library/keystone:main
-  ks_endpoints: registry.atmosphere.dev/library/heat:main
-  ks_service: registry.atmosphere.dev/library/heat:main
-  ks_user: registry.atmosphere.dev/library/heat:main
+  keystone_api: "registry.atmosphere.dev/library/keystone:{{ atmosphere_release }}"
+  keystone_credential_cleanup: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  keystone_credential_rotate: "registry.atmosphere.dev/library/keystone:{{ atmosphere_release }}"
+  keystone_credential_setup: "registry.atmosphere.dev/library/keystone:{{ atmosphere_release }}"
+  keystone_db_sync: "registry.atmosphere.dev/library/keystone:{{ atmosphere_release }}"
+  keystone_domain_manage: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  keystone_fernet_rotate: "registry.atmosphere.dev/library/keystone:{{ atmosphere_release }}"
+  keystone_fernet_setup: "registry.atmosphere.dev/library/keystone:{{ atmosphere_release }}"
+  ks_endpoints: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  ks_service: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  ks_user: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
   kube_apiserver: registry.k8s.io/kube-apiserver:v1.22.17
   kube_controller_manager: registry.k8s.io/kube-controller-manager:v1.22.17
   kube_coredns: registry.k8s.io/coredns/coredns:v1.8.4
@@ -94,79 +96,79 @@ _atmosphere_images:
   kube_scheduler: registry.k8s.io/kube-scheduler:v1.22.17
   kube_state_metrics: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
   kubectl: docker.io/bitnami/kubectl:1.27.3
-  libvirt: registry.atmosphere.dev/library/libvirtd:main
-  libvirt_tls_sidecar: registry.atmosphere.dev/library/libvirt-tls-sidecar:main
+  libvirt: "registry.atmosphere.dev/library/libvirtd:{{ atmosphere_release }}"
+  libvirt_tls_sidecar: "registry.atmosphere.dev/library/libvirt-tls-sidecar:{{ atmosphere_release }}"
   libvirt_exporter: docker.io/vexxhost/libvirtd-exporter:latest
   local_path_provisioner_helper: docker.io/library/busybox:1.36.0
   local_path_provisioner: docker.io/rancher/local-path-provisioner:v0.0.24
   loki_gateway: docker.io/nginxinc/nginx-unprivileged:1.24-alpine
   loki: docker.io/grafana/loki:2.9.6
-  magnum_api: registry.atmosphere.dev/library/magnum:main
-  magnum_cluster_api_proxy: registry.atmosphere.dev/library/magnum:main
-  magnum_conductor: registry.atmosphere.dev/library/magnum:main
-  magnum_db_sync: registry.atmosphere.dev/library/magnum:main
+  magnum_api: "registry.atmosphere.dev/library/magnum:{{ atmosphere_release }}"
+  magnum_cluster_api_proxy: "registry.atmosphere.dev/library/magnum:{{ atmosphere_release }}"
+  magnum_conductor: "registry.atmosphere.dev/library/magnum:{{ atmosphere_release }}"
+  magnum_db_sync: "registry.atmosphere.dev/library/magnum:{{ atmosphere_release }}"
   magnum_registry: quay.io/vexxhost/magnum-cluster-api-registry:latest
-  manila_api: registry.atmosphere.dev/library/manila:main
-  manila_data: registry.atmosphere.dev/library/manila:main
-  manila_db_sync: registry.atmosphere.dev/library/manila:main
-  manila_scheduler: registry.atmosphere.dev/library/manila:main
-  manila_share: registry.atmosphere.dev/library/manila:main
+  manila_api: "registry.atmosphere.dev/library/manila:{{ atmosphere_release }}"
+  manila_data: "registry.atmosphere.dev/library/manila:{{ atmosphere_release }}"
+  manila_db_sync: "registry.atmosphere.dev/library/manila:{{ atmosphere_release }}"
+  manila_scheduler: "registry.atmosphere.dev/library/manila:{{ atmosphere_release }}"
+  manila_share: "registry.atmosphere.dev/library/manila:{{ atmosphere_release }}"
   memcached: docker.io/library/memcached:1.6.17
-  netoffload: registry.atmosphere.dev/library/netoffload:main
-  neutron_bagpipe_bgp: registry.atmosphere.dev/library/neutron:main
-  neutron_bgp_dragent: registry.atmosphere.dev/library/neutron:main
+  netoffload: "registry.atmosphere.dev/library/netoffload:{{ atmosphere_release }}"
+  neutron_bagpipe_bgp: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
+  neutron_bgp_dragent: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
   neutron_coredns: docker.io/coredns/coredns:1.9.3
-  neutron_db_sync: registry.atmosphere.dev/library/neutron:main
-  neutron_dhcp: registry.atmosphere.dev/library/neutron:main
-  neutron_ironic_agent: registry.atmosphere.dev/library/neutron:main
-  neutron_l2gw: registry.atmosphere.dev/library/neutron:main
-  neutron_l3: registry.atmosphere.dev/library/neutron:main
-  neutron_linuxbridge_agent: registry.atmosphere.dev/library/neutron:main
-  neutron_metadata: registry.atmosphere.dev/library/neutron:main
-  neutron_netns_cleanup_cron: registry.atmosphere.dev/library/neutron:main
-  neutron_openvswitch_agent: registry.atmosphere.dev/library/neutron:main
-  neutron_ovn_metadata: registry.atmosphere.dev/library/neutron:main
-  neutron_server: registry.atmosphere.dev/library/neutron:main
-  neutron_sriov_agent_init: registry.atmosphere.dev/library/neutron:main
-  neutron_sriov_agent: registry.atmosphere.dev/library/neutron:main
+  neutron_db_sync: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
+  neutron_dhcp: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
+  neutron_ironic_agent: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
+  neutron_l2gw: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
+  neutron_l3: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
+  neutron_linuxbridge_agent: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
+  neutron_metadata: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
+  neutron_netns_cleanup_cron: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
+  neutron_openvswitch_agent: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
+  neutron_ovn_metadata: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
+  neutron_server: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
+  neutron_sriov_agent_init: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
+  neutron_sriov_agent: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
   node_feature_discovery: registry.k8s.io/nfd/node-feature-discovery:v0.11.2
-  nova_api: registry.atmosphere.dev/library/nova:main
-  nova_archive_deleted_rows: registry.atmosphere.dev/library/nova:main
-  nova_cell_setup_init: registry.atmosphere.dev/library/heat:main
-  nova_cell_setup: registry.atmosphere.dev/library/nova:main
-  nova_compute_ironic: registry.atmosphere.dev/library/nova:main
-  nova_compute_ssh: registry.atmosphere.dev/library/nova-ssh:main
-  nova_compute: registry.atmosphere.dev/library/nova:main
-  nova_conductor: registry.atmosphere.dev/library/nova:main
-  nova_consoleauth: registry.atmosphere.dev/library/nova:main
-  nova_db_sync: registry.atmosphere.dev/library/nova:main
-  nova_novncproxy_assets: registry.atmosphere.dev/library/nova:main
-  nova_novncproxy: registry.atmosphere.dev/library/nova:main
-  nova_placement: registry.atmosphere.dev/library/nova:main
-  nova_scheduler: registry.atmosphere.dev/library/nova:main
-  nova_service_cleaner: registry.atmosphere.dev/library/heat:main
-  nova_spiceproxy_assets: registry.atmosphere.dev/library/nova:main
-  nova_spiceproxy: registry.atmosphere.dev/library/nova:main
+  nova_api: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
+  nova_archive_deleted_rows: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
+  nova_cell_setup_init: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  nova_cell_setup: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
+  nova_compute_ironic: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
+  nova_compute_ssh: "registry.atmosphere.dev/library/nova-ssh:{{ atmosphere_release }}"
+  nova_compute: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
+  nova_conductor: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
+  nova_consoleauth: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
+  nova_db_sync: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
+  nova_novncproxy_assets: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
+  nova_novncproxy: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
+  nova_placement: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
+  nova_scheduler: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
+  nova_service_cleaner: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  nova_spiceproxy_assets: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
+  nova_spiceproxy: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
   oauth2_proxy: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
-  octavia_api: registry.atmosphere.dev/library/octavia:main
-  octavia_db_sync: registry.atmosphere.dev/library/octavia:main
-  octavia_health_manager_init: registry.atmosphere.dev/library/heat:main
-  octavia_health_manager: registry.atmosphere.dev/library/octavia:main
-  octavia_housekeeping: registry.atmosphere.dev/library/octavia:main
-  octavia_worker: registry.atmosphere.dev/library/octavia:main
-  openvswitch_db_server: registry.atmosphere.dev/library/openvswitch:main
-  openvswitch_vswitchd: registry.atmosphere.dev/library/openvswitch:main
-  ovn_controller: registry.atmosphere.dev/library/ovn-host:main
-  ovn_northd: registry.atmosphere.dev/library/ovn-central:main
-  ovn_ovsdb_nb: registry.atmosphere.dev/library/ovn-central:main
-  ovn_ovsdb_sb: registry.atmosphere.dev/library/ovn-central:main
+  octavia_api: "registry.atmosphere.dev/library/octavia:{{ atmosphere_release }}"
+  octavia_db_sync: "registry.atmosphere.dev/library/octavia:{{ atmosphere_release }}"
+  octavia_health_manager_init: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
+  octavia_health_manager: "registry.atmosphere.dev/library/octavia:{{ atmosphere_release }}"
+  octavia_housekeeping: "registry.atmosphere.dev/library/octavia:{{ atmosphere_release }}"
+  octavia_worker: "registry.atmosphere.dev/library/octavia:{{ atmosphere_release }}"
+  openvswitch_db_server: "registry.atmosphere.dev/library/openvswitch:{{ atmosphere_release }}"
+  openvswitch_vswitchd: "registry.atmosphere.dev/library/openvswitch:{{ atmosphere_release }}"
+  ovn_controller: "registry.atmosphere.dev/library/ovn-host:{{ atmosphere_release }}"
+  ovn_northd: "registry.atmosphere.dev/library/ovn-central:{{ atmosphere_release }}"
+  ovn_ovsdb_nb: "registry.atmosphere.dev/library/ovn-central:{{ atmosphere_release }}"
+  ovn_ovsdb_sb: "registry.atmosphere.dev/library/ovn-central:{{ atmosphere_release }}"
   pause: registry.k8s.io/pause:3.9
   percona_xtradb_cluster_haproxy: docker.io/percona/percona-xtradb-cluster-operator:1.13.0-haproxy
   percona_xtradb_cluster_operator: docker.io/percona/percona-xtradb-cluster-operator:1.13.0
   percona_xtradb_cluster: docker.io/percona/percona-xtradb-cluster:8.0.32-24.2
   percona_version_service: docker.io/perconalab/version-service:main-3325140
-  placement_db_sync: registry.atmosphere.dev/library/placement:main
-  placement: registry.atmosphere.dev/library/placement:main
+  placement_db_sync: "registry.atmosphere.dev/library/placement:{{ atmosphere_release }}"
+  placement: "registry.atmosphere.dev/library/placement:{{ atmosphere_release }}"
   prometheus_config_reloader: quay.io/prometheus-operator/prometheus-config-reloader:v0.73.0
   prometheus_ipmi_exporter: us-docker.pkg.dev/vexxhost-infra/openstack/ipmi-exporter:1.4.0
   prometheus_memcached_exporter: quay.io/prometheus/memcached-exporter:v0.10.0
@@ -185,16 +187,16 @@ _atmosphere_images:
   rabbitmq_topology_operator: docker.io/rabbitmqoperator/messaging-topology-operator:1.6.0
   rook_ceph: docker.io/rook/ceph:v1.10.10
   secretgen_controller: ghcr.io/carvel-dev/secretgen-controller@sha256:59ec05ce5847bfd70c8e04f08b5195e918c8f6fbb947ffc91b456494a2958fd5
-  senlin_api: registry.atmosphere.dev/library/senlin:main
-  senlin_conductor: registry.atmosphere.dev/library/senlin:main
-  senlin_db_sync: registry.atmosphere.dev/library/senlin:main
-  senlin_engine_cleaner: registry.atmosphere.dev/library/senlin:main
-  senlin_engine: registry.atmosphere.dev/library/senlin:main
-  senlin_health_manager: registry.atmosphere.dev/library/senlin:main
-  staffeln_db_sync: registry.atmosphere.dev/library/staffeln:main
-  staffeln_conductor: registry.atmosphere.dev/library/staffeln:main
-  staffeln_api: registry.atmosphere.dev/library/staffeln:main
-  tempest_run_tests: registry.atmosphere.dev/library/tempest:main
+  senlin_api: "registry.atmosphere.dev/library/senlin:{{ atmosphere_release }}"
+  senlin_conductor: "registry.atmosphere.dev/library/senlin:{{ atmosphere_release }}"
+  senlin_db_sync: "registry.atmosphere.dev/library/senlin:{{ atmosphere_release }}"
+  senlin_engine_cleaner: "registry.atmosphere.dev/library/senlin:{{ atmosphere_release }}"
+  senlin_engine: "registry.atmosphere.dev/library/senlin:{{ atmosphere_release }}"
+  senlin_health_manager: "registry.atmosphere.dev/library/senlin:{{ atmosphere_release }}"
+  staffeln_db_sync: "registry.atmosphere.dev/library/staffeln:{{ atmosphere_release }}"
+  staffeln_conductor: "registry.atmosphere.dev/library/staffeln:{{ atmosphere_release }}"
+  staffeln_api: "registry.atmosphere.dev/library/staffeln:{{ atmosphere_release }}"
+  tempest_run_tests: "registry.atmosphere.dev/library/tempest:{{ atmosphere_release }}"
   vector: docker.io/timberio/vector:0.37.0-debian
 
 atmosphere_images: '{{ _atmosphere_images | combine(atmosphere_image_overrides, recursive=True)

--- a/zuul.d/container-images/barbican.yaml
+++ b/zuul.d/container-images/barbican.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=barbican
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/cinder.yaml
+++ b/zuul.d/container-images/cinder.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=cinder
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/cluster-api-provider-openstack.yaml
+++ b/zuul.d/container-images/cluster-api-provider-openstack.yaml
@@ -35,7 +35,7 @@
           arch:
             - linux/amd64
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/cluster-api-provider-openstack/.*
 

--- a/zuul.d/container-images/designate.yaml
+++ b/zuul.d/container-images/designate.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=designate
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/glance.yaml
+++ b/zuul.d/container-images/glance.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=glance
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/heat.yaml
+++ b/zuul.d/container-images/heat.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=heat
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/horizon.yaml
+++ b/zuul.d/container-images/horizon.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=horizon
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/ironic.yaml
+++ b/zuul.d/container-images/ironic.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=ironic
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/keepalived.yaml
+++ b/zuul.d/container-images/keepalived.yaml
@@ -37,8 +37,10 @@
           repository: registry.atmosphere.dev/library/keepalived
           arch:
             - linux/amd64
+          build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/keepalived/.*

--- a/zuul.d/container-images/keystone.yaml
+++ b/zuul.d/container-images/keystone.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=keystone
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/kubernetes-entrypoint.yaml
+++ b/zuul.d/container-images/kubernetes-entrypoint.yaml
@@ -35,7 +35,7 @@
           arch:
             - linux/amd64
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/kubernetes-entrypoint/.*
 

--- a/zuul.d/container-images/libvirt-tls-sidecar.yaml
+++ b/zuul.d/container-images/libvirt-tls-sidecar.yaml
@@ -38,8 +38,10 @@
           repository: registry.atmosphere.dev/library/libvirt-tls-sidecar
           arch:
             - linux/amd64
+          build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - cmd/.*

--- a/zuul.d/container-images/libvirtd.yaml
+++ b/zuul.d/container-images/libvirtd.yaml
@@ -42,9 +42,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=nova
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/magnum.yaml
+++ b/zuul.d/container-images/magnum.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=magnum
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/manila.yaml
+++ b/zuul.d/container-images/manila.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=manila
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/netoffload.yaml
+++ b/zuul.d/container-images/netoffload.yaml
@@ -37,8 +37,10 @@
           repository: registry.atmosphere.dev/library/netoffload
           arch:
             - linux/amd64
+          build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/netoffload/.*

--- a/zuul.d/container-images/neutron.yaml
+++ b/zuul.d/container-images/neutron.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=neutron
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/nova-ssh.yaml
+++ b/zuul.d/container-images/nova-ssh.yaml
@@ -42,9 +42,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=nova
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/nova.yaml
+++ b/zuul.d/container-images/nova.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=nova
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/octavia.yaml
+++ b/zuul.d/container-images/octavia.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=octavia
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/openstack-python-runtime.yaml
+++ b/zuul.d/container-images/openstack-python-runtime.yaml
@@ -42,9 +42,10 @@
           arch:
             - linux/amd64
           build_args:
-            - FROM=registry.atmosphere.dev/library/python-base:main
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
+            - "FROM=registry.atmosphere.dev/library/python-base:{{ zuul.branch | replace('stable/', '') }}"
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/openstack-runtime.yaml
+++ b/zuul.d/container-images/openstack-runtime.yaml
@@ -39,8 +39,10 @@
           repository: registry.atmosphere.dev/library/openstack-runtime
           arch:
             - linux/amd64
+          build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/openstack-venv-builder.yaml
+++ b/zuul.d/container-images/openstack-venv-builder.yaml
@@ -41,8 +41,10 @@
           repository: registry.atmosphere.dev/library/openstack-venv-builder
           arch:
             - linux/amd64
+          build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/openvswitch.yaml
+++ b/zuul.d/container-images/openvswitch.yaml
@@ -35,7 +35,7 @@
           arch:
             - linux/amd64
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/openvswitch/.*
 

--- a/zuul.d/container-images/ovn.yaml
+++ b/zuul.d/container-images/ovn.yaml
@@ -38,18 +38,20 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - OVN_COMPONENT=central
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
         - context: images/ovn
           registry: registry.atmosphere.dev
           repository: registry.atmosphere.dev/library/ovn-host
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - OVN_COMPONENT=host
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/openvswitch/.*
       - images/ovn/.*

--- a/zuul.d/container-images/placement.yaml
+++ b/zuul.d/container-images/placement.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=placement
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/python-base.yaml
+++ b/zuul.d/container-images/python-base.yaml
@@ -39,8 +39,10 @@
           repository: registry.atmosphere.dev/library/python-base
           arch:
             - linux/amd64
+          build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/senlin.yaml
+++ b/zuul.d/container-images/senlin.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=senlin
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/staffeln.yaml
+++ b/zuul.d/container-images/staffeln.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=staffeln
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/tempest.yaml
+++ b/zuul.d/container-images/tempest.yaml
@@ -46,9 +46,10 @@
           arch:
             - linux/amd64
           build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=tempest
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/ubuntu-cloud-archive.yaml
+++ b/zuul.d/container-images/ubuntu-cloud-archive.yaml
@@ -37,8 +37,10 @@
           repository: registry.atmosphere.dev/library/ubuntu-cloud-archive
           arch:
             - linux/amd64
+          build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
       - images/ubuntu-cloud-archive/.*

--- a/zuul.d/container-images/ubuntu.yaml
+++ b/zuul.d/container-images/ubuntu.yaml
@@ -34,8 +34,10 @@
           repository: registry.atmosphere.dev/library/ubuntu
           arch:
             - linux/amd64
+          build_args:
+            - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
           tags:
-            - main
+            - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files
       - images/ubuntu/.*
 

--- a/zuul.d/playbooks/molecule/pre.yml
+++ b/zuul.d/playbooks/molecule/pre.yml
@@ -59,15 +59,14 @@
         - name: Replace the registry in image manifest
           ansible.builtin.replace:
             path: "{{ zuul.project.src_dir }}/roles/defaults/vars/main.yml"
-            regexp: "{{ repo }}:{{ tag }}"
-            replace: '{{ buildset_registry.host }}:{{ buildset_registry.port }}/{{ repo }}:{{ tag }}'
+            regexp: "{{ repo }}:"
+            replace: '{{ buildset_registry.host }}:{{ buildset_registry.port }}/{{ repo }}:'
           loop: "{{ zuul.artifacts | default([]) }}"
           loop_control:
             loop_var: zj_zuul_artifact
           when: "'metadata' in zj_zuul_artifact and zj_zuul_artifact.metadata.type | default('') == 'container_image'"
           vars:
             repo: "{{ zj_zuul_artifact.metadata.repository }}"
-            tag: "{{ zj_zuul_artifact.metadata.tag }}"
 
     # TODO(mnaser): Drop this when we move to PBR
     - name: Add current folder to Git's safe directories


### PR DESCRIPTION
In order to simplify backporting and branching of new releases,
this patch relies on the Zuul branch when building images so
that we can easily branch out a new release and it will
automatically pick up the images.
