### PR TITLE
Update Ceph image to v18.2.1

### DIFF
--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -20,7 +20,7 @@ _atmosphere_images:
   barbican_db_sync: "registry.atmosphere.dev/library/barbican:{{ atmosphere_release }}"
   bootstrap: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
   ceph_config_helper: "registry.atmosphere.dev/library/libvirtd:{{ atmosphere_release }}"
-  ceph: quay.io/ceph/ceph:v16.2.11
+  ceph: quay.io/ceph/ceph:v18.2.1
   cert_manager_cainjector: quay.io/jetstack/cert-manager-cainjector:v1.7.1
   cert_manager_cli: quay.io/jetstack/cert-manager-ctl:v1.7.1
   cert_manager_controller: quay.io/jetstack/cert-manager-controller:v1.7.1


### PR DESCRIPTION
A Ceph cluster deployed with vexxhost.ceph uses Ceph v18.2.1 by default but the `rook_ceph_cluster` role specifies v16.11.2 in the [cephClusterSpec](https://github.com/vexxhost/atmosphere/blob/main/roles/rook_ceph_cluster/vars/main.yml#L17). This has the practical effect of deploying RGW with v16.2.11.

Depends-On: https://github.com/vexxhost/atmosphere/pull/1130