### PR TITLE
Change Loki log_level from info to warn

### DIFF
--- a/roles/loki/vars/main.yml
+++ b/roles/loki/vars/main.yml
@@ -14,6 +14,8 @@
 
 _loki_helm_values:
   loki:
+    server:
+      log_level: warn
     image:
       registry: "{{ atmosphere_images['loki'] | vexxhost.kubernetes.docker_image('domain') }}"
       repository: "{{ atmosphere_images['loki'] | vexxhost.kubernetes.docker_image('path') }}"


### PR DESCRIPTION
The default log_level is `info` which causes every query to generate dozens of new log lines with the query's contents which then show up in future results if the query is execute again making it harder to find what you were looking for in the middle of extra noise that has to be filtered out when doing a global search.

Depends-On: https://github.com/vexxhost/atmosphere/pull/1130