### PR TITLE
Increase rook-ceph-operator CPU limit to 1

### DIFF
--- a/roles/rook_ceph/vars/main.yml
+++ b/roles/rook_ceph/vars/main.yml
@@ -18,6 +18,9 @@ _rook_ceph_helm_values:
     tag: "{{ atmosphere_images['rook_ceph'] | vexxhost.kubernetes.docker_image('tag') }}"
   nodeSelector:
     openstack-control-plane: enabled
+  resources:
+    limits:
+      cpu: 1
   # NOTE(mnaser): Once we implement storage inside Atmosphere, we can rely on
   #               Rook to manage this.
   csi:


### PR DESCRIPTION
~~[Default](https://github.com/vexxhost/atmosphere/blob/main/charts/rook-ceph/values.yaml#L29) is 100m which causes a lot of alert flapping even in a tiny idle cluster.~~

Default CPU limit is 500m which causes alert flapping. Increasing to 1 to accommodate peaks.

Tweaking it in the role so it's easier to sync the chart's values.yml with upstream.

Depends-On: https://github.com/vexxhost/atmosphere/pull/1130