### PR TITLE
fix: use kubelet_hostname instead of inventory_hostname_short

### DIFF
--- a/roles/kubernetes_node_labels/tasks/main.yml
+++ b/roles/kubernetes_node_labels/tasks/main.yml
@@ -17,7 +17,7 @@
   kubernetes.core.k8s:
     state: patched
     kind: Node
-    name: "{{ inventory_hostname_short }}"
+    name: "{{ kubelet_hostname | default(inventory_hostname_short) }}"
     definition:
       metadata:
         labels: "{{ kubernetes_node_labels }}"


### PR DESCRIPTION
In `vexxhost.kubernetes.kubelet` `kubelete_hostname` default value is `inventory_hostname_short`.  But it also can be changed to something else. Let's use proper variable here. 