### PR TITLE
fix: Install qemu-block-extra in nova, cinder, ironic images

### DIFF
--- a/images/glance/Dockerfile
+++ b/images/glance/Dockerfile
@@ -36,7 +36,7 @@ FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \
-    ceph-common lsscsi nvme-cli python3-rados python3-rbd qemu-utils sysfsutils udev util-linux
+    ceph-common lsscsi nvme-cli python3-rados python3-rbd qemu-block-extra qemu-utils sysfsutils udev util-linux
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF

--- a/images/ironic/Dockerfile
+++ b/images/ironic/Dockerfile
@@ -30,7 +30,7 @@ FROM registry.atmosphere.dev/library/openstack-python-runtime:${RELEASE}
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \
-    ethtool ipmitool iproute2 ipxe lshw qemu-utils tftpd-hpa
+    ethtool ipmitool iproute2 ipxe lshw qemu-block-extra qemu-utils tftpd-hpa
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF

--- a/images/nova/Dockerfile
+++ b/images/nova/Dockerfile
@@ -34,7 +34,7 @@ ADD https://github.com/novnc/noVNC.git#v1.4.0 /usr/share/novnc
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \
-    ceph-common genisoimage iproute2 libosinfo-bin lsscsi ndctl nvme-cli openssh-client ovmf python3-libvirt python3-rados python3-rbd qemu-efi-aarch64 qemu-utils sysfsutils udev util-linux
+    ceph-common genisoimage iproute2 libosinfo-bin lsscsi ndctl nvme-cli openssh-client ovmf python3-libvirt python3-rados python3-rbd qemu-efi-aarch64 qemu-block-extra qemu-utils sysfsutils udev util-linux
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF


### PR DESCRIPTION
fix https://github.com/vexxhost/atmosphere/issues/1183

In Ubuntu Jammy, the qemu-block-extra package is no longer required by the qemu-utils package and should be additionally installed to use rbd backend.

Depends-On: https://github.com/vexxhost/atmosphere/pull/1181