### PR TITLE
fix: mount host ca trust store

### DIFF
--- a/roles/openstack_cli/templates/atmosphere.sh.j2
+++ b/roles/openstack_cli/templates/atmosphere.sh.j2
@@ -1,6 +1,8 @@
 alias osc='nerdctl run --rm --network host \
       --volume $PWD:/opt --volume /tmp:/tmp \
       --volume /etc/openstack:/etc/openstack:ro \
+      --volume {{ '/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro' if ansible_facts['os_family']
+      in ['Debian'] else '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt:/etc/ssl/certs/ca-certificates.crt:ro' }} \
 {% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca') %}
       --volume {{ '/usr/local/share/ca-certificates/atmosphere.crt:/usr/local/share/ca-certificates/atmosphere.crt:ro' if ansible_facts['os_family']
       in ['Debian'] else '/etc/pki/ca-trust/source/anchors/atmosphere.crt:/etc/pki/ca-trust/source/anchors/atmosphere.crt:ro' }} \


### PR DESCRIPTION
Related to: https://github.com/vexxhost/atmosphere/issues/1185

If we assume that container always be based on ubuntu then internal ca trust path is always the same