### PR TITLE
feat: NIC initialization moved from neutron to openvswitch charts

### DIFF
--- a/charts/patches/openvswitch/0002-copy-nic-init-to-openvswitch-chart.patch
+++ b/charts/patches/openvswitch/0002-copy-nic-init-to-openvswitch-chart.patch
@@ -1,0 +1,849 @@
+diff --git a/openvswitch/templates/bin/_openvswitch-nic-init.sh.tpl b/openvswitch/templates/bin/_openvswitch-nic-init.sh.tpl
+new file mode 100644
+index 0000000..84647ff
+--- /dev/null
++++ b/openvswitch/templates/bin/_openvswitch-nic-init.sh.tpl
+@@ -0,0 +1,508 @@
++#!/bin/bash
++
++{{/*
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++   http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/}}
+0002-move-nic-init-to-openvswitch-.patch+
++set -ex
++
++# This enables the usage of 'ovs-appctl' from neutron pod.
++OVS_CONFIG=""
++OVS_CONFIG_FILE=/tmp/ovs.conf
++OVS_PID=$(cat /run/openvswitch/ovs-vswitchd.pid)
++OVS_CTL=/run/openvswitch/ovs-vswitchd.${OVS_PID}.ctl
++OVS_SOCKET=/run/openvswitch/db.sock
++DPDK_ENABLED=false
++
++function get_dpdk_config_value {
++  values=${@:1:$#-1}
++  filter=${!#}
++  value=$(echo ${values} | jq -r ${filter})
++  if [[ "${value}" == "null" ]]; then
++    echo ""
++  else
++    echo "${value}"
++  fi
++}
++
++# Test for OVS config and wait for vswitchd to come up
++if [ -f ${OVS_CONFIG_FILE} ]; then
++  OVS_CONFIG=$(cat ${OVS_CONFIG_FILE})
++  if [[ $(get_dpdk_config_value ${OVS_CONFIG} '.ovs_dpdk.enabled') == "true" ]]; then
++    DPDK_ENABLED=true
++    until [ -n "$(ovs-vsctl show)" ] && (ovs-vsctl list Open_vSwitch | grep -q "dpdk_initialized.*true") ; do
++      sleep 5;
++      echo "Waiting for OVS initialization..."
++    done
++  else
++    until [ -n "$(ovs-vsctl show)" ]; do
++      sleep 5;
++      echo "Waiting for OVS initialization..."
++    done
++  fi
++else
++  echo "Cannot find ${OVS_CONFIG_FILE}" 1>&2
++  exit
++fi
++
++function bind_nic {
++  echo $2 > /sys/bus/pci/devices/$1/driver_override
++  echo $1 > /sys/bus/pci/drivers/$2/bind
++}
++
++function unbind_nic {
++  echo $1 > /sys/bus/pci/drivers/$2/unbind
++  echo > /sys/bus/pci/devices/$1/driver_override
++}
++
++function get_name_by_pci_id {
++  path=$(find /sys/bus/pci/devices/$1/ -name net)
++  if [ -n "${path}" ] ; then
++    echo $(ls -1 $path/)
++  fi
++}
++
++function get_ip_address_from_interface {
++  local interface=$1
++  local ip=$(ip -4 -o addr s "${interface}" | awk '{ print $4; exit }' | awk -F '/' 'NR==1 {print $1}')
++  if [ -z "${ip}" ] ; then
++    exit 1
++  fi
++  echo ${ip}
++}
++
++function get_ip_prefix_from_interface {
++  local interface=$1
++  local prefix=$(ip -4 -o addr s "${interface}" | awk '{ print $4; exit }' | awk -F '/' 'NR==1 {print $2}')
++  if [ -z "${prefix}" ] ; then
++    exit 1
++  fi
++  echo ${prefix}
++}
++
++function migrate_ip {
++  pci_id=$1
++  bridge_name=$2
++
++  local src_nic=$(get_name_by_pci_id ${pci_id})
++  if [ -n "${src_nic}" ] ; then
++    bridge_exists=$(ip a s "${bridge_name}" | grep "${bridge_name}" | cut -f2 -d':' 2> /dev/null)
++    if [ -z "${bridge_exists}" ] ; then
++      echo "Bridge "${bridge_name}" does not exist. Creating it on demand."
++      init_ovs_dpdk_bridge "${bridge_name}"
++    fi
++
++    migrate_ip_from_nic ${src_nic} ${bridge_name}
++  fi
++}
++
++function migrate_ip_from_nic {
++  src_nic=$1
++  bridge_name=$2
++
++  # Enabling explicit error handling: We must avoid to lose the IP
++  # address in the migration process. Hence, on every error, we
++  # attempt to assign the IP back to the original NIC and exit.
++  set +e
++
++  ip=$(get_ip_address_from_interface ${src_nic})
++  prefix=$(get_ip_prefix_from_interface ${src_nic})
++
++  bridge_ip=$(get_ip_address_from_interface "${bridge_name}")
++  bridge_prefix=$(get_ip_prefix_from_interface "${bridge_name}")
++
++  ip link set ${bridge_name} up
++
++  if [[ -n "${ip}" && -n "${prefix}" ]]; then
++    ip addr flush dev ${src_nic}
++    if [ $? -ne 0 ] ; then
++      ip addr add ${ip}/${prefix} dev ${src_nic}
++      echo "Error while flushing IP from ${src_nic}."
++      exit 1
++    fi
++
++    ip addr add ${ip}/${prefix} dev "${bridge_name}"
++    if [ $? -ne 0 ] ; then
++      echo "Error assigning IP to bridge "${bridge_name}"."
++      ip addr add ${ip}/${prefix} dev ${src_nic}
++      exit 1
++    fi
++  elif [[ -n "${bridge_ip}" && -n "${bridge_prefix}" ]]; then
++    echo "Bridge '${bridge_name}' already has IP assigned. Keeping the same:: IP:[${bridge_ip}]; Prefix:[${bridge_prefix}]..."
++  elif [[ -z "${bridge_ip}" && -z "${ip}" ]]; then
++    echo "Interface and bridge have no ips configured. Leaving as is."
++  else
++    echo "Interface ${name} has invalid IP address. IP:[${ip}]; Prefix:[${prefix}]..."
++    exit 1
++  fi
++
++  set -e
++}
++
++function get_pf_or_vf_pci {
++  dpdk_pci_id=${1}
++  vf_index=${2}
++
++  if [ -n "$vf_index" ]
++  then
++    iface=$(get_name_by_pci_id "${dpdk_pci_id}")
++    sysfs_numvfs_path="/sys/class/net/${iface}/device/sriov_numvfs"
++    if [[ -f /sys/class/net/${iface}/device/sriov_numvfs &&
++          "$(cat /sys/class/net/${iface}/device/sriov_numvfs)" -ne "0" &&
++          -e /sys/class/net/${iface}/device/virtfn${vf_index} ]]
++    then
++      dpdk_pci_id=$(ls -la /sys/class/net/${iface}/device/virtfn${vf_index})
++      dpdk_pci_id=${dpdk_pci_id#*"../"}
++    else
++      echo "Error fetching the VF PCI for PF: ["${iface}", "${dpdk_pci_id}"] and VF-Index: ${vf_index}."
++      exit 1
++    fi
++  fi
++}
++
++function bind_dpdk_nic {
++  target_driver=${1}
++  pci_id=${2}
++
++  current_driver="$(get_driver_by_address "${pci_id}" )"
++  if [ "$current_driver" != "$target_driver" ]; then
++    if [ "$current_driver" != "" ]; then
++      unbind_nic "${pci_id}" ${current_driver}
++    fi
++    bind_nic "${pci_id}" ${target_driver}
++  fi
++}
++
++function process_dpdk_nics {
++  target_driver=$(get_dpdk_config_value ${OVS_CONFIG} '.ovs_dpdk.driver')
++  # loop over all nics
++  echo $OVS_CONFIG | jq -r -c '.ovs_dpdk.nics[]' | \
++  while IFS= read -r nic; do
++    local port_name=$(get_dpdk_config_value ${nic} '.name')
++    local pci_id=$(get_dpdk_config_value ${nic} '.pci_id')
++    local iface=$(get_dpdk_config_value ${nic} '.iface')
++    if [ -n ${iface} ] && [ -z ${pci_id} ]; then
++      local pci_id=$(get_address_by_nicname ${iface})
++    else
++      iface=$(get_name_by_pci_id "${pci_id}")
++    fi
++    local bridge=$(get_dpdk_config_value ${nic} '.bridge')
++    local vf_index=$(get_dpdk_config_value ${nic} '.vf_index')
++
++    if [[ $(get_dpdk_config_value ${nic} '.migrate_ip') == true ]] ; then
++      migrate_ip "${pci_id}" "${bridge}"
++    fi
++
++    if [ -n "${iface}" ]; then
++      ip link set ${iface} promisc on
++      if [ -n "${vf_index}" ]; then
++        vf_string="vf ${vf_index}"
++        ip link set ${iface} ${vf_string} trust on
++
++        # NOTE: To ensure proper toggle of spoofchk,
++        # turn it on then off.
++        ip link set ${iface} ${vf_string} spoofchk on
++        ip link set ${iface} ${vf_string} spoofchk off
++      fi
++    fi
++
++    # Fetch the PCI to be bound to DPDK driver.
++    # In case VF Index is configured then PCI of that particular VF
++    # is bound to DPDK, otherwise PF PCI is bound to DPDK.
++    get_pf_or_vf_pci "${pci_id}" "${vf_index}"
++
++    bind_dpdk_nic ${target_driver} "${dpdk_pci_id}"
++
++    dpdk_options=""
++    ofport_request=$(get_dpdk_config_value ${nic} '.ofport_request')
++    if [ -n "${ofport_request}" ]; then
++      dpdk_options+='ofport_request=${ofport_request} '
++    fi
++    n_rxq=$(get_dpdk_config_value ${nic} '.n_rxq')
++    if [ -n "${n_rxq}" ]; then
++      dpdk_options+='options:n_rxq=${n_rxq} '
++    fi
++    n_txq=$(get_dpdk_config_value ${nic} '.n_txq')
++    if [ -n "${n_txq}" ]; then
++      dpdk_options+='options:n_txq=${n_txq} '
++    fi
++    pmd_rxq_affinity=$(get_dpdk_config_value ${nic} '.pmd_rxq_affinity')
++    if [ -n "${pmd_rxq_affinity}" ]; then
++      dpdk_options+='other_config:pmd-rxq-affinity=${pmd_rxq_affinity} '
++    fi
++    mtu=$(get_dpdk_config_value ${nic} '.mtu')
++    if [ -n "${mtu}" ]; then
++      dpdk_options+='mtu_request=${mtu} '
++    fi
++    n_rxq_size=$(get_dpdk_config_value ${nic} '.n_rxq_size')
++    if [ -n "${n_rxq_size}" ]; then
++      dpdk_options+='options:n_rxq_desc=${n_rxq_size} '
++    fi
++    n_txq_size=$(get_dpdk_config_value ${nic} '.n_txq_size')
++    if [ -n "${n_txq_size}" ]; then
++      dpdk_options+='options:n_txq_desc=${n_txq_size} '
++    fi
++    vhost_iommu_support=$(get_dpdk_config_value ${nic} '.vhost_iommu_support')
++    if [ -n "${vhost_iommu_support}" ]; then
++      dpdk_options+='options:vhost-iommu-support=${vhost_iommu_support} '
++    fi
++
++    ovs-vsctl --db=unix:${OVS_SOCKET} --may-exist add-port ${bridge} ${port_name} \
++       -- set Interface ${port_name} type=dpdk options:dpdk-devargs=${pci_id} ${dpdk_options}
++
++  done
++}
++
++function process_dpdk_bonds {
++  target_driver=$(get_dpdk_config_value ${OVS_CONFIG} '.ovs_dpdk.driver')
++  # loop over all bonds
++  echo $OVS_CONFIG | jq -r -c '.ovs_dpdk.bonds[]' > /tmp/bonds_array
++  while IFS= read -r bond; do
++    local bond_name=$(get_dpdk_config_value ${bond} '.name')
++    local dpdk_bridge=$(get_dpdk_config_value ${bond} '.bridge')
++    local migrate_ip=$(get_dpdk_config_value ${bond} '.migrate_ip')
++    local mtu=$(get_dpdk_config_value ${bond} '.mtu')
++    local n_rxq=$(get_dpdk_config_value ${bond} '.n_rxq')
++    local n_txq=$(get_dpdk_config_value ${bond} '.n_txq')
++    local ofport_request=$(get_dpdk_config_value ${bond} '.ofport_request')
++    local n_rxq_size=$(get_dpdk_config_value ${bond} '.n_rxq_size')
++    local n_txq_size=$(get_dpdk_config_value ${bond} '.n_txq_size')
++    local vhost_iommu_support=$(get_dpdk_config_value ${bond} '.vhost_iommu_support')
++    local ovs_options=$(get_dpdk_config_value ${bond} '.ovs_options')
++
++    local nic_name_str=""
++    local dev_args_str=""
++    local ip_migrated=false
++
++    echo $bond | jq -r -c '.nics[]' > /tmp/nics_array
++    while IFS= read -r nic; do
++      local pci_id=$(get_dpdk_config_value ${nic} '.pci_id')
++      local iface=$(get_dpdk_config_value ${nic} '.iface')
++      if [ -n ${iface} ] && [ -z ${pci_id} ]; then
++        local pci_id=$(get_address_by_nicname ${iface})
++      else
++        iface=$(get_name_by_pci_id "${pci_id}")
++      fi
++      local nic_name=$(get_dpdk_config_value ${nic} '.name')
++      local pmd_rxq_affinity=$(get_dpdk_config_value ${nic} '.pmd_rxq_affinity')
++      local vf_index=$(get_dpdk_config_value ${nic} '.vf_index')
++      local vf_string=""
++
++      if [[ ${migrate_ip} = "true" && ${ip_migrated} = "false" ]]; then
++        migrate_ip "${pci_id}" "${dpdk_bridge}"
++        ip_migrated=true
++      fi
++
++      if [ -n "${iface}" ]; then
++        ip link set ${iface} promisc on
++        if [ -n "${vf_index}" ]; then
++          vf_string="vf ${vf_index}"
++          ip link set ${iface} ${vf_string} trust on
++
++          # NOTE: To ensure proper toggle of spoofchk,
++          # turn it on then off.
++          ip link set ${iface} ${vf_string} spoofchk on
++          ip link set ${iface} ${vf_string} spoofchk off
++        fi
++      fi
++
++      # Fetch the PCI to be bound to DPDK driver.
++      # In case VF Index is configured then PCI of that particular VF
++      # is bound to DPDK, otherwise PF PCI is bound to DPDK.
++      get_pf_or_vf_pci "${pci_id}" "${vf_index}"
++
++      bind_dpdk_nic ${target_driver} "${dpdk_pci_id}"
++
++      nic_name_str+=" "${nic_name}""
++      dev_args_str+=" -- set Interface "${nic_name}" type=dpdk options:dpdk-devargs=""${dpdk_pci_id}"
++
++      if [[ -n ${mtu} ]]; then
++        dev_args_str+=" -- set Interface "${nic_name}" mtu_request=${mtu}"
++      fi
++
++      if [[ -n ${n_rxq} ]]; then
++        dev_args_str+=" -- set Interface "${nic_name}" options:n_rxq=${n_rxq}"
++      fi
++
++      if [[ -n ${n_txq} ]]; then
++        dev_args_str+=" -- set Interface "${nic_name}" options:n_txq=${n_txq}"
++      fi
++
++      if [[ -n ${ofport_request} ]]; then
++        dev_args_str+=" -- set Interface "${nic_name}" ofport_request=${ofport_request}"
++      fi
++
++      if [[ -n ${pmd_rxq_affinity} ]]; then
++        dev_args_str+=" -- set Interface "${nic_name}" other_config:pmd-rxq-affinity=${pmd_rxq_affinity}"
++      fi
++
++      if [[ -n ${n_rxq_size} ]]; then
++        dev_args_str+=" -- set Interface "${nic_name}" options:n_rxq_desc=${n_rxq_size}"
++      fi
++
++      if [[ -n ${n_txq_size} ]]; then
++        dev_args_str+=" -- set Interface "${nic_name}" options:n_txq_desc=${n_txq_size}"
++      fi
++
++      if [[ -n ${vhost_iommu_support} ]]; then
++        dev_args_str+=" -- set Interface "${nic_name}" options:vhost-iommu-support=${vhost_iommu_support}"
++      fi
++    done < /tmp/nics_array
++
++    if [ "$(get_dpdk_config_value ${OVS_CONFIG} '.ovs_dpdk.update_dpdk_bond_config')" == "true" ]; then
++      echo -e "NOTE: UPDATE_DPDK_BOND_CONFIG is set to true.\
++      \nThis might cause disruptions in ovs traffic.\
++      \nTo avoid this disruption set UPDATE_DPDK_BOND_CONFIG to false."
++      ovs-vsctl --db=unix:${OVS_SOCKET} set Bridge "${dpdk_bridge}" other_config:update_config=true
++      ovs_update_config=true
++    else
++      ovs_update_config=$(ovs-vsctl --columns=other_config --no-heading -d json list bridge "${dpdk_bridge}" \
++        | jq -r '.[1][] as $list | if $list[0] == "update_config" then $list[1] else empty end')
++    fi
++
++
++    if [ "${ovs_update_config}" == "true" ] || [ "${ovs_update_config}" == "" ];
++    then
++      ovs-vsctl --db=unix:${OVS_SOCKET} --if-exists del-port "${bond_name}"
++      ovs-vsctl --db=unix:${OVS_SOCKET} set Bridge "${dpdk_bridge}" other_config:update_config=false
++      ovs-vsctl --db=unix:${OVS_SOCKET} --may-exist add-bond "${dpdk_bridge}" "${bond_name}" \
++        ${nic_name_str} \
++        ${ovs_options} ${dev_args_str}
++    fi
++
++  done < "/tmp/bonds_array"
++}
++
++function set_dpdk_module_log_level {
++  # loop over all target modules
++  if [ -n "$(get_dpdk_config_value ${OVS_CONFIG} '.ovs_dpdk.modules')" ]; then
++    echo $OVS_CONFIG | jq -r -c '.ovs_dpdk.modules[]' > /tmp/modules_array
++    while IFS= read -r module; do
++      local mod_name=$(get_dpdk_config_value ${module} '.name')
++      local mod_level=$(get_dpdk_config_value ${module} '.log_level')
++
++      ovs-appctl -t ${OVS_CTL} vlog/set ${mod_name}:${mod_level}
++      ovs-appctl -t ${OVS_CTL} vlog/list|grep ${mod_name}
++    done < /tmp/modules_array
++  fi
++}
++
++function get_driver_by_address {
++  if [[ -e /sys/bus/pci/devices/$1/driver ]]; then
++    echo $(ls /sys/bus/pci/devices/$1/driver -al | awk '{n=split($NF,a,"/"); print a[n]}')
++  fi
++}
++
++function get_address_by_nicname {
++  if [[ -e /sys/class/net/$1/device ]]; then
++    readlink -f /sys/class/net/$1/device | xargs basename
++  fi
++}
++
++function init_ovs_dpdk_bridge {
++  bridge=$1
++  ovs-vsctl --db=unix:${OVS_SOCKET} --may-exist add-br ${bridge} \
++  -- set Bridge ${bridge} datapath_type=netdev
++  ip link set ${bridge} up
++}
++
++# create all additional bridges defined in the DPDK section
++function init_ovs_dpdk_bridges {
++  for br in $(get_dpdk_config_value ${OVS_CONFIG} '.ovs_dpdk.bridges[].name'); do
++    init_ovs_dpdk_bridge ${br}
++  done
++}
++
++# handle any bridge mappings
++echo $OVS_CONFIG | jq -r -c '.auto_bridge_add' | sed 's/[{}"]//g' | tr "," "\n" | \
++while IFS= read -r bmap; do
++  bridge=${bmap%:*}
++  iface=${bmap#*:}
++  ovs-vsctl --no-wait --may-exist add-br $bridge
++  if [ -n "$iface" ] && [ "$iface" != "null" ]
++  then
++    ovs-vsctl --no-wait --may-exist add-port $bridge $iface
++    migrate_ip_from_nic $iface $bridge
++    if [[ "${DPDK_ENABLED}" != "true" ]]; then
++      ip link set dev $iface up
++    fi
++  fi
++done
++
++tunnel_types="$(get_dpdk_config_value ${OVS_CONFIG} '.network.tunnel_types')"
++if [[ -n "${tunnel_types}" ]] ; then
++    tunnel_interface="$(get_dpdk_config_value ${OVS_CONFIG} '.network.interface.tunnel')"
++    if [ -z "${tunnel_interface}" ] ; then
++        # search for interface with tunnel network routing
++        tunnel_network_cidr="$(get_dpdk_config_value ${OVS_CONFIG} '.network.interface.tunnel')"
++        if [ -z "${tunnel_network_cidr}" ] ; then
++            tunnel_network_cidr="0/0"
++        fi
++        # If there is not tunnel network gateway, exit
++        tunnel_interface=$(ip -4 route list ${tunnel_network_cidr} | awk -F 'dev' '{ print $2; exit }' \
++            | awk '{ print $1 }') || exit 1
++    fi
++fi
++
++if [[ "${DPDK_ENABLED}" == "true" ]]; then
++  init_ovs_dpdk_bridges
++  process_dpdk_nics
++  process_dpdk_bonds
++  set_dpdk_module_log_level
++fi
++
++# determine local-ip dynamically based on interface provided but only if tunnel_types is not null
++if [[ -n "${tunnel_types}" ]] ; then
++  LOCAL_IP=$(get_ip_address_from_interface ${tunnel_interface})
++  if [ -z "${LOCAL_IP}" ] ; then
++    echo "Var LOCAL_IP is empty"
++    exit 1
++  fi
++
++  if [[ "${DPDK_ENABLED}" == "true" ]]; then
++    PREFIX=$(get_ip_prefix_from_interface "${tunnel_interface}")
++
++    # loop over all nics
++    echo $OVS_CONFIG | jq -r -c '.ovs_dpdk.bridges[]' | \
++    while IFS= read -r br; do
++      bridge_name=$(get_dpdk_config_value ${br} '.name')
++      tunnel_underlay_vlan=$(get_dpdk_config_value ${br} '.tunnel_underlay_vlan')
++
++      if [[ "${bridge_name}" == "${tunnel_interface}" ]]; then
++        # Route the tunnel traffic via the physical bridge
++        if [[ -n "${LOCAL_IP}" && -n "${PREFIX}" ]]; then
++          if [[ -n $(ovs-appctl -t ${OVS_CTL} ovs/route/show | grep "${LOCAL_IP}" | grep -v '^Cached:') ]]; then
++            ovs-appctl -t ${OVS_CTL} ovs/route/del "${LOCAL_IP}"/"${PREFIX}"
++          fi
++          ovs-appctl -t ${OVS_CTL} ovs/route/add "${LOCAL_IP}"/"${PREFIX}" "${tunnel_interface}"
++
++          if [[ -n "${tunnel_underlay_vlan}" ]]; then
++            # If there is not tunnel network gateway, exit
++            IFS=. read -r i1 i2 i3 i4 <<< "${LOCAL_IP}"
++            IFS=. read -r xx m1 m2 m3 m4 <<< $(for a in $(seq 1 32); do if [ $(((a - 1) % 8)) -eq 0 ]; then echo -n .; fi; if [ $a -le ${PREFIX} ]; then echo -n 1; else echo -n 0; fi; done)
++            tunnel_network_cidr=$(printf "%d.%d.%d.%d\n" "$((i1 & (2#$m1)))" "$((i2 & (2#$m2)))" "$((i3 & (2#$m3)))" "$((i4 & (2#$m4)))") || exit 1
++            # Put a new flow to tag all the tunnel traffic with configured vlan-id
++            if [[ -n $(ovs-ofctl dump-flows "${tunnel_interface}" | grep "nw_dst=${tunnel_network_cidr}") ]]; then
++              ovs-ofctl del-flows "${tunnel_interface}" "cookie=0x9999/-1, table=0, ip,nw_dst=${tunnel_network_cidr}"
++            fi
++            ovs-ofctl add-flow "${tunnel_interface}" "cookie=0x9999, table=0, priority=8, ip,nw_dst=${tunnel_network_cidr}, actions=mod_vlan_vid:${tunnel_underlay_vlan},NORMAL"
++          fi
++        fi
++        break
++      fi
++    done
++  fi
++fi
++
++nova_uid=$(get_dpdk_config_value $OVS_CONFIG | jq -r '.user.nova.uid')
++chown -Rv ${nova_uid}:${nova_uid} /run/openvswitch
+diff --git a/openvswitch/templates/bin/_openvswitch-vswitchd.sh.tpl b/openvswitch/templates/bin/_openvswitch-vswitchd.sh.tpl
+index c1419b66..295328a8 100644
+--- a/openvswitch/templates/bin/_openvswitch-vswitchd.sh.tpl
++++ b/openvswitch/templates/bin/_openvswitch-vswitchd.sh.tpl
+@@ -73,6 +73,10 @@ function start () {
+     ovs-vsctl --db=unix:${OVS_SOCKET} --no-wait set Open_vSwitch . other_config:vhost-iommu-support={{ .Values.conf.ovs_dpdk.vhost_iommu_support }}
+ {{- end }}
+
++{{- if hasKey .Values.conf.ovs_dpdk "userspace_tso_enable" }}
++    ovs-vsctl --db=unix:${OVS_SOCKET} --no-wait set Open_vSwitch . other_config:userspace-tso-enable={{ .Values.conf.ovs_dpdk.userspace_tso_enable }}
++{{- end }}
++
+     ovs-vsctl --db=unix:${OVS_SOCKET} --no-wait set Open_vSwitch . other_config:vhost-sock-dir={{ .Values.conf.ovs_dpdk.vhostuser_socket_dir | quote }}
+     ovs-vsctl --db=unix:${OVS_SOCKET} --no-wait set Open_vSwitch . other_config:dpdk-init=true
+
+@@ -114,13 +118,36 @@ function start () {
+   fi
+ {{- end }}
+
+-  exec /usr/sbin/ovs-vswitchd unix:${OVS_SOCKET} \
+-          -vconsole:emer \
+-          -vconsole:err \
+-          -vconsole:info \
+-          --pidfile=${OVS_PID} \
+-          --mlockall \
+-          --user={{ .Values.conf.ovs_user_name }}
++  # If PID file exists, check to see if we can connect. If it is working then leave
++  # it alone for the admin to terminate the pod to rectify state.(crashbackoff loop)
++  # This allows traffic to keep flowing through the detached process until a maintenance
++  # period for the host. If it is not working, clean up files and start new process.
++  if [[ ! -f ${OVS_PID} ]]; then
++    exec /usr/sbin/ovs-vswitchd unix:${OVS_SOCKET} \
++            -vconsole:emer \
++            -vconsole:err \
++            -vconsole:info \
++            --pidfile=${OVS_PID} \
++            --mlockall \
++            --user={{ .Values.conf.ovs_user_name }}
++  else
++    PID=$(cat ${OVS_PID})
++    if [[ "$(ovs-appctl -T1 -t /run/openvswitch/ovs-vswitchd.${PID}.ctl version)" ]]; then
++      echo "Existing PID and working process PID ${PID}. Waiting for someone to kill me"
++    else
++      if [[ -f /run/openvswitch/ovs-vswitchd.${PID}.ctl ]]; then
++        rm /run/openvswitch/ovs-vswitchd.${PID}.ctl
++      fi
++      rm ${OVS_PID}
++      exec /usr/sbin/ovs-vswitchd unix:${OVS_SOCKET} \
++              -vconsole:emer \
++              -vconsole:err \
++              -vconsole:info \
++              --pidfile=${OVS_PID} \
++              --mlockall \
++              --user={{ .Values.conf.ovs_user_name }}
++    fi
++  fi
+ }
+
+ function stop () {
+@@ -169,6 +196,8 @@ function poststart () {
+   done
+   chown {{ .Values.pod.user.nova.uid }}.{{ .Values.pod.user.nova.uid }} ${OVS_CTL}
+
++  /tmp/openvswitch-nic-init.sh > /var/tmp/openvswitch-nic-init_$(date +%Y%m%d_%H:%M:%S).log 2>&1
++
+ {{- if .Values.conf.poststart.extraCommand }}
+ {{ .Values.conf.poststart.extraCommand | indent 2 }}
+ {{- end }}
+diff --git a/openvswitch/templates/configmap-bin.yaml b/openvswitch/templates/configmap-bin.yaml
+index f6e8dc5..6b05249 100644
+--- a/openvswitch/templates/configmap-bin.yaml
++++ b/openvswitch/templates/configmap-bin.yaml
+@@ -30,4 +30,6 @@ data:
+ {{ tuple "bin/_openvswitch-vswitchd.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
+   openvswitch-vswitchd-init-modules.sh: |
+ {{ tuple "bin/_openvswitch-vswitchd-init-modules.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
++  openvswitch-nic-init.sh: |
++{{ tuple "bin/_openvswitch-nic-init.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
+ {{- end }}
+diff --git a/openvswitch/templates/configmap-etc.yaml b/openvswitch/templates/configmap-etc.yaml
+new file mode 100644
+index 0000000..333c131
+--- /dev/null
++++ b/openvswitch/templates/configmap-etc.yaml
+@@ -0,0 +1,33 @@
++{{/*
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++   http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/}}
++
++{{- define "openvswitch.configmap.etc" }}
++{{- $configMapName := index . 0 }}
++{{- $envAll := index . 1 }}
++{{- with $envAll }}
++
++---
++apiVersion: v1
++kind: Secret
++metadata:
++  name: {{ $configMapName }}
++type: Opaque
++data:
++  ovs.conf: {{ toJson $envAll.Values.conf | b64enc}}
++{{- end }}
++{{- end }}
++
++{{- if .Values.manifests.configmap_etc }}
++{{- list "openvswitch-etc" . | include "openvswitch.configmap.etc" }}
++{{- end }}
+diff --git a/openvswitch/templates/daemonset.yaml b/openvswitch/templates/daemonset.yaml
+index 3a66fa5..7b17fee 100644
+--- a/openvswitch/templates/daemonset.yaml
++++ b/openvswitch/templates/daemonset.yaml
+@@ -54,11 +54,14 @@ exec:
+ {{- end }}
+ {{- end }}
+
+-{{- if .Values.manifests.daemonset }}
+-{{- $envAll := . }}
+
+-{{- $serviceAccountName := "openvswitch-server" }}
+-{{ tuple $envAll "ovs" $serviceAccountName | include "helm-toolkit.snippets.kubernetes_pod_rbac_serviceaccount" }}
++{{- define "openvswitch.server.daemonset" }}
++{{- $daemonset := index . 0 }}
++{{- $configMapName := index . 1 }}
++{{- $serviceAccountName := index . 2 }}
++{{- $envAll := index . 3 }}
++{{- with $envAll }}
++
+ ---
+ apiVersion: apps/v1
+ kind: DaemonSet
+@@ -67,21 +70,22 @@ metadata:
+   annotations:
+     {{ tuple $envAll | include "helm-toolkit.snippets.release_uuid" }}
+   labels:
+-{{ tuple $envAll "openvswitch" "server" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
++{{ tuple $envAll .Chart.Name $daemonset | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
+ spec:
+   selector:
+     matchLabels:
+-{{ tuple $envAll "openvswitch" "server" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 6 }}
++{{ tuple $envAll .Chart.Name $daemonset | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 6 }}
+ {{ tuple $envAll "ovs" | include "helm-toolkit.snippets.kubernetes_upgrades_daemonset" | indent 2 }}
+   template:
+     metadata:
+       labels:
+-{{ tuple $envAll "openvswitch" "server" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
++{{ tuple $envAll .Chart.Name $daemonset | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+       annotations:
+ {{ tuple $envAll | include "helm-toolkit.snippets.release_uuid" | indent 8 }}
+         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "helm-toolkit.utils.hash" }}
+ {{ dict "envAll" $envAll "podName" "openvswitch" "containerNames" (list "openvswitch-db" "openvswitch-db-perms" "openvswitch-vswitchd" "openvswitch-vswitchd-modules" "init") | include "helm-toolkit.snippets.kubernetes_mandatory_access_control_annotation" | indent 8 }}
+     spec:
++      priorityClassName: platform
+       shareProcessNamespace: true
+       serviceAccountName: {{ $serviceAccountName }}
+ {{ dict "envAll" $envAll "application" "ovs" | include "helm-toolkit.snippets.kubernetes_pod_security_context" | indent 6 }}
+@@ -193,6 +202,8 @@ It should be handled through lcore and pmd core masks. */}}
+                   - /tmp/openvswitch-vswitchd.sh
+                   - stop
+           volumeMounts:
++            - name: var-tmp
++              mountPath: /var/tmp
+             - name: pod-tmp
+               mountPath: /tmp
+             - name: openvswitch-bin
+@@ -201,6 +212,14 @@ It should be handled through lcore and pmd core masks. */}}
+               readOnly: true
+             - name: run
+               mountPath: /run
++            - name: openvswitch-bin
++              mountPath: /tmp/openvswitch-nic-init.sh
++              subPath: openvswitch-nic-init.sh
++              readOnly: true
++            - name: openvswitch-etc
++              mountPath: /tmp/ovs.conf
++              subPath: ovs.conf
++              readOnly: true
+ {{- if .Values.conf.ovs_dpdk.enabled }}
+             - name: hugepages
+               mountPath: {{ .Values.conf.ovs_dpdk.hugepages_mountpath | quote }}
+@@ -220,6 +239,10 @@ It should be handled through lcore and pmd core masks. */}}
+               mountPath: /sys/fs/cgroup
+ {{- end }}
+       volumes:
++        - name: var-tmp
++          hostPath:
++            path: /var/tmp
++            type: DirectoryOrCreate
+         - name: pod-tmp
+           emptyDir: {}
+         - name: openvswitch-bin
+@@ -238,6 +261,10 @@ It should be handled through lcore and pmd core masks. */}}
+           hostPath:
+             path: /
+             type: Directory
++        - name: openvswitch-etc
++          secret:
++            secretName: {{ $configMapName }}
++            defaultMode: 0444
+ {{- if .Values.conf.ovs_dpdk.enabled }}
+         - name: devs
+           hostPath:
+@@ -271,4 +298,16 @@ It should be handled through lcore and pmd core masks. */}}
+           hostPath:
+             path: /sys/fs/cgroup
+ {{- end }}
+-{{- end }}
+\ No newline at end of file
++{{- end }}
++{{- end }}
++
++{{- if .Values.manifests.daemonset }}
++{{- $envAll := . }}
++{{- $daemonset := "server" }}
++{{- $configMapName := "openvswitch-etc" }}
++{{- $serviceAccountName := "openvswitch-server" }}
++{{ tuple $envAll "ovs" $serviceAccountName | include "helm-toolkit.snippets.kubernetes_pod_rbac_serviceaccount" }}
++{{- $daemonset_yaml := list $daemonset $configMapName $serviceAccountName . | include "openvswitch.server.daemonset" | toString | fromYaml }}
++{{- $configmap_yaml := "openvswitch.configmap.etc" }}
++{{- list $daemonset $daemonset_yaml $configmap_yaml $configMapName . | include "helm-toolkit.utils.daemonset_overrides" }}
++{{- end }}
+diff --git a/openvswitch/values.yaml b/openvswitch/values.yaml
+index 5555b60f..43b6dd4b 100644
+--- a/openvswitch/values.yaml
++++ b/openvswitch/values.yaml
+@@ -140,7 +140,7 @@ pod:
+         limits:
+           memory: "1024Mi"
+           cpu: "2000m"
+-  user:
++  user: &pod_users
+     nova:
+       uid: 42424
+
+@@ -203,6 +203,7 @@ dependencies:
+
+ manifests:
+   configmap_bin: true
++  configmap_etc: true
+   daemonset: true
+   daemonset_ovs_vswitchd: true
+   job_image_repo_sync: true
+@@ -241,6 +241,81 @@ conf:
+     #     vHost IOMMU feature restricts the vhost memory that a virtio device
+     #     access, available with DPDK v17.11
+     # vhost_iommu_support: true
++    # setting update_dpdk_bond_config to true will have default behavior,
++    # which may cause disruptions in ovs dpdk traffic in case of neutron
++    # ovs agent restart or when dpdk nic/bond configurations are changed.
++    # Setting this to false will configure dpdk in the first run and
++    # disable nic/bond config on event of restart or config update.
++    update_dpdk_bond_config: true
++    driver: uio_pci_generic
++    # In case bonds are configured, the nics which are part of those bonds
++    # must NOT be provided here.
++    # nics: [] # to zero out this attribute for DPDK bonds
++    nics:
++      - name: dpdk0
++        pci_id: '0000:05:00.0'
++        # Set VF Index in case some particular VF(s) need to be
++        # used with ovs-dpdk.
++        # vf_index: 0
++        bridge: br-phy
++        migrate_ip: true
++        n_rxq: 2
++        n_txq: 2
++        pmd_rxq_affinity: "0:3,1:27"
++        ofport_request: 1
++        # optional parameters for tuning the OVS DPDK config
++        # in alignment with the available hardware resources
++        # mtu: 2000
++        # n_rxq_size: 1024
++        # n_txq_size: 1024
++        # vhost_iommu_support: true
++    bridges:
++      - name: br-ex
++      # optional parameter, in case tunnel traffic needs to be transported over a vlan underlay
++      # - tunnel_underlay_vlan: 45
++    # Optional parameter for configuring bonding in OVS-DPDK
++    #   - name: br-phy-bond0
++    # bonds:
++    #   - name: dpdkbond0
++    #     bridge: br-phy-bond0
++    #     # The IP from the first nic in nics list shall be used
++    #     migrate_ip: true
++    #     mtu: 2000
++    #     # Please note that n_rxq is set for each NIC individually
++    #     # rather than denoting the total number of rx queues for
++    #     # the bond as a whole. So setting n_rxq = 2 below for ex.
++    #     # would be 4 rx queues in total for the bond.
++    #     # Same for n_txq
++    #     n_rxq: 2
++    #     n_txq: 2
++    #     ofport_request: 1
++    #     n_rxq_size: 1024
++    #     n_txq_size: 1024
++    #     vhost-iommu-support: true
++    #     ovs_options: "bond_mode=active-backup"
++    #     nics:
++    #       - name: dpdk_b0s0
++    #         pci_id: '0000:06:00.0'
++    #         pmd_rxq_affinity: "0:3,1:27"
++    #         # Set VF Index in case some particular VF(s) need to be
++    #         # used with ovs-dpdk. In which case pci_id of PF must be
++    #         # provided above.
++    #         # vf_index: 0
++    #       - name: dpdk_b0s1
++    #         pci_id: '0000:07:00.0'
++    #         pmd_rxq_affinity: "0:3,1:27"
++    #         # Set VF Index in case some particular VF(s) need to be
++    #         # used with ovs-dpdk. In which case pci_id of PF must be
++    #         # provided above.
++    #         # vf_index: 0
++    #
++    # Set the log level for each target module (default level is always dbg)
++    # Supported log levels are: off, emer, err, warn, info, dbg
++    #
++    # modules:
++    #   - name: dpdk
++    #     log_level: info
++  user: *pod_users
+
+   ## OVS supports run in non-root for both OVS and OVS DPDK mode, you can
+   # optionally specify to use user with id 42424, ensure the user exists


### PR DESCRIPTION
This PR is to move the NIC initialization from neutron init scripts to openvswitch.  My PR https://github.com/vexxhost/atmosphere/pull/773 introduced a race condition between neutron-ovn-metadata-agent and ovn-controller daemonsets, where ovn-controller was waiting on metadata to initialize the bridge interface br-ex and neutron-ovn-metadata was waiting on ovn-controller.. 

moved the NIC/BOND initialization stuff from neutron to the openvswitch helm charts.  This is important for environments using DPDK, OVN/OpenVswitch deployments.