### PR TITLE
docs/glance: Fix typo in image_format section name for cinder backend

### DIFF
--- a/doc/source/deploy/glance.rst
+++ b/doc/source/deploy/glance.rst
@@ -33,7 +33,7 @@ managing images as block storage volumes, apply the following configuration:
           glance_store:
             stores: cinder
             default_store: cinder
-          image_formats:
+          image_format:
             disk_formats: raw
 
 This configuration sets Cinder as the default and only storage backend for


### PR DESCRIPTION
https://docs.openstack.org/glance/latest/configuration/glance_api.html#image_format