### PR TITLE
Ignore ansible-lint warnings about storpool files and zuul.d dir

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -8,6 +8,8 @@ exclude_paths:
   - plugins/filter
   - roles/defaults/vars/main.yml
   - roles/kube_prometheus_stack/files/jsonnet
+  - roles/storpool_csi/files
+  - zuul.d
 
 mock_roles:
   - opendev.container_registry

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -45,6 +45,7 @@ build_ignore:
   - .flake8
   - .gitignore
   - .markdownlint.yaml
+  - .mypy_cache
   - .pre-commit-config.yaml
   - .python-version
   - .release-please-manifest.json


### PR DESCRIPTION
Also don't add .mypy_cache to galaxy builds (58% of disk usage or 54MB uncompressed).