### PR TITLE
feat: trust private acme CA

### DIFF
--- a/roles/cluster_issuer/defaults/main.yml
+++ b/roles/cluster_issuer/defaults/main.yml
@@ -15,6 +15,8 @@
 cluster_issuer_name: "{{ atmosphere_ingress_cluster_issuer }}"
 cluster_issuer_type: acme
 
+cluster_issuer_acme_private_ca: false
+
 cluster_issuer_acme_server: https://acme-v02.api.letsencrypt.org/directory
 # cluster_issuer_acme_email:
 cluster_issuer_acme_private_key_secret_name: cert-manager-issuer-account-key

--- a/roles/cluster_issuer/tasks/main.yml
+++ b/roles/cluster_issuer/tasks/main.yml
@@ -27,15 +27,13 @@
   ansible.builtin.include_tasks: "type/{{ cluster_issuer_type }}/main.yml"
 
 - name: Bootstrap PKI
-  when: cluster_issuer_type in ("self-signed", "ca") or cluster_issuer_acme_private_ca | bool
+  when: cluster_issuer_type in ("self-signed", "ca")
   block:
     - name: Wait till the secret is created
       kubernetes.core.k8s_info:
         api_version: v1
         kind: Secret
-        name: "{{ (cluster_issuer_self_signed_secret_name if cluster_issuer_type == 'self-signed')
-              or
-              (cluster_issuer_ca_secret_name if cluster_issuer_type == 'ca' else cluster_issuer_name) }}"
+        name: "{{ (cluster_issuer_type == 'self-signed') | ternary(cluster_issuer_self_signed_secret_name, cluster_issuer_ca_secret_name) }}"
         namespace: cert-manager
         wait: true
         wait_sleep: 1

--- a/roles/cluster_issuer/tasks/main.yml
+++ b/roles/cluster_issuer/tasks/main.yml
@@ -27,13 +27,15 @@
   ansible.builtin.include_tasks: "type/{{ cluster_issuer_type }}/main.yml"
 
 - name: Bootstrap PKI
-  when: (cluster_issuer_type in ("self-signed", "ca") or cluster_issuer_acme_private_ca | bool
+  when: cluster_issuer_type in ("self-signed", "ca") or cluster_issuer_acme_private_ca | bool
   block:
     - name: Wait till the secret is created
       kubernetes.core.k8s_info:
         api_version: v1
         kind: Secret
-        name: "{{ (cluster_issuer_type == 'self-signed') | ternary(cluster_issuer_self_signed_secret_name, cluster_issuer_ca_secret_name) else cluster_issuer_name }}"
+        name: "{{ (cluster_issuer_self_signed_secret_name if cluster_issuer_type == 'self-signed')
+              or
+              (cluster_issuer_ca_secret_name if cluster_issuer_type == 'ca' else cluster_issuer_name) }}"
         namespace: cert-manager
         wait: true
         wait_sleep: 1

--- a/roles/cluster_issuer/tasks/main.yml
+++ b/roles/cluster_issuer/tasks/main.yml
@@ -27,13 +27,13 @@
   ansible.builtin.include_tasks: "type/{{ cluster_issuer_type }}/main.yml"
 
 - name: Bootstrap PKI
-  when: cluster_issuer_type in ("self-signed", "ca")
+  when: (cluster_issuer_type in ("self-signed", "ca") or cluster_issuer_acme_private_ca | bool
   block:
     - name: Wait till the secret is created
       kubernetes.core.k8s_info:
         api_version: v1
         kind: Secret
-        name: "{{ (cluster_issuer_type == 'self-signed') | ternary(cluster_issuer_self_signed_secret_name, cluster_issuer_ca_secret_name) }}"
+        name: "{{ (cluster_issuer_type == 'self-signed') | ternary(cluster_issuer_self_signed_secret_name, cluster_issuer_ca_secret_name) else cluster_issuer_name }}"
         namespace: cert-manager
         wait: true
         wait_sleep: 1

--- a/roles/openstack_cli/templates/atmosphere.sh.j2
+++ b/roles/openstack_cli/templates/atmosphere.sh.j2
@@ -1,9 +1,13 @@
 alias osc='nerdctl run --rm --network host \
       --volume $PWD:/opt --volume /tmp:/tmp \
       --volume /etc/openstack:/etc/openstack:ro \
-{% if (cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca')) or (cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool) %}
+{% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca') %}
       --volume {{ '/usr/local/share/ca-certificates/atmosphere.crt:/usr/local/share/ca-certificates/atmosphere.crt:ro' if ansible_facts['os_family']
-      in ['Debian'] else '/etc/pki/ca-trust/source/anchors/atmosphere.crt:/etc/pki/ca-trust/source/anchors/atmosphere.crt:ro' }} \
+      in ['Debian'] else '/etc/pki/ca-trust/source/anchors/atmosphere.crt:/usr/local/share/ca-certificates/atmosphere.crt:ro' }} \
+{% endif %}
+{% if cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
+      --volume {{ '/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro' if ansible_facts['os_family']
+      in ['Debian'] else '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt:/etc/ssl/certs/ca-certificates.crt:ro' }} \
 {% endif %}
       --env-file <(env | grep OS_) \
       {{ atmosphere_images['openstack_cli'] }}'

--- a/roles/openstack_cli/templates/atmosphere.sh.j2
+++ b/roles/openstack_cli/templates/atmosphere.sh.j2
@@ -4,8 +4,7 @@ alias osc='nerdctl run --rm --network host \
 {% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca') %}
       --volume {{ '/usr/local/share/ca-certificates/atmosphere.crt:/usr/local/share/ca-certificates/atmosphere.crt:ro' if ansible_facts['os_family']
       in ['Debian'] else '/etc/pki/ca-trust/source/anchors/atmosphere.crt:/usr/local/share/ca-certificates/atmosphere.crt:ro' }} \
-{% endif %}
-{% if cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
+{% elif cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
       --volume {{ '/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro' if ansible_facts['os_family']
       in ['Debian'] else '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt:/etc/ssl/certs/ca-certificates.crt:ro' }} \
 {% endif %}

--- a/roles/openstack_cli/templates/atmosphere.sh.j2
+++ b/roles/openstack_cli/templates/atmosphere.sh.j2
@@ -1,7 +1,7 @@
 alias osc='nerdctl run --rm --network host \
       --volume $PWD:/opt --volume /tmp:/tmp \
       --volume /etc/openstack:/etc/openstack:ro \
-{% if (cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca')) or cluster_issuer_acme_private_ca | bool %}
+{% if (cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca')) or (cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool) %}
       --volume {{ '/usr/local/share/ca-certificates/atmosphere.crt:/usr/local/share/ca-certificates/atmosphere.crt:ro' if ansible_facts['os_family']
       in ['Debian'] else '/etc/pki/ca-trust/source/anchors/atmosphere.crt:/etc/pki/ca-trust/source/anchors/atmosphere.crt:ro' }} \
 {% endif %}

--- a/roles/openstack_cli/templates/atmosphere.sh.j2
+++ b/roles/openstack_cli/templates/atmosphere.sh.j2
@@ -1,7 +1,7 @@
 alias osc='nerdctl run --rm --network host \
       --volume $PWD:/opt --volume /tmp:/tmp \
       --volume /etc/openstack:/etc/openstack:ro \
-{% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca') %}
+{% if (cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca')) or cluster_issuer_acme_private_ca | bool %}
       --volume {{ '/usr/local/share/ca-certificates/atmosphere.crt:/usr/local/share/ca-certificates/atmosphere.crt:ro' if ansible_facts['os_family']
       in ['Debian'] else '/etc/pki/ca-trust/source/anchors/atmosphere.crt:/etc/pki/ca-trust/source/anchors/atmosphere.crt:ro' }} \
 {% endif %}

--- a/roles/openstack_cli/templates/openrc.j2
+++ b/roles/openstack_cli/templates/openrc.j2
@@ -11,6 +11,9 @@ export OS_PASSWORD="{{ openstack_helm_endpoints['identity']['auth']['admin']['pa
 export OS_PROJECT_DOMAIN_NAME=Default
 export OS_PROJECT_NAME=admin
 
-{% if (cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca')) or (cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool) %}
-export OS_CACERT={{ '/usr/local/share/ca-certificates' if ansible_facts['os_family'] in ['Debian'] else '/etc/pki/ca-trust/source/anchors' }}/atmosphere.crt
+{% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca') %}
+export OS_CACERT=/usr/local/share/ca-certificates/atmosphere.crt
+{% endif %}
+{% if cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
+export OS_CACERT=/etc/ssl/certs/ca-certificates.crt
 {% endif %}

--- a/roles/openstack_cli/templates/openrc.j2
+++ b/roles/openstack_cli/templates/openrc.j2
@@ -11,6 +11,6 @@ export OS_PASSWORD="{{ openstack_helm_endpoints['identity']['auth']['admin']['pa
 export OS_PROJECT_DOMAIN_NAME=Default
 export OS_PROJECT_NAME=admin
 
-{% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca') %}
+{% if (cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca')) or cluster_issuer_acme_private_ca | bool %}
 export OS_CACERT={{ '/usr/local/share/ca-certificates' if ansible_facts['os_family'] in ['Debian'] else '/etc/pki/ca-trust/source/anchors' }}/atmosphere.crt
 {% endif %}

--- a/roles/openstack_cli/templates/openrc.j2
+++ b/roles/openstack_cli/templates/openrc.j2
@@ -13,7 +13,6 @@ export OS_PROJECT_NAME=admin
 
 {% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca') %}
 export OS_CACERT=/usr/local/share/ca-certificates/atmosphere.crt
-{% endif %}
-{% if cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
+{% elif cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
 export OS_CACERT=/etc/ssl/certs/ca-certificates.crt
 {% endif %}

--- a/roles/openstack_cli/templates/openrc.j2
+++ b/roles/openstack_cli/templates/openrc.j2
@@ -11,6 +11,6 @@ export OS_PASSWORD="{{ openstack_helm_endpoints['identity']['auth']['admin']['pa
 export OS_PROJECT_DOMAIN_NAME=Default
 export OS_PROJECT_NAME=admin
 
-{% if (cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca')) or cluster_issuer_acme_private_ca | bool %}
+{% if (cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca')) or (cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool) %}
 export OS_CACERT={{ '/usr/local/share/ca-certificates' if ansible_facts['os_family'] in ['Debian'] else '/etc/pki/ca-trust/source/anchors' }}/atmosphere.crt
 {% endif %}

--- a/roles/openstacksdk/templates/clouds.yaml.j2
+++ b/roles/openstacksdk/templates/clouds.yaml.j2
@@ -10,7 +10,6 @@ clouds:
     region_name: "{{ openstack_helm_endpoints_keystone_region_name }}"
 {% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca') %}
     cacert: "/usr/local/share/ca-certificates/atmosphere.crt"
-{% endif %}
-{% if cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
+{% elif cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
     cacert: "/etc/ssl/certs/ca-certificates.crt"
 {% endif %}

--- a/roles/openstacksdk/templates/clouds.yaml.j2
+++ b/roles/openstacksdk/templates/clouds.yaml.j2
@@ -8,6 +8,6 @@ clouds:
       user_domain_name: Default
       project_domain_name: Default
     region_name: "{{ openstack_helm_endpoints_keystone_region_name }}"
-{% if (cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca')) or cluster_issuer_acme_private_ca | bool %}
+{% if (cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca')) or (cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool) %}
     cacert: "{{ '/usr/local/share/ca-certificates' if ansible_facts['os_family'] in ['Debian'] else '/etc/pki/ca-trust/source/anchors' }}/atmosphere.crt"
 {% endif %}

--- a/roles/openstacksdk/templates/clouds.yaml.j2
+++ b/roles/openstacksdk/templates/clouds.yaml.j2
@@ -8,6 +8,6 @@ clouds:
       user_domain_name: Default
       project_domain_name: Default
     region_name: "{{ openstack_helm_endpoints_keystone_region_name }}"
-{% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca') %}
+{% if (cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca')) or cluster_issuer_acme_private_ca | bool %}
     cacert: "{{ '/usr/local/share/ca-certificates' if ansible_facts['os_family'] in ['Debian'] else '/etc/pki/ca-trust/source/anchors' }}/atmosphere.crt"
 {% endif %}

--- a/roles/openstacksdk/templates/clouds.yaml.j2
+++ b/roles/openstacksdk/templates/clouds.yaml.j2
@@ -8,6 +8,9 @@ clouds:
       user_domain_name: Default
       project_domain_name: Default
     region_name: "{{ openstack_helm_endpoints_keystone_region_name }}"
-{% if (cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca')) or (cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool) %}
-    cacert: "{{ '/usr/local/share/ca-certificates' if ansible_facts['os_family'] in ['Debian'] else '/etc/pki/ca-trust/source/anchors' }}/atmosphere.crt"
+{% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca') %}
+    cacert: "/usr/local/share/ca-certificates/atmosphere.crt"
+{% endif %}
+{% if cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
+    cacert: "/etc/ssl/certs/ca-certificates.crt"
 {% endif %}


### PR DESCRIPTION
Related: https://github.com/vexxhost/atmosphere/issues/1185

We disscused with @mpiscaer on Slack about the reason why this happens and found that such a configuration was not foreseen.

Mounting whole directory like here: https://github.com/vexxhost/ansible-collection-kubernetes/blob/main/roles/cert_manager/vars/main.yml#L21 is a bad idea because on EL distros this host path doesn't exist.