### PR TITLE
[ATMOSPHERE-362] generate_workspace: Set mgr/cephadm/warn_on_stray_daemons to false

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -26,3 +26,8 @@
 - import_playbook: vexxhost.ceph.site
   vars:
     containerd_pause_image: "{{ atmosphere_images['pause'] }}"
+    ceph_conf_overrides:
+      # Avoid HEALTH_WARN state due to daemons deployed by rook-ceph outside of cephadm (e.g. rgw)
+      - section: mgr
+        option: mgr cephadm warn_on_stray_daemons
+        value: false

--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -26,8 +26,3 @@
 - import_playbook: vexxhost.ceph.site
   vars:
     containerd_pause_image: "{{ atmosphere_images['pause'] }}"
-    ceph_conf_overrides:
-      # Avoid HEALTH_WARN state due to daemons deployed by rook-ceph outside of cephadm (e.g. rgw)
-      - section: mgr
-        option: mgr cephadm warn_on_stray_daemons
-        value: false

--- a/roles/rook_ceph_cluster/tasks/main.yml
+++ b/roles/rook_ceph_cluster/tasks/main.yml
@@ -12,6 +12,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+# (rlin) This is because rgw will be managed by rook operator. We need to mute
+# CEPHADM_STRAY_DAEMON until we have all daemon managed by cephadm
+- name: Set mgr/cephadm/warn_on_stray_daemons to false
+  run_once: true
+  delegate_to: "{{ groups[rook_ceph_cluster_mon_group][0] }}"
+  ansible.builtin.command: cephadm shell -- ceph config set mgr mgr/cephadm/warn_on_stray_daemons false
+  failed_when: false
+  changed_when: false
+
 - name: Collect "ceph quorum_status" output from a monitor
   run_once: true
   delegate_to: "{{ groups[rook_ceph_cluster_mon_group][0] }}"

--- a/roles/rook_ceph_cluster/tasks/main.yml
+++ b/roles/rook_ceph_cluster/tasks/main.yml
@@ -12,15 +12,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-# (rlin) This is because rgw will be managed by rook operator. We need to mute
-# CEPHADM_STRAY_DAEMON until we have all daemon managed by cephadm
-- name: Mute CEPHADM_STRAY_DAEMON warning
-  run_once: true
-  delegate_to: "{{ groups[rook_ceph_cluster_mon_group][0] }}"
-  ansible.builtin.command: cephadm shell -- ceph health mute CEPHADM_STRAY_DAEMON
-  failed_when: false
-  changed_when: false
-
 - name: Collect "ceph quorum_status" output from a monitor
   run_once: true
   delegate_to: "{{ groups[rook_ceph_cluster_mon_group][0] }}"


### PR DESCRIPTION
When rook-ceph deploys daemon outside of cephadm purview, cephadm will trigger a warning about stray daemons, putting the cluster in HEALTH_WARN state.

https://docs.ceph.com/en/latest/cephadm/operations/#cephadm-stray-daemon
