### PR TITLE
fix: allow ssh login for nova user in nova-ssh image

### DIFF
--- a/zuul.d/container-images/nova-ssh.yaml
+++ b/zuul.d/container-images/nova-ssh.yaml
@@ -46,6 +46,7 @@
           build_args:
             - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=nova
+            - SHELL=/bin/bash
           tags:
             - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files


### PR DESCRIPTION
nologin avoids ssh connection between noova-computes which is required for live migrations.

fix https://github.com/vexxhost/atmosphere/issues/1245