### PR TITLE
Align horizon chart

### DIFF
--- a/.charts.yml
+++ b/.charts.yml
@@ -70,7 +70,7 @@ charts:
         review.opendev.org:
           - 899931
   - name: horizon
-    version: 0.3.15
+    version: 0.3.22
     repository: *openstack_helm_repository
     dependencies: *openstack_helm_dependencies
     patches:

--- a/charts/horizon/Chart.yaml
+++ b/charts/horizon/Chart.yaml
@@ -9,4 +9,4 @@ name: horizon
 sources:
 - https://opendev.org/openstack/horizon
 - https://opendev.org/openstack/openstack-helm
-version: 0.3.15
+version: 0.3.22

--- a/charts/horizon/templates/bin/_db-sync.sh.tpl
+++ b/charts/horizon/templates/bin/_db-sync.sh.tpl
@@ -16,7 +16,7 @@ limitations under the License.
 
 set -ex
 
-SITE_PACKAGES_ROOT=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+SITE_PACKAGES_ROOT=$(python -c "from sysconfig import get_path; print(get_path('platlib'))")
 rm -f ${SITE_PACKAGES_ROOT}/openstack_dashboard/local/local_settings.py
 ln -s /etc/openstack-dashboard/local_settings ${SITE_PACKAGES_ROOT}/openstack_dashboard/local/local_settings.py
 

--- a/charts/horizon/templates/bin/_django.wsgi.tpl
+++ b/charts/horizon/templates/bin/_django.wsgi.tpl
@@ -22,6 +22,8 @@ import os
 import sys
 
 import pymysql
+
+pymysql.version_info = (2, 2, 4, 'final', 0)
 pymysql.install_as_MySQLdb()
 
 from django.core.wsgi import get_wsgi_application

--- a/charts/horizon/templates/bin/_horizon.sh.tpl
+++ b/charts/horizon/templates/bin/_horizon.sh.tpl
@@ -18,7 +18,7 @@ set -ex
 COMMAND="${@:-start}"
 
 function start () {
-  SITE_PACKAGES_ROOT=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+  SITE_PACKAGES_ROOT=$(python -c "from sysconfig import get_path; print(get_path('platlib'))")
   rm -f ${SITE_PACKAGES_ROOT}/openstack_dashboard/local/local_settings.py
   ln -s /etc/openstack-dashboard/local_settings ${SITE_PACKAGES_ROOT}/openstack_dashboard/local/local_settings.py
   ln -s  ${SITE_PACKAGES_ROOT}/openstack_dashboard/conf/default_policies  /etc/openstack-dashboard/default_policies

--- a/charts/horizon/templates/bin/_manage.py.tpl
+++ b/charts/horizon/templates/bin/_manage.py.tpl
@@ -23,6 +23,7 @@ import os
 import sys
 
 import pymysql
+pymysql.version_info = (2, 2, 4, 'final', 0)
 pymysql.install_as_MySQLdb()
 
 from django.core.management import execute_from_command_line


### PR DESCRIPTION
- Update pymysql version info. Horizon requiers newer mysql client version than we had previously
- Update scripts to use sysconfig.get_path instead of distutils.sysconfig.get_python_lib which is deprecated

reference: https://review.opendev.org/c/openstack/openstack-helm/+/919778