### PR TITLE
Add rebuild time for images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/build/manage-dockerfile.py
+++ b/build/manage-dockerfile.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import pathlib
+from datetime import datetime
+
+
+def update_dockerfile(dockerfile, timestamp):
+    rebuild_line = f"# Atmosphere-Rebuild-Time: {timestamp}"
+
+    lines = dockerfile.read_text().splitlines()
+    new_lines = []
+    rebuild_line_found = False
+
+    for line in lines:
+        if line.startswith("# Atmosphere-Rebuild-Time: "):
+            new_lines.append(rebuild_line)
+            rebuild_line_found = True
+        else:
+            new_lines.append(line)
+
+    if not rebuild_line_found:
+        new_lines.insert(1, rebuild_line)  # Insert after SPDX line
+
+    dockerfile.write_text("\n".join(new_lines) + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rebuild", action="store_true")
+    parser.add_argument(
+        "dockerfiles", type=pathlib.Path, nargs="+", help="List of Dockerfiles"
+    )
+    args = parser.parse_args()
+
+    if args.rebuild:
+        now_utc = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        for dockerfile in args.dockerfiles:
+            update_dockerfile(dockerfile, now_utc)
+
+
+if __name__ == "__main__":
+    main()

--- a/images/barbican/Dockerfile
+++ b/images/barbican/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/cinder/Dockerfile
+++ b/images/cinder/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/cluster-api-provider-openstack/Dockerfile
+++ b/images/cluster-api-provider-openstack/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 FROM alpine/git:2.43.0 AS src
 ARG CAPO_VERSION=v0.9.0

--- a/images/designate/Dockerfile
+++ b/images/designate/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/glance/Dockerfile
+++ b/images/glance/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/heat/Dockerfile
+++ b/images/heat/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/horizon/Dockerfile
+++ b/images/horizon/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/ironic/Dockerfile
+++ b/images/ironic/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/keepalived/Dockerfile
+++ b/images/keepalived/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/keystone/Dockerfile
+++ b/images/keystone/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/kubernetes-entrypoint/Dockerfile
+++ b/images/kubernetes-entrypoint/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 FROM golang:1.21 AS build
 ARG KUBERNETES_ENTRYPOINT_GIT_REF=4fbcf7ce324dc66e78480f73035e31434cfea1e8

--- a/images/libvirtd/Dockerfile
+++ b/images/libvirtd/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/magnum/Dockerfile
+++ b/images/magnum/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/manila/Dockerfile
+++ b/images/manila/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/netoffload/Dockerfile
+++ b/images/netoffload/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/neutron/Dockerfile
+++ b/images/neutron/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/nova-ssh/Dockerfile
+++ b/images/nova-ssh/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/nova/Dockerfile
+++ b/images/nova/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/octavia/Dockerfile
+++ b/images/octavia/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/openstack-runtime/Dockerfile
+++ b/images/openstack-runtime/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/openstack-venv-builder/Dockerfile
+++ b/images/openstack-venv-builder/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/openvswitch/Dockerfile
+++ b/images/openvswitch/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 FROM quay.io/centos/centos:stream9
 ARG OVS_SERIES=3.2

--- a/images/ovn/Dockerfile
+++ b/images/ovn/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/placement/Dockerfile
+++ b/images/placement/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/python-base/Dockerfile
+++ b/images/python-base/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/python-openstackclient/Dockerfile
+++ b/images/python-openstackclient/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/staffeln/Dockerfile
+++ b/images/staffeln/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/tempest/Dockerfile
+++ b/images/tempest/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/ubuntu-cloud-archive/Dockerfile
+++ b/images/ubuntu-cloud-archive/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 ARG RELEASE
 

--- a/images/ubuntu/Dockerfile
+++ b/images/ubuntu/Dockerfile
@@ -1,16 +1,5 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# Atmosphere-Rebuild-Time: 2024-05-30T20:29:01Z
 
 FROM ubuntu:jammy-20240227
 LABEL org.opencontainers.image.source=https://github.com/vexxhost/atmosphere


### PR DESCRIPTION
If we want to rebuild all images for security reasons or when
branching a new version of OpenStack, we need to be able to
rebuild all images.  Doing this change in the job definition
is not enough to cause the promotion to happen.

This adds a tool that can modify the file by passing a Dockerfile
or many to it.

Depends-On: https://github.com/vexxhost/atmosphere/pull/1264
