### PR TITLE
Enable allowSnippetAnnotations for ingress

### DIFF
--- a/roles/ingress_nginx/vars/main.yml
+++ b/roles/ingress_nginx/vars/main.yml
@@ -22,6 +22,7 @@ _ingress_nginx_helm_values:
     config:
       proxy-buffer-size: 16k
     dnsPolicy: ClusterFirstWithHostNet
+    allowSnippetAnnotations: true
     hostNetwork: true
     ingressClassResource:
       name: "{{ atmosphere_ingress_class_name }}"


### PR DESCRIPTION
The newer versions of the Ingress flip it to false

Related-To: https://github.com/vexxhost/atmosphere/issues/1282
Related-To: https://github.com/vexxhost/atmosphere/pull/1308
