### PR TITLE
ipmi-exporter: Add ability to specify imagePullSecrets

### DIFF
--- a/roles/ipmi_exporter/defaults/main.yml
+++ b/roles/ipmi_exporter/defaults/main.yml
@@ -44,3 +44,6 @@ ipmi_exporter_config:
         - 185 # Entity Presence (Dell PowerEdge servers)
 
                                                                    # ]]]
+# Container registry credentials (https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry)
+#ipmi_exporter_imagepullsecrets:
+#  - name: regcred

--- a/roles/ipmi_exporter/tasks/main.yml
+++ b/roles/ipmi_exporter/tasks/main.yml
@@ -45,6 +45,7 @@
                 application: ipmi-exporter
                 job: ipmi
             spec:
+              imagePullSecrets: "{{ ipmi_exporter_imagepullsecrets if ipmi_exporter_imagepullsecrets is defined else [] }}"
               containers:
                 - name: exporter
                   image: "{{ atmosphere_images['prometheus_ipmi_exporter'] | vexxhost.kubernetes.docker_image('ref') }}"


### PR DESCRIPTION
Quick fix to add imagePullSecrets. Proper fix is to turn this into a helm chart.