### PR TITLE
openstack-exporter: Add ability to specify imagePullSecrets

### DIFF
--- a/roles/openstack_exporter/defaults/main.yml
+++ b/roles/openstack_exporter/defaults/main.yml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) VEXXHOST, Inc.
+
+#openstack_exporter_imagepullsecrets:
+#  - name: regcred

--- a/roles/openstack_exporter/tasks/main.yml
+++ b/roles/openstack_exporter/tasks/main.yml
@@ -33,6 +33,7 @@
               labels:
                 application: openstack-exporter
             spec:
+              imagePullSecrets: "{{ openstack_exporter_imagepullsecrets if openstack_exporter_imagepullsecrets is defined else [] }}"
               nodeSelector:
                 openstack-control-plane: enabled
               initContainers:


### PR DESCRIPTION
Quick fix to add imagePullSecrets. Proper fix is to turn this into a helm chart.