### PR TITLE
[stable/2023.1] Bump Neutron version

### DIFF
--- a/images/neutron/Dockerfile
+++ b/images/neutron/Dockerfile
@@ -4,7 +4,7 @@
 ARG RELEASE
 
 FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
-ARG NEUTRON_GIT_REF=ce2560f23f133a550a5d56e784cc9c1eaa0006ca
+ARG NEUTRON_GIT_REF=0c9735dfa92ba7ed0694f4b50356959fa4a145f6
 ADD --keep-git-dir=true https://opendev.org/openstack/neutron.git#${NEUTRON_GIT_REF} /src/neutron
 RUN git -C /src/neutron fetch --unshallow
 ADD --keep-git-dir=true https://opendev.org/openstack/neutron-vpnaas.git#stable/2023.1 /src/neutron-vpnaas


### PR DESCRIPTION
This is to bring in the OVN FIP gateway_port support fix.
