### PR TITLE
fix: neutron designate integration

### DIFF
--- a/roles/neutron/tasks/main.yml
+++ b/roles/neutron/tasks/main.yml
@@ -12,6 +12,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Set external_dns_driver
+  ansible.builtin.set_fact:
+    _neutron_external_dns_driver: "designate"
+  when: neutron_designate_integration_enabled | bool
+
 - name: Generate Helm values
   ansible.builtin.set_fact:
     _neutron_helm_values: "{{ __neutron_helm_values }}"
@@ -20,11 +25,6 @@
   when: atmosphere_network_backend == 'ovn'
   ansible.builtin.set_fact:
     _neutron_helm_values: "{{ _neutron_helm_values | combine(__neutron_ovn_helm_values, recursive=True) }}"
-
-- name: Set external_dns_driver
-  ansible.builtin.set_fact:
-    _neutron_external_dns_driver: "designate"
-  when: neutron_designate_integration_enabled | bool
 
 - name: Deploy Helm chart
   run_once: true

--- a/roles/neutron/vars/main.yml
+++ b/roles/neutron/vars/main.yml
@@ -37,6 +37,12 @@ __neutron_helm_values:
       database:
         connection_recycle_time: 10
         max_pool_size: 1
+      designate:
+        url: http://designate-api.openstack.svc.cluster.local:9001/v2
+        auth_url: http://keystone-api.openstack.svc.cluster.local:5000
+        region_name: "{{ openstack_helm_endpoints_neutron_region_name }}"
+        username: "neutron-{{ openstack_helm_endpoints_neutron_region_name }}"
+        password: "{{ openstack_helm_endpoints_neutron_keystone_password }}"
       nova:
         live_migration_events: true
       placement:


### PR DESCRIPTION
 - Set `_neutron_external_dns_driver` before `__neutron_helm_values` and `__neutron_ovn_helm_values`. In other case it is always omitted.

Even if we set `external_dns_driver` to `designate`: https://opendev.org/openstack/openstack-helm/src/branch/master/neutron/templates/configmap-etc.yaml#L222

There is a bug/typo  upstream which sets Keystone URI to Designate endpoint: https://opendev.org/openstack/openstack-helm/src/branch/master/neutron/templates/configmap-etc.yaml#L239

 - Adding auth_url and url accordingly until this will be fixed.