### PR TITLE
fix: limit neutron vpnaas ref

### DIFF
--- a/images/neutron/Dockerfile
+++ b/images/neutron/Dockerfile
@@ -7,7 +7,8 @@ FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG NEUTRON_GIT_REF=019294c71d94b788c14b23dc1da3c21f51bcdb0b
 ADD --keep-git-dir=true https://opendev.org/openstack/neutron.git#${NEUTRON_GIT_REF} /src/neutron
 RUN git -C /src/neutron fetch --unshallow
-ADD --keep-git-dir=true https://opendev.org/openstack/neutron-vpnaas.git#master /src/neutron-vpnaas
+ARG NEUTRON_VPNAAS_GIT_REF=7bc6d94305d34269d7522a9850c22aa42b50cdab
+ADD --keep-git-dir=true https://opendev.org/openstack/neutron-vpnaas.git#${NEUTRON_VPNAAS_GIT_REF} /src/neutron-vpnaas
 RUN git -C /src/neutron-vpnaas fetch --unshallow
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip,sharing=private <<EOF bash -xe
 pip3 install \


### PR DESCRIPTION
The cause for this is due to projects are around release cycle that makes the dependency conflict https://github.com/openstack/neutron-vpnaas/commit/f2fcd4586c96e7ff4fa5ca368fbe89cffa55fe7a

this is currently blocking our neutron image build jobs in https://github.com/vexxhost/atmosphere/pull/1428