### PR TITLE
[stable/2023.1] chore: use git ref for neutron-vpnaas

### DIFF
--- a/images/neutron/Dockerfile
+++ b/images/neutron/Dockerfile
@@ -7,7 +7,8 @@ FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG NEUTRON_GIT_REF=ce2560f23f133a550a5d56e784cc9c1eaa0006ca
 ADD --keep-git-dir=true https://opendev.org/openstack/neutron.git#${NEUTRON_GIT_REF} /src/neutron
 RUN git -C /src/neutron fetch --unshallow
-ADD --keep-git-dir=true https://opendev.org/openstack/neutron-vpnaas.git#stable/2023.1 /src/neutron-vpnaas
+ARG NEUTRON_VPNAAS_GIT_REF=25a6800815a8592df57f81cf310c8a6fd78e0b70
+ADD --keep-git-dir=true https://opendev.org/openstack/neutron-vpnaas.git#${NEUTRON_VPNAAS_GIT_REF} /src/neutron-vpnaas
 RUN git -C /src/neutron-vpnaas fetch --unshallow
 COPY patches/neutron /patches/neutron
 RUN git -C /src/neutron apply --verbose /patches/neutron/*


### PR DESCRIPTION
relate to https://github.com/vexxhost/atmosphere/pull/1458