### PR TITLE
grafana: Allow user lookups by email

### DIFF
--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -153,6 +153,7 @@ _kube_prometheus_stack_helm_values:
       server:
         root_url: https://{{ kube_prometheus_stack_grafana_host }}
       auth:
+        oauth_allow_insecure_email_lookup: true
         oauth_skip_org_role_update_sync: false
         disable_login_form: true
         signout_redirect_url: "{{ kube_prometheus_stack_keycloak_server_url }}/realms/{{ kube_prometheus_stack_keycloak_realm }}/protocol/openid-connect/logout?post_logout_redirect_uri=https://{{ kube_prometheus_stack_grafana_host }}/login"


### PR DESCRIPTION
Fix for this error:

![image](https://github.com/vexxhost/atmosphere/assets/5902830/0191ab87-5359-41ee-8199-816a5378cd6a)

Logs:

```
logger=user.sync t=2024-07-03T13:21:38.811238068Z level=error msg="Failed to create user" error="user already exists" auth_module=oauth_generic_oauth auth_id=c783731b-55bc-44db-acc3-263924027437
```

This stopped working in >10.1.0 and prevents Grafana from finding existing users by their email when configured to use Keycloak SSO.

https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/#enable-email-lookup