### PR TITLE
Fix `libvirt_exporter` missing `namespaceSelector:

### DIFF
--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -448,6 +448,9 @@ _kube_prometheus_stack_helm_values:
             relabelings: *relabelings_instance_to_node_name
       - name: libvirt-exporter
         jobLabel: job
+        namespaceSelector:
+          matchNames:
+            - openstack
         selector:
           matchLabels:
             application: libvirt


### PR DESCRIPTION
fix #675 