### PR TITLE
Fix multipathd ppa install failure in non Ubuntu Jammy release

### DIFF
--- a/roles/multipathd/tasks/main.yml
+++ b/roles/multipathd/tasks/main.yml
@@ -19,6 +19,7 @@
   retries: 10
   delay: 2
   until: _add_multipathd_ppa is not failed
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'jammy'
 
 - name: Install the multipathd package
   ansible.builtin.package:


### PR DESCRIPTION
Closes #1574 