### PR TITLE
ovn: Use chart name in oci_image_registry secret

### DIFF
--- a/charts/ovn/values.yaml
+++ b/charts/ovn/values.yaml
@@ -295,11 +295,7 @@ pod:
 
 secrets:
   oci_image_registry:
-    ovn_ovsdb_nb: ovn-ovsdb-nb-oci-image-registry-key
-    ovn_ovsdb_sb: ovn-ovsdb-sb-oci-image-registry-key
-    ovn_northd: ovn-northd-oci-image-registry-key
-    ovn_controller: ovn-controller-oci-image-registry-key
-    ovn_controller_gw: ovn-controller-gw-oci-image-registry-key
+    ovn: ovn-oci-image-registry-key
 
 # TODO: Check these endpoints?!
 endpoints:

--- a/charts/patches/ovn/0003-oci-image-registry-secret.patch
+++ b/charts/patches/ovn/0003-oci-image-registry-secret.patch
@@ -1,0 +1,14 @@
+diff --git a/ovn/values.yaml b/ovn/values.yaml
+index 4171db47..2df5c38c 100644
+--- a/ovn/values.yaml
++++ b/ovn/values.yaml
+@@ -295,11 +295,7 @@ pod:
+
+ secrets:
+   oci_image_registry:
+-    ovn_ovsdb_nb: ovn-ovsdb-nb-oci-image-registry-key
+-    ovn_ovsdb_sb: ovn-ovsdb-sb-oci-image-registry-key
+-    ovn_northd: ovn-northd-oci-image-registry-key
+-    ovn_controller: ovn-controller-oci-image-registry-key
+-    ovn_controller_gw: ovn-controller-gw-oci-image-registry-key
++    ovn: ovn-oci-image-registry-key


### PR DESCRIPTION
The current values.yaml uses the service name to create separate secrets. However, helm-toolkit indexes into oci_image_registry using .Chart.Name and not $serviceName so the secrets are not used.

Upstream: https://review.opendev.org/c/openstack/openstack-helm-infra/+/923779

Pushing this as a patch until we have it upstream (applied with `tox -e sync-charts`).