### PR TITLE
[ATMOSPHERE-363] Update to Ansible 2.17 and dependencies

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.17.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-ansible-core>=2.15.9
+ansible-core>=2.17.2
 jmespath>=1.0.1
-openstacksdk<0.99.0
-docker-image-py>=0.1.12
-rjsonnet>=0.5.2
-netaddr>=0.8.0
+openstacksdk>=3.3.0
+docker-image-py>=0.1.13
+rjsonnet>=0.5.4
+netaddr>=1.3.0


### PR DESCRIPTION
Porting guide doesn't show any major changes between 2.15 and 2.17 so opening this PR to get CI signal.