### PR TITLE
ci: Flag stale issues and PRs

### DIFF
--- a/.github/workflows/pr_stale.yml
+++ b/.github/workflows/pr_stale.yml
@@ -1,0 +1,32 @@
+name: 'Stale issues and PRs'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        with:
+          exempt-all-milestones: true
+
+          stale-pr-message: Pull request marked as stale due to inactivity for 30 days.
+          close-pr-message: Pull request closed due to inactivity.
+          days-before-pr-stale: 30
+          days-before-pr-close: -1 # Do not close
+          stale-pr-label: lifecycle/stale
+          exempt-pr-labels: lifecycle/keep
+
+          stale-issue-message: Issue marked as stale due to inactivity for 180 days.
+          close-issue-message: Issue closed due to inactivity.
+          days-before-issue-stale: 180
+          days-before-issue-close: -1 # Do not close
+          stale-issue-label: lifecycle/stale
+          exempt-issue-labels: lifecycle/keep


### PR DESCRIPTION
Adds an action to remind developers of stale issues/PRs.

https://github.com/actions/stale