### PR TITLE
[ATMOSPHERE-396] charts: Fix outdated charts

### DIFF
--- a/charts/ironic/charts/helm-toolkit/Chart.yaml
+++ b/charts/ironic/charts/helm-toolkit/Chart.yaml
@@ -9,4 +9,4 @@ name: helm-toolkit
 sources:
 - https://opendev.org/openstack/openstack-helm-infra
 - https://opendev.org/openstack/openstack-helm
-version: 0.2.64
+version: 0.2.69

--- a/charts/ironic/charts/helm-toolkit/templates/endpoints/_authenticated_endpoint_uri_lookup.tpl
+++ b/charts/ironic/charts/helm-toolkit/templates/endpoints/_authenticated_endpoint_uri_lookup.tpl
@@ -50,7 +50,7 @@ return: |
 {{- $endpointScheme := tuple $type $endpoint $port $context | include "helm-toolkit.endpoints.keystone_endpoint_scheme_lookup" }}
 {{- $userMap := index $context.Values.endpoints ( $type | replace "-" "_" ) "auth" $userclass }}
 {{- $endpointUser := index $userMap "username" }}
-{{- $endpointPass := index $userMap "password" }}
+{{- $endpointPass := index $userMap "password" | urlquery }}
 {{- $endpointHost := tuple $type $endpoint $context | include "helm-toolkit.endpoints.endpoint_host_lookup" }}
 {{- $endpointPort := tuple $type $endpoint $port $context | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
 {{- $endpointPath := tuple $type $endpoint $port $context | include "helm-toolkit.endpoints.keystone_endpoint_path_lookup" }}

--- a/charts/ironic/charts/helm-toolkit/templates/endpoints/_authenticated_transport_endpoint_uri_lookup.tpl
+++ b/charts/ironic/charts/helm-toolkit/templates/endpoints/_authenticated_transport_endpoint_uri_lookup.tpl
@@ -100,7 +100,7 @@ examples:
 {{-   $ssMap := index $context.Values.endpoints ( $type | replace "-" "_" ) "statefulset" | default false}}
 {{-   $hostFqdnOverride := index $context.Values.endpoints ( $type | replace "-" "_" ) "host_fqdn_override" }}
 {{-   $endpointUser := index $userMap "username" }}
-{{-   $endpointPass := index $userMap "password" }}
+{{-   $endpointPass := index $userMap "password" | urlquery }}
 {{-   $endpointHostSuffix := tuple $type $endpoint $context | include "helm-toolkit.endpoints.endpoint_host_lookup" }}
 {{-   $endpointPort := tuple $type $endpoint $port $context | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
 {{-   $local := dict "endpointCredsAndHosts" list -}}

--- a/charts/ironic/charts/helm-toolkit/templates/scripts/_db-drop.py.tpl
+++ b/charts/ironic/charts/helm-toolkit/templates/scripts/_db-drop.py.tpl
@@ -124,7 +124,12 @@ except:
 
 # Delete DB
 try:
-    root_engine.execute("DROP DATABASE IF EXISTS {0}".format(database))
+    with root_engine.connect() as connection:
+        connection.execute("DROP DATABASE IF EXISTS {0}".format(database))
+        try:
+            connection.commit()
+        except AttributeError:
+            pass
     logger.info("Deleted database {0}".format(database))
 except:
     logger.critical("Could not drop database {0}".format(database))
@@ -132,7 +137,12 @@ except:
 
 # Delete DB User
 try:
-    root_engine.execute("DROP USER IF EXISTS {0}".format(user))
+    with root_engine.connect() as connection:
+        connection.execute("DROP USER IF EXISTS {0}".format(user))
+        try:
+            connection.commit()
+        except AttributeError:
+            pass
     logger.info("Deleted user {0}".format(user))
 except:
     logger.critical("Could not delete user {0}".format(user))

--- a/charts/ironic/charts/helm-toolkit/templates/scripts/_db-init.py.tpl
+++ b/charts/ironic/charts/helm-toolkit/templates/scripts/_db-init.py.tpl
@@ -124,7 +124,12 @@ except:
 
 # Create DB
 try:
-    root_engine.execute("CREATE DATABASE IF NOT EXISTS {0}".format(database))
+    with root_engine.connect() as connection:
+        connection.execute("CREATE DATABASE IF NOT EXISTS {0}".format(database))
+        try:
+            connection.commit()
+        except AttributeError:
+            pass
     logger.info("Created database {0}".format(database))
 except:
     logger.critical("Could not create database {0}".format(database))
@@ -132,11 +137,16 @@ except:
 
 # Create DB User
 try:
-    root_engine.execute(
-        "CREATE USER IF NOT EXISTS \'{0}\'@\'%%\' IDENTIFIED BY \'{1}\' {2}".format(
-            user, password, mysql_x509))
-    root_engine.execute(
-        "GRANT ALL ON `{0}`.* TO \'{1}\'@\'%%\'".format(database, user))
+    with root_engine.connect() as connection:
+        connection.execute(
+            "CREATE USER IF NOT EXISTS \'{0}\'@\'%%\' IDENTIFIED BY \'{1}\' {2}".format(
+                user, password, mysql_x509))
+        connection.execute(
+            "GRANT ALL ON `{0}`.* TO \'{1}\'@\'%%\'".format(database, user))
+        try:
+            connection.commit()
+        except AttributeError:
+            pass
     logger.info("Created user {0} for {1}".format(user, database))
 except:
     logger.critical("Could not create user {0} for {1}".format(user, database))

--- a/charts/ironic/charts/helm-toolkit/templates/snippets/_image.tpl
+++ b/charts/ironic/charts/helm-toolkit/templates/snippets/_image.tpl
@@ -19,7 +19,7 @@ values: |
   images:
     tags:
       test_image: docker.io/port/test:version-foo
-      image_foo: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
+      image_foo: quay.io/airshipit/kubernetes-entrypoint:latest-ubuntu_focal
     pull_policy: IfNotPresent
     local_registry:
       active: true

--- a/charts/ironic/charts/helm-toolkit/templates/snippets/_kubernetes_entrypoint_init_container.tpl
+++ b/charts/ironic/charts/helm-toolkit/templates/snippets/_kubernetes_entrypoint_init_container.tpl
@@ -19,7 +19,7 @@ abstract: |
 values: |
   images:
     tags:
-      dep_check: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
+      dep_check: quay.io/airshipit/kubernetes-entrypoint:latest-ubuntu_focal
     pull_policy: IfNotPresent
     local_registry:
       active: true
@@ -76,7 +76,7 @@ usage: |
   {{ tuple . "calico_node" list | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" }}
 return: |
   - name: init
-    image: "quay.io/airshipit/kubernetes-entrypoint:v1.0.0"
+    image: "quay.io/airshipit/kubernetes-entrypoint:latest-ubuntu_focal"
     imagePullPolicy: IfNotPresent
     securityContext:
       allowPrivilegeEscalation: false

--- a/charts/ironic/requirements.lock
+++ b/charts/ironic/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: helm-toolkit
   repository: https://tarballs.openstack.org/openstack-helm-infra
-  version: 0.2.64
-digest: sha256:4c00b9bfa1d3dc0426a82ec22f51b440e838c55cbd1f81dbf7de5b28471f6141
+  version: 0.2.69
+digest: sha256:f971f98746c97193da5ff7a44d2401ae7d91201a49ed9f23d52359a1b6e9d0ef
 generated: '0001-01-01T00:00:00Z'

--- a/charts/ironic/requirements.yaml
+++ b/charts/ironic/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: helm-toolkit
   repository: https://tarballs.openstack.org/openstack-helm-infra
-  version: 0.2.64
+  version: 0.2.69

--- a/charts/ironic/templates/bin/_ironic-conductor-pxe-init.sh.tpl
+++ b/charts/ironic/templates/bin/_ironic-conductor-pxe-init.sh.tpl
@@ -43,7 +43,7 @@ fi
 mkdir -p /var/lib/openstack-helm/tftpboot
 mkdir -p /var/lib/openstack-helm/tftpboot/master_images
 
-for FILE in undionly.kpxe ipxe.efi pxelinux.0 snponly.efi; do
+for FILE in undionly.kpxe ipxe.efi pxelinux.0; do
   if [ -f /usr/lib/ipxe/$FILE ]; then
     cp -v /usr/lib/ipxe/$FILE /var/lib/openstack-helm/tftpboot
   fi

--- a/charts/ironic/values.yaml
+++ b/charts/ironic/values.yaml
@@ -406,7 +406,7 @@ endpoints:
         user_domain_name: service
         project_domain_name: service
       ironic:
-        role: admin,service
+        role: admin
         region_name: RegionOne
         username: ironic
         password: password

--- a/charts/libvirt/templates/daemonset-libvirt.yaml
+++ b/charts/libvirt/templates/daemonset-libvirt.yaml
@@ -299,8 +299,6 @@ spec:
               {{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "10" ) }}
               mountPropagation: Bidirectional
               {{- end }}
-          args:
-            - "--libvirt.nova"
         {{- end }}
       volumes:
         - name: etc-pki-qemu


### PR DESCRIPTION
I couldn't find atmosphere-linters running against the following commits:
- a4d8b259359e353fa32a738c2547f6624ca3eb3d
- 298f0278d923859be6f1dd8416ec8757252111f0

This is causing CI to [fail](https://ci.atmosphere.dev/t/atmosphere/build/1bb9ddd060af4c6e9f695bf6d2823aa4).