### PR TITLE
[ATMOSPHERE-116] Support loki log rotation

### DIFF
--- a/roles/loki/vars/main.yml
+++ b/roles/loki/vars/main.yml
@@ -24,8 +24,16 @@ _loki_helm_values:
     auth_enabled: false
     commonConfig:
       replication_factor: 1
+    compactor:
+      working_directory: /var/loki/compactor
+      compaction_interval: 10m
+      retention_enabled: true
+      delete_request_store: filesystem
+      retention_delete_delay: 2h
+      retention_delete_worker_count: 150
     limits_config:
       max_label_names_per_series: 25
+      retention_period: 30d
     rulerConfig:
       alertmanager_url: http://alertmanager-operated.monitoring:9093
       enable_alertmanager_v2: true


### PR DESCRIPTION
Fixes #525 Adds the following config

ref: https://grafana.com/docs/loki/latest/operations/storage/retention/

limits_config:
  retention_period: 30d # Keep 30 days
compactor:
  delete_request_cancel_period: 10m # don't wait 24h before processing the delete_request
  retention_enabled: true # enable log retention
  retention_delete_delay: 2h # wait 2 hours before actually deleting stuff