### PR TITLE
Add TLS to node exporter

### DIFF
--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -155,7 +155,6 @@ _atmosphere_images:
   neutron_sriov_agent: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
   neutron_policy_server: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
   node_feature_discovery: registry.k8s.io/nfd/node-feature-discovery:v0.15.4
-  node_tls_sidecar: registry.atmosphere.dev/library/node-tls-sidecar:latest
   nova_api: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
   nova_archive_deleted_rows: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
   nova_cell_setup_init: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
@@ -195,6 +194,7 @@ _atmosphere_images:
   percona_version_service: docker.io/perconalab/version-service:production-2048c1f
   placement_db_sync: "registry.atmosphere.dev/library/placement:{{ atmosphere_release }}"
   placement: "registry.atmosphere.dev/library/placement:{{ atmosphere_release }}"
+  pod_tls_sidecar: registry.atmosphere.dev/library/pod-tls-sidecar:latest
   prometheus_config_reloader: quay.io/prometheus-operator/prometheus-config-reloader:v0.73.0
   prometheus_ipmi_exporter: us-docker.pkg.dev/vexxhost-infra/openstack/ipmi-exporter:1.4.0
   prometheus_memcached_exporter: quay.io/prometheus/memcached-exporter:v0.14.3

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -155,6 +155,7 @@ _atmosphere_images:
   neutron_sriov_agent: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
   neutron_policy_server: "registry.atmosphere.dev/library/neutron:{{ atmosphere_release }}"
   node_feature_discovery: registry.k8s.io/nfd/node-feature-discovery:v0.15.4
+  node_tls_sidecar: registry.atmosphere.dev/library/node-tls-sidecar:latest
   nova_api: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
   nova_archive_deleted_rows: "registry.atmosphere.dev/library/nova:{{ atmosphere_release }}"
   nova_cell_setup_init: "registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"

--- a/roles/kube_prometheus_stack/defaults/main.yml
+++ b/roles/kube_prometheus_stack/defaults/main.yml
@@ -19,26 +19,7 @@ kube_prometheus_stack_helm_chart_ref: /usr/local/src/kube-prometheus-stack
 kube_prometheus_stack_helm_release_namespace: monitoring
 kube_prometheus_stack_helm_values: {}
 
-kube_prometheus_stack_node_exporter_tls_template:
-  apiVersion: cert-manager.io/v1
-  kind: Certificate
-  metadata:
-    name: "{{ '{{`{{ .PodInfo.Name }}`}}' ~ '-tls' }}"
-    namespace: "{{ '{{`{{ .PodInfo.Namespace }}`}}' }}"
-  spec:
-    commonName: "{{ '{{`{{ .FQDN }}`}}' }}"
-    dnsNames:
-      - "{{ '{{`{{ .Hostname }}`}}' }}"
-      - "{{ '{{`{{ .FQDN }}`}}' }}"
-    ipAddresses:
-      - "{{ '{{`{{ .PodInfo.IP }}`}}' }}"
-    issuerRef:
-      kind: ClusterIssuer
-      name: kube-prometheus-stack
-    usages:
-      - client auth
-      - server auth
-    secretName: "{{ '{{`{{ .PodInfo.Name }}`}}' ~ '-tls' }}"
+kube_prometheus_stack_node_exporter_tls_template: "{{ _kube_prometheus_stack_tls_template }}"
 kube_prometheus_stack_node_exporter_config:
   tls_server_config:
     # NOTE(mnaser): The kubelet doesn't have the ability of sending a client
@@ -67,6 +48,7 @@ kube_prometheus_stack_prometheus_host: "{{ undef('You must specify a Prometheus 
 kube_prometheus_stack_prometheus_ingress_annotations:
   cert-manager.io/cluster-issuer: "{{ kube_prometheus_stack_ingress_cluster_issuer }}"
   cert-manager.io/common-name: "{{ kube_prometheus_stack_prometheus_host }}"
+kube_prometheus_stack_prometheus_tls_template: "{{ _kube_prometheus_stack_tls_template }}"
 
 kube_prometheus_stack_keycloak_server_url: "https://{{ keycloak_host }}"
 kube_prometheus_stack_keycloak_admin_realm_name: master

--- a/roles/kube_prometheus_stack/defaults/main.yml
+++ b/roles/kube_prometheus_stack/defaults/main.yml
@@ -23,22 +23,22 @@ kube_prometheus_stack_node_exporter_tls_template:
   apiVersion: cert-manager.io/v1
   kind: Certificate
   metadata:
-    name: "{{ '{{ .PodInfo.Name }}-tls' }}"
-    namespace: "{{ '{{ .PodInfo.Namespace }}' }}"
+    name: "{{ '{{`{{ .PodInfo.Name }}`}}' ~ '-tls' }}"
+    namespace: "{{ '{{`{{ .PodInfo.Namespace }}`}}' }}"
   spec:
-    commonName: "{{ '{{ .FQDN }}' }}"
+    commonName: "{{ '{{`{{ .FQDN }}`}}' }}"
     dnsNames:
-      - "{{ '{{ .Hostname }}' }}"
-      - "{{ '{{ .FQDN }}' }}"
+      - "{{ '{{`{{ .Hostname }}`}}' }}"
+      - "{{ '{{`{{ .FQDN }}`}}' }}"
     ipAddresses:
-      - "{{ '{{ .PodInfo.IP }}' }}"
+      - "{{ '{{`{{ .PodInfo.IP }}`}}' }}"
     issuerRef:
-      kind: ClusterIssuer
-      name: atmosphere
+      kind: Issuer
+      name: kube-promethetus-stack
     usages:
       - client auth
       - server auth
-    secretName: "{{ '{{ .PodInfo.Name }}-tls' }}"
+    secretName: "{{ '{{`{{ .PodInfo.Name }}`}}' ~ '-tls' }}"
 
 kube_prometheus_stack_ingress_class_name: "{{ atmosphere_ingress_class_name }}"
 kube_prometheus_stack_ingress_cluster_issuer: "{{ atmosphere_ingress_cluster_issuer }}"

--- a/roles/kube_prometheus_stack/defaults/main.yml
+++ b/roles/kube_prometheus_stack/defaults/main.yml
@@ -41,7 +41,9 @@ kube_prometheus_stack_node_exporter_tls_template:
     secretName: "{{ '{{`{{ .PodInfo.Name }}`}}' ~ '-tls' }}"
 kube_prometheus_stack_node_exporter_config:
   tls_server_config:
-    client_auth_type: RequireAndVerifyClientCert
+    # NOTE(mnaser): The kubelet doesn't have the ability of sending a client
+    #               certificate, so we can't verify with a client certificate.
+    client_auth_type: VerifyClientCertIfGiven
     client_ca_file: /certs/ca.crt
     cert_file: /certs/tls.crt
     key_file: /certs/tls.key

--- a/roles/kube_prometheus_stack/defaults/main.yml
+++ b/roles/kube_prometheus_stack/defaults/main.yml
@@ -39,6 +39,12 @@ kube_prometheus_stack_node_exporter_tls_template:
       - client auth
       - server auth
     secretName: "{{ '{{`{{ .PodInfo.Name }}`}}' ~ '-tls' }}"
+kube_prometheus_stack_node_exporter_config:
+  tls_server_config:
+    client_auth_type: RequireAndVerifyClientCert
+    client_ca_file: /certs/ca.crt
+    cert_file: /certs/tls.crt
+    key_file: /certs/tls.key
 
 kube_prometheus_stack_ingress_class_name: "{{ atmosphere_ingress_class_name }}"
 kube_prometheus_stack_ingress_cluster_issuer: "{{ atmosphere_ingress_cluster_issuer }}"

--- a/roles/kube_prometheus_stack/defaults/main.yml
+++ b/roles/kube_prometheus_stack/defaults/main.yml
@@ -19,6 +19,27 @@ kube_prometheus_stack_helm_chart_ref: /usr/local/src/kube-prometheus-stack
 kube_prometheus_stack_helm_release_namespace: monitoring
 kube_prometheus_stack_helm_values: {}
 
+kube_prometheus_stack_node_exporter_tls_template:
+  apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    name: "{{ '{{ .PodInfo.Name }}-tls' }}"
+    namespace: "{{ '{{ .PodInfo.Namespace }}' }}"
+  spec:
+    commonName: "{{ '{{ .FQDN }}' }}"
+    dnsNames:
+      - "{{ '{{ .Hostname }}' }}"
+      - "{{ '{{ .FQDN }}' }}"
+    ipAddresses:
+      - "{{ '{{ .PodInfo.IP }}' }}"
+    issuerRef:
+      kind: ClusterIssuer
+      name: atmosphere
+    usages:
+      - client auth
+      - server auth
+    secretName: "{{ '{{ .PodInfo.Name }}-tls' }}"
+
 kube_prometheus_stack_ingress_class_name: "{{ atmosphere_ingress_class_name }}"
 kube_prometheus_stack_ingress_cluster_issuer: "{{ atmosphere_ingress_cluster_issuer }}"
 

--- a/roles/kube_prometheus_stack/defaults/main.yml
+++ b/roles/kube_prometheus_stack/defaults/main.yml
@@ -33,8 +33,8 @@ kube_prometheus_stack_node_exporter_tls_template:
     ipAddresses:
       - "{{ '{{`{{ .PodInfo.IP }}`}}' }}"
     issuerRef:
-      kind: Issuer
-      name: kube-promethetus-stack
+      kind: ClusterIssuer
+      name: kube-prometheus-stack
     usages:
       - client auth
       - server auth

--- a/roles/kube_prometheus_stack/tasks/main.yml
+++ b/roles/kube_prometheus_stack/tasks/main.yml
@@ -257,6 +257,38 @@
   loop_control:
     label: "{{ item.id }}"
 
+- name: Create certificate issuer
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      - apiVersion: cert-manager.io/v1
+        kind: Certificate
+        metadata:
+          name: kube-promethetus-stack-ca
+          namespace: "{{ kube_prometheus_stack_helm_release_namespace }}"
+        spec:
+          commonName: kube-promethetus-stack
+          duration: 87600h0m0s
+          isCA: true
+          issuerRef:
+            group: cert-manager.io
+            kind: ClusterIssuer
+            name: self-signed
+          privateKey:
+            algorithm: ECDSA
+            size: 256
+          renewBefore: 720h0m0s
+          secretName: kube-promethetus-stack-ca
+
+      - apiVersion: cert-manager.io/v1
+        kind: Issuer
+        metadata:
+          name: kube-promethetus-stack
+          namespace: "{{ kube_prometheus_stack_helm_release_namespace }}"
+        spec:
+          ca:
+            secretName: kube-promethetus-stack-ca
+
 - name: Install all CRDs
   run_once: true
   changed_when: false

--- a/roles/kube_prometheus_stack/tasks/main.yml
+++ b/roles/kube_prometheus_stack/tasks/main.yml
@@ -264,10 +264,10 @@
       - apiVersion: cert-manager.io/v1
         kind: Certificate
         metadata:
-          name: kube-promethetus-stack-ca
-          namespace: "{{ kube_prometheus_stack_helm_release_namespace }}"
+          name: kube-prometheus-stack-ca
+          namespace: cert-manager
         spec:
-          commonName: kube-promethetus-stack
+          commonName: kube-prometheus-stack
           duration: 87600h0m0s
           isCA: true
           issuerRef:
@@ -278,16 +278,15 @@
             algorithm: ECDSA
             size: 256
           renewBefore: 720h0m0s
-          secretName: kube-promethetus-stack-ca
+          secretName: kube-prometheus-stack-ca
 
       - apiVersion: cert-manager.io/v1
-        kind: Issuer
+        kind: ClusterIssuer
         metadata:
-          name: kube-promethetus-stack
-          namespace: "{{ kube_prometheus_stack_helm_release_namespace }}"
+          name: kube-prometheus-stack
         spec:
           ca:
-            secretName: kube-promethetus-stack-ca
+            secretName: kube-prometheus-stack-ca
 
 - name: Install all CRDs
   run_once: true

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -691,7 +691,7 @@ _kube_prometheus_stack_helm_values:
         name: "{{ kube_prometheus_stack_helm_release_name }}-prometheus-tls"
       data:
         certificate-template.yml: |
-          {{ kube_prometheus_stack_prometheus_tls_template | to_nice_yaml | indent(4) }}
+          {{ kube_prometheus_stack_prometheus_tls_template | to_nice_yaml }}
 
 _kube_prometheus_stack_tls_template:
   apiVersion: cert-manager.io/v1

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -323,6 +323,35 @@ _kube_prometheus_stack_helm_values:
       secrets:
         - kube-prometheus-stack-etcd-client-cert
       containers:
+        - name: pod-tls-sidecar
+          image: "{{ atmosphere_images['pod_tls_sidecar'] }}"
+          args:
+            - --template=/config/certificate-template.yml
+            - --ca-path=/certs/ca.crt
+            - --cert-path=/certs/tls.crt
+            - --key-path=/certs/tls.key
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          volumeMounts:
+            - name: kube-prometheus-stack-prometheus-tls
+              mountPath: /config
+            - name: certs
+              mountPath: /certs
         - name: oauth2-proxy
           image: "{{ atmosphere_images['oauth2_proxy'] }}"
           envFrom:
@@ -364,6 +393,12 @@ _kube_prometheus_stack_helm_values:
         - name: ca-certificates
           hostPath:
             path: "{{ defaults_ca_certificates_path }}"
+        - name: certs
+          emptyDir:
+            medium: Memory
+        - name: kube-prometheus-stack-prometheus-tls
+          configMap:
+            name: kube-prometheus-stack-prometheus-tls
     additionalServiceMonitors:
       - name: goldpinger
         jobLabel: app.kubernetes.io/instance
@@ -602,45 +637,6 @@ _kube_prometheus_stack_helm_values:
         scheme: https
     extraManifests:
       - |
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: Role
-        metadata:
-          name: "{{ '{{ .Release.Name }}' ~ '-cert-manager' }}"
-          namespace: "{{ '{{ .Release.Namespace }}' }}"
-        rules:
-          - apiGroups:
-              - cert-manager.io
-            verbs:
-              - get
-              - list
-              - create
-              - watch
-            resources:
-              - certificates
-          - apiGroups:
-              - ""
-            verbs:
-              - get
-              - list
-              - patch
-              - watch
-            resources:
-              - secrets
-      - |
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        metadata:
-          name: "{{ '{{ .Release.Name }}' ~ '-cert-manager' }}"
-          namespace: "{{ '{{ .Release.Namespace }}' }}"
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: Role
-          name: "{{ '{{ .Release.Name }}' ~ '-cert-manager' }}"
-        subjects:
-          - kind: ServiceAccount
-            name: "{{ '{{ .Release.Name }}' ~ '-prometheus-node-exporter' }}"
-            namespace: "{{ '{{ .Release.Namespace }}' }}"
-      - |
         apiVersion: v1
         kind: ConfigMap
         metadata:
@@ -651,3 +647,72 @@ _kube_prometheus_stack_helm_values:
           certificate-template.yml: |
             {{ kube_prometheus_stack_node_exporter_tls_template | to_nice_yaml | indent(4) }}
   additionalPrometheusRulesMap: "{{ lookup('vexxhost.atmosphere.jsonnet', 'jsonnet/rules.jsonnet') }}"
+  extraManifests:
+    - |
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: "{{ '{{ .Release.Name }}' ~ '-cert-manager' }}"
+        namespace: "{{ '{{ .Release.Namespace }}' }}"
+      rules:
+        - apiGroups:
+            - cert-manager.io
+          verbs:
+            - get
+            - list
+            - create
+            - watch
+          resources:
+            - certificates
+        - apiGroups:
+            - ""
+          verbs:
+            - get
+            - list
+            - patch
+            - watch
+          resources:
+            - secrets
+    - |
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: "{{ '{{ .Release.Name }}' ~ '-cert-manager' }}"
+        namespace: "{{ '{{ .Release.Namespace }}' }}"
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: "{{ '{{ .Release.Name }}' ~ '-cert-manager' }}"
+      subjects:
+        - kind: ServiceAccount
+          name: "{{ '{{ .Release.Name }}' ~ '-prometheus-node-exporter' }}"
+          namespace: "{{ '{{ .Release.Namespace }}' }}"
+    - |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: kube-prometheus-stack-prometheus-tls
+      data:
+        certificate-template.yml: |
+          {{ kube_prometheus_stack_prometheus_tls_template | to_nice_yaml | indent(4) }}
+
+_kube_prometheus_stack_tls_template:
+  apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    name: "{{ '{{`{{ .PodInfo.Name }}`}}' ~ '-tls' }}"
+    namespace: "{{ '{{`{{ .PodInfo.Namespace }}`}}' }}"
+  spec:
+    commonName: "{{ '{{`{{ .FQDN }}`}}' }}"
+    dnsNames:
+      - "{{ '{{`{{ .Hostname }}`}}' }}"
+      - "{{ '{{`{{ .FQDN }}`}}' }}"
+    ipAddresses:
+      - "{{ '{{`{{ .PodInfo.IP }}`}}' }}"
+    issuerRef:
+      kind: ClusterIssuer
+      name: kube-prometheus-stack
+    usages:
+      - client auth
+      - server auth
+    secretName: "{{ '{{`{{ .PodInfo.Name }}`}}' ~ '-tls' }}"

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -558,7 +558,7 @@ _kube_prometheus_stack_helm_values:
       - --collector.systemd
       - --collector.stat.softirq
     configmaps:
-      - kube-prometheus-stack-pod-tls-sidecar
+      - name: kube-prometheus-stack-pod-tls-sidecar
     sidecars:
       - name: pod-tls-sidecar
         image: "{{ atmosphere_images['pod_tls_sidecar'] }}"

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -648,8 +648,7 @@ _kube_prometheus_stack_helm_values:
             {{ kube_prometheus_stack_node_exporter_tls_template | to_nice_yaml | indent(4) }}
   additionalPrometheusRulesMap: "{{ lookup('vexxhost.atmosphere.jsonnet', 'jsonnet/rules.jsonnet') }}"
   extraManifests:
-    - |
-      apiVersion: rbac.authorization.k8s.io/v1
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
         name: "{{ kube_prometheus_stack_helm_release_name }}-pod-tls-sidecar"
@@ -673,8 +672,7 @@ _kube_prometheus_stack_helm_values:
             - watch
           resources:
             - secrets
-    - |
-      apiVersion: rbac.authorization.k8s.io/v1
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
         name: "{{ kube_prometheus_stack_helm_release_name }}-pod-tls-sidecar"
@@ -687,8 +685,7 @@ _kube_prometheus_stack_helm_values:
         - kind: ServiceAccount
           name: "{{ kube_prometheus_stack_helm_release_name }}-prometheus-node-exporter"
           namespace: "{{ kube_prometheus_stack_helm_release_namespace }}"
-    - |
-      apiVersion: v1
+    - apiVersion: v1
       kind: ConfigMap
       metadata:
         name: "{{ kube_prometheus_stack_helm_release_name }}-prometheus-tls"

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -559,6 +559,7 @@ _kube_prometheus_stack_helm_values:
       - --collector.processes
       - --collector.systemd
       - --collector.stat.softirq
+      - --web.config.file=/config/node-exporter.yml
     configmaps:
       - name: kube-prometheus-stack-pod-tls-sidecar
         mountPath: /pod-tls-sidecar-config
@@ -566,7 +567,7 @@ _kube_prometheus_stack_helm_values:
       - name: pod-tls-sidecar
         image: "{{ atmosphere_images['pod_tls_sidecar'] }}"
         args:
-          - --template=/pod-tls-sidecar-config/template
+          - --template=/config/certificate-template.yml
           - --ca-path=/certs/ca.crt
           - --cert-path=/certs/tls.crt
           - --key-path=/certs/tls.key
@@ -588,8 +589,8 @@ _kube_prometheus_stack_helm_values:
               fieldRef:
                 fieldPath: status.podIP
         volumeMounts:
-          - name: kube-prometheus-stack-pod-tls-sidecar
-            mountPath: /pod-tls-sidecar-config
+          - name: kube-prometheus-stack-node-exporter
+            mountPath: /config
     sidecarVolumeMount:
       - name: certs
         mountPath: /certs
@@ -637,8 +638,10 @@ _kube_prometheus_stack_helm_values:
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: kube-prometheus-stack-pod-tls-sidecar
+          name: kube-prometheus-stack-node-exporter
         data:
-          template: |
+          node-exporter.yml: |
+            {{ kube_prometheus_stack_node_exporter_config | to_nice_yaml | indent(4) }}
+          certificate-template.yml: |
             {{ kube_prometheus_stack_node_exporter_tls_template | to_nice_yaml | indent(4) }}
   additionalPrometheusRulesMap: "{{ lookup('vexxhost.atmosphere.jsonnet', 'jsonnet/rules.jsonnet') }}"

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -585,11 +585,12 @@ _kube_prometheus_stack_helm_values:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+        volumeMounts:
+          - name: kube-prometheus-stack-pod-tls-sidecar
+            mountPath: /pod-tls-sidecar-config
     sidecarVolumeMount:
       - name: certs
         mountPath: /certs
-      - name: kube-prometheus-stack-pod-tls-sidecar
-        mountPath: /pod-tls-sidecar-config
     extraManifests:
       - |
         apiVersion: v1

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -652,8 +652,8 @@ _kube_prometheus_stack_helm_values:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
-        name: "{{ '{{ .Release.Name }}' ~ '-cert-manager' }}"
-        namespace: "{{ '{{ .Release.Namespace }}' }}"
+        name: "{{ kube_prometheus_stack_helm_release_name }}-pod-tls-sidecar"
+        namespace: "{{ kube_prometheus_stack_helm_release_namespace }}"
       rules:
         - apiGroups:
             - cert-manager.io
@@ -677,21 +677,21 @@ _kube_prometheus_stack_helm_values:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
-        name: "{{ '{{ .Release.Name }}' ~ '-cert-manager' }}"
-        namespace: "{{ '{{ .Release.Namespace }}' }}"
+        name: "{{ kube_prometheus_stack_helm_release_name }}-pod-tls-sidecar"
+        namespace: "{{ kube_prometheus_stack_helm_release_namespace }}"
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
-        name: "{{ '{{ .Release.Name }}' ~ '-cert-manager' }}"
+        name: "{{ kube_prometheus_stack_helm_release_name }}-pod-tls-sidecar"
       subjects:
         - kind: ServiceAccount
-          name: "{{ '{{ .Release.Name }}' ~ '-prometheus-node-exporter' }}"
-          namespace: "{{ '{{ .Release.Namespace }}' }}"
+          name: "{{ kube_prometheus_stack_helm_release_name }}-prometheus-node-exporter"
+          namespace: "{{ kube_prometheus_stack_helm_release_namespace }}"
     - |
       apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: kube-prometheus-stack-prometheus-tls
+        name: "{{ kube_prometheus_stack_helm_release_name }}-prometheus-tls"
       data:
         certificate-template.yml: |
           {{ kube_prometheus_stack_prometheus_tls_template | to_nice_yaml | indent(4) }}

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -685,6 +685,9 @@ _kube_prometheus_stack_helm_values:
         - kind: ServiceAccount
           name: "{{ kube_prometheus_stack_helm_release_name }}-prometheus-node-exporter"
           namespace: "{{ kube_prometheus_stack_helm_release_namespace }}"
+        - kind: ServiceAccount
+          name: "{{ kube_prometheus_stack_helm_release_name }}-prometheus"
+          namespace: "{{ kube_prometheus_stack_helm_release_namespace }}"
     - apiVersion: v1
       kind: ConfigMap
       metadata:

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -558,8 +558,8 @@ _kube_prometheus_stack_helm_values:
       - --collector.systemd
       - --collector.stat.softirq
     sidecars:
-      - name: node-tls-sidecar
-        image: "{{ atmosphere_images['node_tls_sidecar'] }}"
+      - name: pod-tls-sidecar
+        image: "{{ atmosphere_images['pod_tls_sidecar'] }}"
         env:
           - name: POD_UID
             valueFrom:

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -545,6 +545,9 @@ _kube_prometheus_stack_helm_values:
       registry: "{{ atmosphere_images['prometheus_node_exporter'] | vexxhost.kubernetes.docker_image('domain') }}"
       repository: "{{ atmosphere_images['prometheus_node_exporter'] | vexxhost.kubernetes.docker_image('path') }}"
       tag: "{{ atmosphere_images['prometheus_node_exporter'] | vexxhost.kubernetes.docker_image('tag') }}"
+    prometheus:
+      monitor:
+        relabelings: *relabelings_instance_to_node_name
     extraArgs:
       - --collector.diskstats.ignored-devices=^(ram|loop|nbd|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$
       - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|fuse.squashfuse_ll|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
@@ -554,7 +557,24 @@ _kube_prometheus_stack_helm_values:
       - --collector.processes
       - --collector.systemd
       - --collector.stat.softirq
-    prometheus:
-      monitor:
-        relabelings: *relabelings_instance_to_node_name
+    sidecars:
+      - name: node-tls-sidecar
+        image: "{{ atmosphere_images['node_tls_sidecar'] }}"
+        env:
+          - name: POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
   additionalPrometheusRulesMap: "{{ lookup('vexxhost.atmosphere.jsonnet', 'jsonnet/rules.jsonnet') }}"

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -595,6 +595,45 @@ _kube_prometheus_stack_helm_values:
         mountPath: /certs
     extraManifests:
       - |
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        metadata:
+          name: "{{ '{{ .Release.Name }}' ~ '-cert-manager' }}"
+          namespace: "{{ '{{ .Release.Namespace }}' }}"
+        rules:
+          - apiGroups:
+              - cert-manager.io
+            verbs:
+              - get
+              - list
+              - create
+              - watch
+            resources:
+              - certificates
+          - apiGroups:
+              - ""
+            verbs:
+              - get
+              - list
+              - patch
+              - watch
+            resources:
+              - secrets
+      - |
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: "{{ '{{ .Release.Name }}' ~ '-cert-manager' }}"
+          namespace: "{{ '{{ .Release.Namespace }}' }}"
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: Role
+          name: "{{ '{{ .Release.Name }}' ~ '-cert-manager' }}"
+        subjects:
+          - kind: ServiceAccount
+            name: "{{ '{{ .Release.Name }}' }}"
+            namespace: "{{ '{{ .Release.Namespace }}' }}"
+      - |
         apiVersion: v1
         kind: ConfigMap
         metadata:

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -548,6 +548,8 @@ _kube_prometheus_stack_helm_values:
     prometheus:
       monitor:
         relabelings: *relabelings_instance_to_node_name
+    serviceAccount:
+      automountServiceAccountToken: true
     extraArgs:
       - --collector.diskstats.ignored-devices=^(ram|loop|nbd|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$
       - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|fuse.squashfuse_ll|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -631,7 +631,7 @@ _kube_prometheus_stack_helm_values:
           name: "{{ '{{ .Release.Name }}' ~ '-cert-manager' }}"
         subjects:
           - kind: ServiceAccount
-            name: "{{ '{{ .Release.Name }}' }}"
+            name: "{{ '{{ .Release.Name }}' ~ '-prometheus-node-exporter' }}"
             namespace: "{{ '{{ .Release.Namespace }}' }}"
       - |
         apiVersion: v1

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -399,6 +399,9 @@ _kube_prometheus_stack_helm_values:
         - name: kube-prometheus-stack-prometheus-tls
           configMap:
             name: kube-prometheus-stack-prometheus-tls
+      volumeMounts:
+        - name: certs
+          mountPath: /certs
     additionalServiceMonitors:
       - name: goldpinger
         jobLabel: app.kubernetes.io/instance
@@ -582,6 +585,11 @@ _kube_prometheus_stack_helm_values:
       tag: "{{ atmosphere_images['prometheus_node_exporter'] | vexxhost.kubernetes.docker_image('tag') }}"
     prometheus:
       monitor:
+        tlsConfig:
+          scheme: https
+          caFile: /certs/ca.crt
+          certFile: /certs/tls.crt
+          keyFile: /certs/tls.key
         relabelings: *relabelings_instance_to_node_name
     serviceAccount:
       automountServiceAccountToken: true
@@ -703,7 +711,7 @@ _kube_prometheus_stack_tls_template:
     name: "{{ '{{`{{ .PodInfo.Name }}`}}' ~ '-tls' }}"
     namespace: "{{ '{{`{{ .PodInfo.Namespace }}`}}' }}"
   spec:
-    commonName: "{{ '{{`{{ .FQDN }}`}}' }}"
+    commonName: "{{ '{{`{{ .Hostname }}`}}' }}"
     dnsNames:
       - "{{ '{{`{{ .Hostname }}`}}' }}"
       - "{{ '{{`{{ .FQDN }}`}}' }}"

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -594,6 +594,12 @@ _kube_prometheus_stack_helm_values:
     sidecarVolumeMount:
       - name: certs
         mountPath: /certs
+    livenessProbe:
+      httpGet:
+        scheme: https
+    readinessProbe:
+      httpGet:
+        scheme: https
     extraManifests:
       - |
         apiVersion: rbac.authorization.k8s.io/v1

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -561,8 +561,8 @@ _kube_prometheus_stack_helm_values:
       - --collector.stat.softirq
       - --web.config.file=/config/node-exporter.yml
     configmaps:
-      - name: kube-prometheus-stack-pod-tls-sidecar
-        mountPath: /pod-tls-sidecar-config
+      - name: kube-prometheus-stack-node-exporter
+        mountPath: /config
     sidecars:
       - name: pod-tls-sidecar
         image: "{{ atmosphere_images['pod_tls_sidecar'] }}"

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -559,11 +559,12 @@ _kube_prometheus_stack_helm_values:
       - --collector.stat.softirq
     configmaps:
       - name: kube-prometheus-stack-pod-tls-sidecar
+        mountPath: /pod-tls-sidecar-config
     sidecars:
       - name: pod-tls-sidecar
         image: "{{ atmosphere_images['pod_tls_sidecar'] }}"
         args:
-          - --template=/config/template
+          - --template=/pod-tls-sidecar-config/template
           - --ca-path=/certs/ca.crt
           - --cert-path=/certs/tls.crt
           - --key-path=/certs/tls.key
@@ -584,12 +585,11 @@ _kube_prometheus_stack_helm_values:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-        volumeMounts:
-          - name: certs
-            mountPath: /certs
     sidecarVolumeMount:
+      - name: certs
+        mountPath: /certs
       - name: kube-prometheus-stack-pod-tls-sidecar
-        mountPath: /config
+        mountPath: /pod-tls-sidecar-config
     extraManifests:
       - |
         apiVersion: v1

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -585,8 +585,8 @@ _kube_prometheus_stack_helm_values:
       tag: "{{ atmosphere_images['prometheus_node_exporter'] | vexxhost.kubernetes.docker_image('tag') }}"
     prometheus:
       monitor:
+        scheme: https
         tlsConfig:
-          scheme: https
           caFile: /certs/ca.crt
           certFile: /certs/tls.crt
           keyFile: /certs/tls.key

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -557,9 +557,16 @@ _kube_prometheus_stack_helm_values:
       - --collector.processes
       - --collector.systemd
       - --collector.stat.softirq
+    configmaps:
+      - kube-prometheus-stack-pod-tls-sidecar
     sidecars:
       - name: pod-tls-sidecar
         image: "{{ atmosphere_images['pod_tls_sidecar'] }}"
+        args:
+          - --template=/config/template
+          - --ca-path=/certs/ca.crt
+          - --cert-path=/certs/tls.crt
+          - --key-path=/certs/tls.key
         env:
           - name: POD_UID
             valueFrom:
@@ -577,4 +584,19 @@ _kube_prometheus_stack_helm_values:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+        volumeMounts:
+          - name: certs
+            mountPath: /certs
+    sidecarVolumeMount:
+      - name: kube-prometheus-stack-pod-tls-sidecar
+        mountPath: /config
+    extraManifests:
+      - |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: kube-prometheus-stack-pod-tls-sidecar
+        data:
+          template: |
+            {{ kube_prometheus_stack_node_exporter_tls_template | to_nice_yaml | indent(4) }}
   additionalPrometheusRulesMap: "{{ lookup('vexxhost.atmosphere.jsonnet', 'jsonnet/rules.jsonnet') }}"


### PR DESCRIPTION
- **Initial round of node-tls-sidecar**
- **Fix image name**
- **Added pod-tls-sidecar for node-exporter**
- **The art of escaping Helm and Ansible**
- **Fix configmap mount**
- **Dance around Helm**
- **Fix volume mount**
- **Mount service token**
- **Added RBAC**
- **Fix role binding name**
- **Switch node exporter to use TLS**
- **Fix mount**
- **Switch to VerifyClientCertIfGiven**
