### PR TITLE
[ATMOSPHERE-391] zed allow for smoother ingress nginx upgrades

### DIFF
--- a/roles/ingress_nginx/vars/main.yml
+++ b/roles/ingress_nginx/vars/main.yml
@@ -21,6 +21,7 @@ _ingress_nginx_helm_values:
       digest: "{{ atmosphere_images['ingress_nginx_controller'] | vexxhost.kubernetes.docker_image('digest') }}"
     config:
       proxy-buffer-size: 16k
+      worker-shutdown-timeout: 5s
     dnsPolicy: ClusterFirstWithHostNet
     hostNetwork: true
     ingressClassResource:
@@ -41,6 +42,7 @@ _ingress_nginx_helm_values:
           digest: "{{ atmosphere_images['ingress_nginx_kube_webhook_certgen'] | vexxhost.kubernetes.docker_image('digest') }}"
     metrics:
       enabled: true
+    terminationGracePeriodSeconds: 10
   defaultBackend:
     nodeSelector:
       openstack-control-plane: enabled


### PR DESCRIPTION
Set the wait up from default 300s to 30s for the drain of ingress connections.

(cherry picked from commit 1d7285b013f6c515d0c2537bf418967b358e78dd)