### PR TITLE
feat: specify api microversion for nova client in magnum conf

### DIFF
--- a/roles/magnum/vars/main.yml
+++ b/roles/magnum/vars/main.yml
@@ -69,6 +69,7 @@ _magnum_helm_values:
         endpoint_type: internalURL
         region_name: "{{ openstack_helm_endpoints_neutron_region_name }}"
       nova_client:
+        api_version: 2.15
         endpoint_type: internalURL
         region_name: "{{ openstack_helm_endpoints_nova_region_name }}"
       octavia_client:


### PR DESCRIPTION
2.15 is minimum version to support soft-* server group policy rule