### PR TITLE
fix: allow ssh login for nova user in nova image

### DIFF
--- a/zuul.d/container-images/nova.yaml
+++ b/zuul.d/container-images/nova.yaml
@@ -51,6 +51,7 @@
           build_args:
             - "RELEASE={{ zuul.branch | replace('stable/', '') }}"
             - PROJECT=nova
+            - SHELL=/bin/bash
           tags:
             - "{{ zuul.branch | replace('stable/', '') }}"
     files: &container_image_files


### PR DESCRIPTION
Login should be enabled for nova resizing or migrating between hypervisors [1].

[1]: https://docs.openstack.org/nova/latest/admin/ssh-configuration.html