### PR TITLE
[ATMOSPHERE-543] [stable/zed] log warning when failed to load pkcs12 cert 

### DIFF
--- a/images/octavia/Dockerfile
+++ b/images/octavia/Dockerfile
@@ -7,6 +7,8 @@ FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG OCTAVIA_GIT_REF=000b577f3e9c9ff7cb893e9f6e635753017a78c6
 ADD --keep-git-dir=true https://opendev.org/openstack/octavia.git#${OCTAVIA_GIT_REF} /src/octavia
 RUN git -C /src/octavia fetch --unshallow
+COPY patches/octavia /patches/octavia
+RUN git -C /src/octavia apply --verbose /patches/octavia/*
 ADD --keep-git-dir=true https://opendev.org/openstack/ovn-octavia-provider.git#unmaintained/zed /src/ovn-octavia-provider
 RUN git -C /src/ovn-octavia-provider fetch --unshallow
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip,sharing=private <<EOF bash -xe

--- a/images/octavia/patches/octavia/0000-Print-error-when-failed-to-load-pkcs12.patch
+++ b/images/octavia/patches/octavia/0000-Print-error-when-failed-to-load-pkcs12.patch
@@ -1,0 +1,16 @@
+diff --git a/octavia/certificates/manager/barbican.py b/octavia/certificates/manager/barbican.py
+index 748759c3..049b23b0 100644
+--- a/octavia/certificates/manager/barbican.py
++++ b/octavia/certificates/manager/barbican.py
+@@ -115,7 +115,10 @@ class BarbicanCertManager(cert_mgr.CertManager):
+             return pkcs12.PKCS12Cert(cert_secret.payload)
+         except exceptions.UnreadablePKCS12:
+             raise
+-        except Exception:
++        except Exception as e:
++            LOG.warning('Failed to load PKCS12Cert for secret %s with %s',
++                        cert_ref, str(e))
++            LOG.warning('Falling back to the barbican_legacy implementation.')
+             # If our get fails, try with the legacy driver.
+             # TODO(rm_work): Remove this code when the deprecation cycle for
+             # the legacy driver is complete.


### PR DESCRIPTION
https://opendev.org/openstack/octavia/commit/0ad935c7aa679f764d11d692c613aee939a508bc this commit was not backported to zed in upstream because it is unmaintained