### PR TITLE
[ATMOSPHERE-345] fix: Ensure iscsid starts

### DIFF
--- a/playbooks/openstack.yml
+++ b/playbooks/openstack.yml
@@ -75,6 +75,10 @@
       tags:
         - multipathd
 
+    - role: iscsi
+      tags:
+        - iscsi
+
 - name: Deploy Open vSwitch
   hosts: controllers:computes
   become: true

--- a/roles/iscsi/README.md
+++ b/roles/iscsi/README.md
@@ -1,0 +1,3 @@
+# ISCSI
+
+This role ensure iscsid

--- a/roles/iscsi/tasks/main.yml
+++ b/roles/iscsi/tasks/main.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Ensure iscsid is started
+  ansible.builtin.service:
+    name: iscsid
+    state: started


### PR DESCRIPTION
This make sure initiatorname gets properly configured And avoid `GenerateName=yes` that failed Nova on attach cinder volume.