### PR TITLE
fix: fix default venv build

### DIFF
--- a/roles/openstack_cli/templates/atmosphere.sh.j2
+++ b/roles/openstack_cli/templates/atmosphere.sh.j2
@@ -1,4 +1,4 @@
-alias osc='nerdctl run --rm --network host \
+alias osc='env|grep OS_ > /tmp/openrc && nerdctl run --rm --network host \
       --volume $PWD:/opt --volume /tmp:/tmp \
       --volume /etc/openstack:/etc/openstack:ro \
 {% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca', 'venafi') %}
@@ -8,7 +8,7 @@ alias osc='nerdctl run --rm --network host \
       --volume {{ '/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro' if ansible_facts['os_family']
       in ['Debian'] else '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt:/etc/ssl/certs/ca-certificates.crt:ro' }} \
 {% endif %}
-      --env-file <(env | grep OS_) \
+      --env-file /tmp/openrc \
       {{ atmosphere_images['openstack_cli'] }}'
 alias openstack='osc openstack'
 alias nova='osc nova'

--- a/roles/percona_xtradb_cluster/tasks/main.yml
+++ b/roles/percona_xtradb_cluster/tasks/main.yml
@@ -135,7 +135,7 @@
         namespace: openstack
       spec: "{{ _percona_xtradb_cluster_spec | combine(percona_xtradb_cluster_spec, recursive=True) }}"
     wait_sleep: 1
-    wait_timeout: 600
+    wait_timeout: 1200
     wait: true
     wait_condition:
       type: ready

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ passenv =
   OS_*
 deps =
   molecule
+  molecule-plugins
   kubernetes
   oslotest
   stestr

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,6 @@ commands =
 deps =
   {[testenv:molecule-venv]deps}
 setenv =
-  ATMOSPHERE_DEBUG = false
   openvswitch: ATMOSPHERE_NETWORK_BACKEND = openvswitch
   ovn: ATMOSPHERE_NETWORK_BACKEND = ovn
 commands =


### PR DESCRIPTION
Introduce some fixes for issues that found in
default molecule venv build.

* Add molecule-plugins as molecule needs docker plugin in new versions.
* Add extra wait time for pxc cluster to ready
* avoid OS_X not set when running openstack_cli role