### PR TITLE
[ATMOSPHERE-444] ironic unvalidated image data passed to qemu img CVE 2024 44082

### DIFF
--- a/images/ironic/Dockerfile
+++ b/images/ironic/Dockerfile
@@ -4,7 +4,7 @@
 ARG RELEASE
 
 FROM registry.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
-ARG IRONIC_GIT_REF=84fb43b81b9aab2e579ea961cb692a331ddf2125
+ARG IRONIC_GIT_REF=19de7ae2f48705cfa0e59d0642cec3cca7b6ca22
 ADD --keep-git-dir=true https://opendev.org/openstack/ironic.git#${IRONIC_GIT_REF} /src/ironic
 RUN git -C /src/ironic fetch --unshallow
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip,sharing=private <<EOF bash -xe


### PR DESCRIPTION
Bump to latest ironic stable/2024.1 to fix CVE-2024-44082