### PR TITLE
fix: memcached and memcachedExporter use the atmosphere_images

### DIFF
--- a/roles/loki/vars/main.yml
+++ b/roles/loki/vars/main.yml
@@ -49,6 +49,14 @@ _loki_helm_values:
           index:
             prefix: index_
             period: 24h
+  memcached:
+    image:
+      repository: "{{ atmosphere_images['memcached'] | vexxhost.kubernetes.docker_image('name') }}"
+      tag: "{{ atmosphere_images['memcached'] | vexxhost.kubernetes.docker_image('tag') }}"
+  memcachedExporter:
+    image:
+      repository: "{{ atmosphere_images['prometheus_memcached_exporter'] | vexxhost.kubernetes.docker_image('name') }}"
+      tag: "{{ atmosphere_images['prometheus_memcached_exporter'] | vexxhost.kubernetes.docker_image('tag') }}"
   test:
     enabled: false
   singleBinary:


### PR DESCRIPTION
Currently the containers memcached and memcachedExporter for loki don't use the atmosphere_images variable. This way it is not overwritable.

I have tested this on the zed and 2023.1 branch. This has only been seen on the 2023.1 branch.