### PR TITLE
fix: add acmesolver for airgapped clusters

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -17,7 +17,7 @@ dependencies:
   kubernetes.core: 2.4.0
   openstack.cloud: 1.7.0
   vexxhost.ceph: 3.0.1
-  vexxhost.kubernetes: ">=1.13.4"
+  vexxhost.kubernetes: ">=1.14.3"
 tags:
   - application
   - cloud

--- a/roles/cert_manager/tasks/main.yml
+++ b/roles/cert_manager/tasks/main.yml
@@ -20,5 +20,6 @@
     cert_manager_image_controller: "{{ atmosphere_images['cert_manager_controller'] }}"
     cert_manager_image_cainjector: "{{ atmosphere_images['cert_manager_cainjector'] }}"
     cert_manager_image_webhook: "{{ atmosphere_images['cert_manager_webhook'] }}"
+    cert_manager_image_acmesolver: "{{ atmosphere_images['cert_manager_acmesolver'] }}"
     cert_manager_node_selector:
       openstack-control-plane: enabled

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -25,6 +25,7 @@ _atmosphere_images:
   cert_manager_cli: quay.io/jetstack/cert-manager-ctl:v1.12.10
   cert_manager_controller: quay.io/jetstack/cert-manager-controller:v1.12.10
   cert_manager_webhook: quay.io/jetstack/cert-manager-webhook:v1.12.10
+  cert_manager_acmesolver: quay.io/jetstack/cert-manager-acmesolver:v1.12.10
   cilium_node: quay.io/cilium/cilium:v1.14.8
   cilium_operator: quay.io/cilium/operator-generic:v1.14.8
   cinder_api: "registry.atmosphere.dev/library/cinder:{{ atmosphere_release }}"


### PR DESCRIPTION
solves airgapped clusters and using ACME certificates, cert PR requires vexxhost/ansible-collection-kubernetes#132

fixes: vexxhost/ansible-collection-containers#29