### PR TITLE
[ATMOSPHERE-455] fix: disable ceph exporter managed by rook operator (#1896)

### DIFF
--- a/roles/rook_ceph_cluster/vars/main.yml
+++ b/roles/rook_ceph_cluster/vars/main.yml
@@ -17,6 +17,10 @@ _rook_ceph_cluster_spec:
     image: "{{ atmosphere_images['ceph'] | vexxhost.kubernetes.docker_image('ref') }}"
   external:
     enable: true
+  # NOTE(yaguang): As we are using external ceph cluster, so we can safely disable
+  # rook operator monitoring related metrics collection.
+  monitoring:
+    metricsDisabled: true
 
 _rook_ceph_cluster_radosgw_spec:
   preservePoolsOnDelete: true


### PR DESCRIPTION
Currently we are using external ceph cluster, so ceph exporter service managed by rook operator is useless to collect k8s ceph metrics.

Reviewed-by: Mohammed Naser <mnaser@vexxhost.com>