### PR TITLE
fix: change magnum-api registry tag to main

### DIFF
--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -130,7 +130,7 @@ _atmosphere_images:
   magnum_cluster_api_proxy: "registry.atmosphere.dev/library/magnum:{{ atmosphere_release }}"
   magnum_conductor: "registry.atmosphere.dev/library/magnum:{{ atmosphere_release }}"
   magnum_db_sync: "registry.atmosphere.dev/library/magnum:{{ atmosphere_release }}"
-  magnum_registry: quay.io/vexxhost/magnum-cluster-api-registry:latest
+  magnum_registry: quay.io/vexxhost/magnum-cluster-api-registry:main
   manila_api: "registry.atmosphere.dev/library/manila:{{ atmosphere_release }}"
   manila_data: "registry.atmosphere.dev/library/manila:{{ atmosphere_release }}"
   manila_db_sync: "registry.atmosphere.dev/library/manila:{{ atmosphere_release }}"


### PR DESCRIPTION
`latest` tag is not updates for a 7 months but instead `main` tag is updated on every github push.