### PR TITLE
[ATMOSPHERE-533] ci: update go unit tests

### DIFF
--- a/charts/charts_test.go
+++ b/charts/charts_test.go
@@ -105,6 +105,7 @@ func TestKubeconform(t *testing.T) {
 									},
 								},
 							},
+							"useTestSchema": true,
 						},
 					)
 					require.NoError(t, err)

--- a/charts/charts_test.go
+++ b/charts/charts_test.go
@@ -78,6 +78,9 @@ func TestKubeconform(t *testing.T) {
 		if !file.IsDir() {
 			continue
 		}
+		if file.Name() == "patches" {
+			continue
+		}
 
 		t.Run(file.Name(), func(t *testing.T) {
 			chart, err := loader.LoadDir(file.Name())

--- a/charts/charts_test.go
+++ b/charts/charts_test.go
@@ -104,8 +104,8 @@ func TestKubeconform(t *testing.T) {
 										"admin":  "FIXME",
 									},
 								},
+								"useTestSchema": true,
 							},
-							"useTestSchema": true,
 						},
 					)
 					require.NoError(t, err)

--- a/charts/charts_test.go
+++ b/charts/charts_test.go
@@ -16,7 +16,6 @@ import (
 
 var (
 	KUBERNETES_VERSIONS = []string{
-		"1.22.0",
 		"1.23.0",
 		"1.24.0",
 		"1.25.0",
@@ -59,10 +58,11 @@ func TestKubeconform(t *testing.T) {
 		opts := validator.Opts{
 			KubernetesVersion: version,
 			SkipKinds: map[string]struct{}{
-				"CephBlockPool":   {},
-				"CephCluster":     {},
-				"CephFilesystem":  {},
-				"CephObjectStore": {},
+				"CephBlockPool":                {},
+				"CephCluster":                  {},
+				"CephFilesystem":               {},
+				"CephObjectStore":              {},
+				"CephFilesystemSubVolumeGroup": {},
 				"apiextensions.k8s.io/v1/CustomResourceDefinition": {},
 			},
 			Strict: true,
@@ -92,7 +92,21 @@ func TestKubeconform(t *testing.T) {
 
 					t.Parallel()
 
-					rel, err := client.Run(chart, map[string]interface{}{})
+					rel, err := client.Run(
+						chart,
+						// NOTE(okozachenko1203): loki helm chart default values doesn't work.
+						map[string]interface{}{
+							"loki": map[string]interface{}{
+								"storage": map[string]interface{}{
+									"bucketNames": map[string]string{
+										"chunks": "FIXME",
+										"ruler":  "FIXME",
+										"admin":  "FIXME",
+									},
+								},
+							},
+						},
+					)
 					require.NoError(t, err)
 
 					manifests := io.NopCloser(strings.NewReader(rel.Manifest))

--- a/internal/testutils/oslo_db.go
+++ b/internal/testutils/oslo_db.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDatabaseConf(t *testing.T, config *openstack_helm.DatabaseConf) {
-	assert.Equal(t, 10, config.ConnectionRecycleTime)
-	assert.Equal(t, 1, config.MaxPoolSize)
+	assert.Equal(t, 600, config.ConnectionRecycleTime)
+	assert.Equal(t, 5, config.MaxPoolSize)
 	assert.Equal(t, -1, config.MaxRetries)
 }

--- a/roles/defaults/vars.go
+++ b/roles/defaults/vars.go
@@ -3,6 +3,7 @@ package defaults
 import (
 	"bytes"
 	_ "embed"
+	"strings"
 
 	"github.com/goccy/go-yaml"
 )
@@ -12,14 +13,25 @@ var (
 	varsFile []byte
 )
 
+// Define a global variable for the release value.
+var release = "main"
+
+// Function to replace the {{ release }} placeholders
+func replaceReleaseInYAML(yamlContent []byte, release string) []byte {
+	return []byte(strings.ReplaceAll(string(yamlContent), "{{ atmosphere_release }}", release))
+}
+
 func GetImages() (map[string]string, error) {
+	// Replace {{ release }} with the actual release value
+	modifiedVarsFile := replaceReleaseInYAML(varsFile, release)
+
 	path, err := yaml.PathString("$._atmosphere_images")
 	if err != nil {
 		return nil, err
 	}
 
 	var images map[string]string
-	if err := path.Read(bytes.NewReader(varsFile), &images); err != nil {
+	if err := path.Read(bytes.NewReader(modifiedVarsFile), &images); err != nil {
 		return nil, err
 	}
 

--- a/roles/defaults/vars_test.go
+++ b/roles/defaults/vars_test.go
@@ -28,16 +28,22 @@ func TestImageExist(t *testing.T) {
 		// NOTE(mnaser): ParseReference does not allow both tag & digest,
 		//               so we strip the tags from the image name.
 		nameWithTagSplit := strings.Split(image, "@")
-		require.Len(t, nameWithTagSplit, 2)
+		// NOTE(okozachenko1203): We'll enable this again when use image digest.
+		// require.Len(t, nameWithTagSplit, 2)
 		nameWithTag := nameWithTagSplit[0]
-		name := strings.Split(nameWithTag, ":")[0]
-		digest := strings.Split(image, "@")[1]
-		image := fmt.Sprintf("%s@%s", name, digest)
+		var imageRef string
+		if len(nameWithTagSplit) == 2 {
+			name := strings.Split(nameWithTag, ":")[0]
+			digest := strings.Split(image, "@")[1]
+			imageRef = fmt.Sprintf("%s@%s", name, digest)
+		} else {
+			imageRef = nameWithTag
+		}
 
-		t.Run(image, func(t *testing.T) {
+		t.Run(imageRef, func(t *testing.T) {
 			t.Parallel()
 
-			ref, err := docker.ParseReference(fmt.Sprintf("//%s", image))
+			ref, err := docker.ParseReference(fmt.Sprintf("//%s", imageRef))
 			require.NoError(t, err)
 
 			ctx := context.Background()

--- a/roles/percona_xtradb_cluster/vars_test.go
+++ b/roles/percona_xtradb_cluster/vars_test.go
@@ -105,10 +105,6 @@ func TestPerconaXtraDBClusterPXCSidecarSpec(t *testing.T) {
 			},
 		},
 	}, sidecar.Env[0])
-	assert.Equal(t, v1.EnvVar{
-		Name:  "DATA_SOURCE_NAME",
-		Value: "monitor:$(MONITOR_PASSWORD)@(localhost:3306)/",
-	}, sidecar.Env[1])
 
 	assert.Equal(t, v1.ContainerPort{
 		Name:          "metrics",
@@ -124,7 +120,7 @@ func TestPerconaXtraDBClusterHAProxySpec(t *testing.T) {
 	require.NoError(t, err)
 
 	defaults.AssertAtmosphereImage(t,
-		fmt.Sprintf("docker.io/percona/percona-xtradb-cluster-operator:%s-haproxy@sha256:f04e4fea548bfc7cb0bfc73c75c7f2c64d299cf04125a07a8101a55f0f734fed", chart.AppVersion()),
+		fmt.Sprintf("docker.io/percona/percona-xtradb-cluster-operator:%s-haproxy", chart.AppVersion()),
 		vars.PerconaXtraDBClusterSpec.HAProxy.Image,
 	)
 

--- a/roles/percona_xtradb_cluster/vars_test.go
+++ b/roles/percona_xtradb_cluster/vars_test.go
@@ -53,7 +53,7 @@ func TestPerconaXtraDBClusterSpec(t *testing.T) {
 func TestPerconaXtraDBClusterPXCSpec(t *testing.T) {
 	assert.Equal(t, int32(3), vars.PerconaXtraDBClusterSpec.PXC.Size)
 	assert.Equal(t, true, *vars.PerconaXtraDBClusterSpec.PXC.AutoRecovery)
-	defaults.AssertAtmosphereImage(t, "docker.io/percona/percona-xtradb-cluster:8.0.32-24.2@sha256:1f978ab8912e1b5fc66570529cb7e7a4ec6a38adbfce1ece78159b0fcfa7d47a", vars.PerconaXtraDBClusterSpec.PXC.Image)
+	defaults.AssertAtmosphereImage(t, "docker.io/percona/percona-xtradb-cluster:8.0.36-28.1", vars.PerconaXtraDBClusterSpec.PXC.Image)
 
 	assert.Equal(t, map[string]string{
 		"openstack-control-plane": "enabled",
@@ -92,10 +92,10 @@ func TestPerconaXtraDBClusterPXCConfiguration(t *testing.T) {
 func TestPerconaXtraDBClusterPXCSidecarSpec(t *testing.T) {
 	sidecar := vars.PerconaXtraDBClusterSpec.PXC.Sidecars[0]
 	assert.Equal(t, "exporter", sidecar.Name)
-	defaults.AssertAtmosphereImage(t, "quay.io/prometheus/mysqld-exporter:v0.14.0@sha256:eb6fe170738bf9181c51f5bc89f93adb26672ec49ffdcb22f55c24834003b45d", sidecar.Image)
+	defaults.AssertAtmosphereImage(t, "quay.io/prometheus/mysqld-exporter:v0.15.1", sidecar.Image)
 
 	assert.Equal(t, v1.EnvVar{
-		Name: "MONITOR_PASSWORD",
+		Name: "MYSQLD_EXPORTER_PASSWORD",
 		ValueFrom: &v1.EnvVarSource{
 			SecretKeyRef: &v1.SecretKeySelector{
 				LocalObjectReference: v1.LocalObjectReference{

--- a/roles/percona_xtradb_cluster/vars_test.go
+++ b/roles/percona_xtradb_cluster/vars_test.go
@@ -116,11 +116,8 @@ func TestPerconaXtraDBClusterHAProxySpec(t *testing.T) {
 	assert.Equal(t, true, vars.PerconaXtraDBClusterSpec.HAProxy.Enabled)
 	assert.Equal(t, int32(3), vars.PerconaXtraDBClusterSpec.HAProxy.Size)
 
-	chart, err := loader.LoadDir("../../charts/pxc-operator")
-	require.NoError(t, err)
-
 	defaults.AssertAtmosphereImage(t,
-		fmt.Sprintf("docker.io/percona/percona-xtradb-cluster-operator:%s-haproxy", chart.AppVersion()),
+		fmt.Sprintf("docker.io/percona/percona-xtradb-cluster-operator:%s-haproxy", vars.PerconaXtraDBClusterSpec.CRVersion),
 		vars.PerconaXtraDBClusterSpec.HAProxy.Image,
 	)
 
@@ -130,9 +127,6 @@ func TestPerconaXtraDBClusterHAProxySpec(t *testing.T) {
 }
 
 func TestPerconaXtraDBClusterHAProxyConfiguration(t *testing.T) {
-	chart, err := loader.LoadDir("../../charts/pxc-operator")
-	require.NoError(t, err)
-
 	pxcConfig := parsePXCConfiguration(t, vars.PerconaXtraDBClusterSpec.PXC.Configuration)
 	maxConnections := pxcConfig.Section("mysqld").Key("max_connections").MustInt()
 
@@ -141,7 +135,7 @@ func TestPerconaXtraDBClusterHAProxyConfiguration(t *testing.T) {
 	//               then compare it.
 
 	// Get the default HAproxy configuration
-	configFileUrl := fmt.Sprintf("https://raw.githubusercontent.com/percona/percona-docker/pxc-operator-%s/haproxy/dockerdir/etc/haproxy/haproxy-global.cfg", chart.AppVersion())
+	configFileUrl := fmt.Sprintf("https://raw.githubusercontent.com/percona/percona-docker/pxc-operator-%s/haproxy/dockerdir/etc/haproxy/haproxy-global.cfg", vars.PerconaXtraDBClusterSpec.CRVersion)
 	resp, err := http.Get(configFileUrl)
 	require.NoError(t, err)
 	defer resp.Body.Close()

--- a/roles/placement/vars/main.yml
+++ b/roles/placement/vars/main.yml
@@ -27,6 +27,7 @@ _placement_helm_values:
         connection_recycle_time: 600
         max_overflow: 50
         max_pool_size: 5
+        max_retries: -1
         pool_timeout: 30
       oslo_messaging_notifications:
         driver: noop

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,4 +1,11 @@
 - job:
+    name: atmosphere-unit-test
+    parent: golang-go
+    vars:
+      go_version: 1.21.13
+      go_command: test ./... -v
+
+- job:
     name: atmosphere-chart-vendor
     parent: chart-vendor
 

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,8 +1,14 @@
 - job:
-    name: atmosphere-unit-test
+    name: atmosphere-golang-go
     parent: golang-go
+    abstract: true
     vars:
       go_version: 1.21.13
+
+- job:
+    name: atmosphere-golang-go-test
+    parent: atmosphere-golang-go
+    vars:
       go_command: test ./... -v
 
 - job:

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -17,7 +17,7 @@
     check:
       jobs:
         - atmosphere-chart-vendor
-        - atmosphere-unit-test
+        - atmosphere-golang-go-test
         - atmosphere-linters
         - atmosphere-tox-py3
         - atmosphere-build-collection:
@@ -87,7 +87,7 @@
     gate:
       jobs:
         - atmosphere-chart-vendor
-        - atmosphere-unit-test
+        - atmosphere-golang-go-test
         - atmosphere-linters
         - atmosphere-tox-py3
         - atmosphere-build-collection:

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -17,6 +17,7 @@
     check:
       jobs:
         - atmosphere-chart-vendor
+        - atmosphere-unit-test
         - atmosphere-linters
         - atmosphere-tox-py3
         - atmosphere-build-collection:
@@ -86,6 +87,7 @@
     gate:
       jobs:
         - atmosphere-chart-vendor
+        - atmosphere-unit-test
         - atmosphere-linters
         - atmosphere-tox-py3
         - atmosphere-build-collection:


### PR DESCRIPTION
- remove 1.22 from `TestKubeconform` test (`node-feature-discovery` uses grpc in probe which is available since 1.22)
- add a workaround values in `TestKubeconform` for loki chart
- skip `CephFilesystemSubVolumeGroup` kind for ceph chart
- fix `oslo_db` test expected values
- update `TestImageExist` test to support image tags without digest
- fix pxc test codes
- supplement placement chart value for database max_retries param

depends-on: https://github.com/vexxhost/atmosphere/pull/1977 
depends-on: https://github.com/vexxhost/atmosphere/pull/1211
depends-on: https://github.com/vexxhost/atmosphere/pull/1987 https://github.com/vexxhost/atmosphere/pull/1211 #1977 