### PR TITLE
[ATMOSPHERE-514] fix ovn for backward compatibility

### DIFF
--- a/roles/ovn/tasks/main.yml
+++ b/roles/ovn/tasks/main.yml
@@ -27,7 +27,7 @@
       failed_when: false
 
     - name: Check if ovn controller has type label in spec.selector
-      set_fact:
+      ansible.builtin.set_fact:
         _ovn_controller_replace: "{{ 'type' in _ovn_controller_ds_info.resources[0].spec.selector.matchLabels }}"
       when: _ovn_controller_ds_info.resources | length > 0
 

--- a/roles/ovn/tasks/main.yml
+++ b/roles/ovn/tasks/main.yml
@@ -26,11 +26,6 @@
       register: _ovn_controller_ds_info
       failed_when: false
 
-    - name: Check if ovn controller has type label in spec.selector
-      ansible.builtin.set_fact:
-        _ovn_controller_replace: "{{ 'type' in _ovn_controller_ds_info.resources[0].spec.selector.matchLabels }}"
-      when: _ovn_controller_ds_info.resources | length > 0
-
     - name: Delete existing ovn controller DaemonSet if type label is found
       kubernetes.core.k8s:
         api_version: apps/v1
@@ -39,7 +34,9 @@
         namespace: "{{ ovn_helm_release_namespace }}"
         state: absent
         kubeconfig: "{{ ovn_helm_kubeconfig }}"
-      when: _ovn_controller_replace | default(false)
+      when:
+        - _ovn_controller_ds_info.resources | length > 0
+        - "'type' in _ovn_controller_ds_info.resources[0].spec.selector.matchLabels"
 
 - name: Deploy Helm chart
   run_once: true

--- a/roles/ovn/tasks/main.yml
+++ b/roles/ovn/tasks/main.yml
@@ -12,6 +12,35 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Replace unnecessary label in ovn-controller daemonset
+  run_once: true
+  when: atmosphere_network_backend == 'ovn'
+  block:
+    - name: Check if ovn_controller DaemonSet exists
+      kubernetes.core.k8s_info:
+        api_version: apps/v1
+        kind: DaemonSet
+        namespace: "{{ ovn_helm_release_namespace }}"
+        name: ovn-controller
+        kubeconfig: "{{ ovn_helm_kubeconfig }}"
+      register: _ovn_controller_ds_info
+      failed_when: false
+
+    - name: Check if ovn controller has type label in spec.selector
+      set_fact:
+        _ovn_controller_replace: "{{ 'type' in _ovn_controller_ds_info.resources[0].spec.selector.matchLabels }}"
+      when: _ovn_controller_ds_info.resources | length > 0
+
+    - name: Delete existing ovn controller DaemonSet if type label is found
+      kubernetes.core.k8s:
+        api_version: apps/v1
+        kind: DaemonSet
+        name: ovn-controller
+        namespace: "{{ ovn_helm_release_namespace }}"
+        state: absent
+        kubeconfig: "{{ ovn_helm_kubeconfig }}"
+      when: _ovn_controller_replace | default(false)
+
 - name: Deploy Helm chart
   run_once: true
   when: atmosphere_network_backend == 'ovn'

--- a/roles/ovn/vars/main.yml
+++ b/roles/ovn/vars/main.yml
@@ -41,3 +41,7 @@ _ovn_helm_values:
     sidecars:
       ovn_logging_parser: "{{ ovn_network_logging_parser_enabled }}"
       vector: "{{ ovn_network_logging_parser_enabled }}"
+    # NOTE(okozachenko1203): Just for backward compatibility
+    labels:
+      ovn-controller:
+        type: hv

--- a/roles/ovn/vars/main.yml
+++ b/roles/ovn/vars/main.yml
@@ -41,7 +41,3 @@ _ovn_helm_values:
     sidecars:
       ovn_logging_parser: "{{ ovn_network_logging_parser_enabled }}"
       vector: "{{ ovn_network_logging_parser_enabled }}"
-    # NOTE(okozachenko1203): Just for backward compatibility
-    labels:
-      ovn-controller:
-        type: hv


### PR DESCRIPTION
we used to keep `type: hv|gw` labels in ovn-controller and ovn-controller-gw daemonsents to distinguish them.
in the PR #2023, we removed ovn-controller-gw daemonset and keep only one DS to sync with upstream as much as possible. so `type: xx` label is unnecessary. But we cannot remove it for running clouds because `spec.selector` field is immutable.

this pr reverts that label for backward compatibility.