### PR TITLE
add non root ovs-user-id to ovn container image to rebuild 

### DIFF
--- a/charts/ovn/templates/bin/_ovn-controller-init.sh.tpl
+++ b/charts/ovn/templates/bin/_ovn-controller-init.sh.tpl
@@ -175,5 +175,8 @@ do
   then
     ovs-vsctl --may-exist add-port $bridge $iface
     migrate_ip_from_nic $iface $bridge
+  # update bridge socket file to non root owner 42424
+  chown 42424:42424 /var/run/openvswitch/*.mgmt
+  chown 42424:42424 /var/run/openvswitch/*.snoop
   fi
 done

--- a/charts/patches/ovn/0003-update-ovs-bridge-socket-file-ownship-to-non-root.patch
+++ b/charts/patches/ovn/0003-update-ovs-bridge-socket-file-ownship-to-non-root.patch
@@ -1,0 +1,13 @@
+diff --git a/charts/ovn/templates/bin/_ovn-controller-init.sh.tpl b/charts/ovn/templates/bin/_ovn-controller-init.sh.tpl
+index b1960212..8da8416f 100644
+--- a/ovn/templates/bin/_ovn-controller-init.sh.tpl
++++ b/ovn/templates/bin/_ovn-controller-init.sh.tpl
+@@ -169,5 +169,8 @@ do
+   then
+     ovs-vsctl --may-exist add-port $bridge $iface
+     migrate_ip_from_nic $iface $bridge
++  # update bridge socket file to non root owner 42424
++  chown 42424:42424 /var/run/openvswitch/*.mgmt
++  chown 42424:42424 /var/run/openvswitch/*.snoop
+   fi
+ done

--- a/images/ovn/Dockerfile
+++ b/images/ovn/Dockerfile
@@ -34,3 +34,11 @@ EOF
 COPY --from=ovn-kubernetes --link /src/dist/images/ovndb-raft-functions.sh /root/ovndb-raft-functions.sh
 COPY --from=ovn-kubernetes --link /src/dist/images/ovnkube.sh /root/ovnkube.sh
 COPY --from=ovn-kubernetes --link /usr/bin/ovn-kube-util /usr/bin/ovn-kube-util
+
+ARG PROJECT=ovn
+ENV OVS_USER_ID=42424
+RUN \
+    groupadd -g 42424 ${PROJECT} && \
+    useradd -u 42424 -g 42424 -M -d /var/lib/${PROJECT} -s /sbin/nologin -c "${PROJECT} User" ${PROJECT} && \
+    mkdir -p /etc/${PROJECT} /var/log/${PROJECT} /var/lib/${PROJECT} /var/run/${PROJECT} && \
+    chown -Rv ${PROJECT}:${PROJECT} /etc/${PROJECT} /var/log/${PROJECT} /var/lib/${PROJECT} /var/run/${PROJECT}


### PR DESCRIPTION


update ovn-controler script to chown ovs bridge socket files so that libvirt pod can read

fix #1982