### PR TITLE
[ATMOSPHERE-529] update magnum images to  1.29.6 1.30.2 1.31.1 (#1979)

### DIFF
--- a/molecule/aio/group_vars/all/molecule.yml
+++ b/molecule/aio/group_vars/all/molecule.yml
@@ -223,10 +223,7 @@ magnum_helm_values:
       api: 1
       conductor: 1
 magnum_image_disk_format: qcow2
-magnum_images:
-  - name: ubuntu-2204-kube-v1.27.8s
-    url: https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.27.8.qcow2
-    distro: ubuntu
+magnum_images: "[ {{ _magnum_images[-1] }} ]"
 
 manila_helm_values:
   conf:

--- a/roles/magnum/defaults/main.yml
+++ b/roles/magnum/defaults/main.yml
@@ -42,16 +42,7 @@ magnum_clusterctl_config:
 # List of images to load into OpenStack for Magnum
 magnum_image_container_format: bare
 magnum_image_disk_format: raw
-magnum_images:
-  - name: ubuntu-2204-kube-v1.25.11
-    url: https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.25.11.qcow2
-    distro: ubuntu
-  - name: ubuntu-2204-kube-v1.26.6
-    url: https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.26.6.qcow2
-    distro: ubuntu
-  - name: ubuntu-2204-kube-v1.27.3
-    url: https://object-storage.public.mtl1.vexxhost.net/swift/v1/a91f106f55e64246babde7402c21b87a/magnum-capi/ubuntu-2204-kube-v1.27.3.qcow2
-    distro: ubuntu
+magnum_images: "{{ _magnum_images }}"
 
 magnum_cluster_api_proxy_ovs_node_selector:
   openstack-control-plane: enabled

--- a/roles/magnum/vars/main.yml
+++ b/roles/magnum/vars/main.yml
@@ -100,3 +100,14 @@ _magnum_registry_ingress_annotations:
     if ($request_method !~* "^(GET|HEAD)$") {
       return 403;
     }
+
+_magnum_images:
+  - name: ubuntu-2204-kube-v1.29.6
+    url: https://static.atmosphere.dev/artifacts/magnum-cluster-api/ubuntu-jammy-kubernetes-1-29-6-1720107687.qcow2
+    distro: ubuntu
+  - name: ubuntu-2204-kube-v1.30.2
+    url: https://static.atmosphere.dev/artifacts/magnum-cluster-api/ubuntu-jammy-kubernetes-1-30-2-1720107688.qcow2
+    distro: ubuntu
+  - name: ubuntu-2204-kube-v1.31.1
+    url: https://static.atmosphere.dev/artifacts/magnum-cluster-api/ubuntu-jammy-kubernetes-1-31-1-1728920853.qcow2
+    distro: ubuntu


### PR DESCRIPTION
also update molecule magnum to use latest 1.31.1 k8s image

Reviewed-by: Mohammed Naser <mnaser@vexxhost.com>
