### PR TITLE
[ATMOSPHERE-567] allow failover on ERROR Amphora

### DIFF
--- a/images/octavia/Dockerfile
+++ b/images/octavia/Dockerfile
@@ -4,7 +4,7 @@
 ARG RELEASE
 
 FROM harbor.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
-ARG OCTAVIA_GIT_REF=824b51a1dad80292b7a8ad5d61bf3ce706b1fb29
+ARG OCTAVIA_GIT_REF=dda68b1cf6387170c3c68aad7dec82e6d84596a8
 ADD --keep-git-dir=true https://opendev.org/openstack/octavia.git#${OCTAVIA_GIT_REF} /src/octavia
 RUN git -C /src/octavia fetch --unshallow
 COPY patches/octavia /patches/octavia

--- a/images/octavia/Dockerfile
+++ b/images/octavia/Dockerfile
@@ -7,6 +7,8 @@ FROM harbor.atmosphere.dev/library/openstack-venv-builder:${RELEASE} AS build
 ARG OCTAVIA_GIT_REF=824b51a1dad80292b7a8ad5d61bf3ce706b1fb29
 ADD --keep-git-dir=true https://opendev.org/openstack/octavia.git#${OCTAVIA_GIT_REF} /src/octavia
 RUN git -C /src/octavia fetch --unshallow
+COPY patches/octavia /patches/octavia
+RUN git -C /src/octavia apply --verbose /patches/octavia/*
 ADD --keep-git-dir=true https://opendev.org/openstack/ovn-octavia-provider.git#master /src/ovn-octavia-provider
 RUN git -C /src/ovn-octavia-provider fetch --unshallow
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip,sharing=private <<EOF bash -xe

--- a/images/octavia/patches/octavia/0001-Allow-failover-on-error.patch
+++ b/images/octavia/patches/octavia/0001-Allow-failover-on-error.patch
@@ -1,0 +1,335 @@
+From 4a639f5c0f75cc5e58adf2e247808836de9a0d23 Mon Sep 17 00:00:00 2001
+From: ricolin <rlin@vexxhost.com>
+Date: Mon, 11 Nov 2024 19:04:39 +0800
+Subject: [PATCH] Allow failover on error
+
+Add config `failover_on_error` to allow Amphora failover with `ERROR`
+status.
+Add config `failover_on_error_max_retries` to allow limit retries for
+Amphora failover with `ERROR` status. Set to -1 to drop the limitation.
+
+Add column `error_retries` to Amphora table for allow tracking error retry
+counts.
+
+A lot of Amphora `ERROR` are able to solved by running failover on LB.
+With nothing change on original scenario, these new configs allow
+environments to do failover automatically for Amphora on ERROR status.
+
+Change-Id: Icff02f7a621cc13a8a0383e1b322f96027c421a6
+---
+ octavia/common/config.py                      | 11 ++++++
+ octavia/common/constants.py                   |  3 ++
+ octavia/common/data_models.py                 |  4 +-
+ .../healthmanager/health_manager.py           |  3 +-
+ .../controller/worker/v2/controller_worker.py | 23 +++++++++--
+ .../worker/v2/flows/amphora_flows.py          |  2 +-
+ .../worker/v2/tasks/database_tasks.py         |  3 +-
+ .../6c59498c8922_add_error_retries.py         | 39 +++++++++++++++++++
+ octavia/db/models.py                          |  1 +
+ octavia/db/repositories.py                    | 34 ++++++++++++++--
+ ...ror-amphora-failover-ab882982adc05f01.yaml | 24 ++++++++++++
+ 15 files changed, 202 insertions(+), 32 deletions(-)
+ create mode 100644 octavia/db/migration/alembic_migrations/versions/6c59498c8922_add_error_retries.py
+ create mode 100644 releasenotes/notes/allow-error-amphora-failover-ab882982adc05f01.yaml
+
+diff --git a/octavia/common/config.py b/octavia/common/config.py
+index a414b737e..c115f279f 100644
+--- a/octavia/common/config.py
++++ b/octavia/common/config.py
+@@ -309,6 +309,17 @@ health_manager_opts = [
+                default=10,
+                mutable=True,
+                help=_('Sleep time between sending heartbeats.')),
++    cfg.BoolOpt('failover_on_error', default=False,
++                help=_('Set this to True to allow failover when amphora '
++                       'status in Error. Beware that, try to performing '
++                       'failover when ERROR status might not help to solve '
++                       'the ERROR status for Amphora. '
++                       'So use this option with caution.')),
++    cfg.IntOpt('failover_on_error_max_retries',
++               default=3,
++               min=-1,
++               help=_('Retry threshold for failover on an ERROR amphora.'
++                      'Setting "-1" to remove the threshold.')),
+ ]
+ 
+ oslo_messaging_opts = [
+diff --git a/octavia/common/constants.py b/octavia/common/constants.py
+index 7e31cc2ad..bf0ffd31f 100644
+--- a/octavia/common/constants.py
++++ b/octavia/common/constants.py
+@@ -977,3 +977,6 @@ NFT_TABLE = 'amphora_table'
+ NFT_CHAIN = 'amphora_chain'
+ NFT_VIP_CHAIN = 'amphora_vip_chain'
+ PROTOCOL = 'protocol'
++
++# Amphora failover retries on ERROR status
++AMP_ERR_RETRIES = 'error_retries'
+diff --git a/octavia/common/data_models.py b/octavia/common/data_models.py
+index b416c25e7..059684561 100644
+--- a/octavia/common/data_models.py
++++ b/octavia/common/data_models.py
+@@ -620,7 +620,8 @@ class Amphora(BaseDataModel):
+                  load_balancer=None, role=None, cert_expiration=None,
+                  cert_busy=False, vrrp_interface=None, vrrp_id=None,
+                  vrrp_priority=None, cached_zone=None, created_at=None,
+-                 updated_at=None, image_id=None, compute_flavor=None):
++                 updated_at=None, image_id=None, compute_flavor=None,
++                 error_retries=0):
+         self.id = id
+         self.load_balancer_id = load_balancer_id
+         self.compute_id = compute_id
+@@ -642,6 +643,7 @@ class Amphora(BaseDataModel):
+         self.updated_at = updated_at
+         self.image_id = image_id
+         self.compute_flavor = compute_flavor
++        self.error_retries = error_retries
+ 
+     def delete(self):
+         for amphora in self.load_balancer.amphorae:
+diff --git a/octavia/controller/healthmanager/health_manager.py b/octavia/controller/healthmanager/health_manager.py
+index 1ba19c025..d037564e9 100644
+--- a/octavia/controller/healthmanager/health_manager.py
++++ b/octavia/controller/healthmanager/health_manager.py
+@@ -138,7 +138,8 @@ class HealthManager:
+ 
+             LOG.info("Stale amphora's id is: %s", amp_health.amphora_id)
+             fut = self.executor.submit(
+-                self.cw.failover_amphora, amp_health.amphora_id, reraise=True)
++                self.cw.failover_amphora, amp_health.amphora_id, reraise=True,
++                count_error_retries=True)
+             fut.add_done_callback(
+                 functools.partial(update_stats_on_done, stats)
+             )
+diff --git a/octavia/controller/worker/v2/controller_worker.py b/octavia/controller/worker/v2/controller_worker.py
+index fa1feb216..1ad6616a0 100644
+--- a/octavia/controller/worker/v2/controller_worker.py
++++ b/octavia/controller/worker/v2/controller_worker.py
+@@ -395,7 +395,8 @@ class ControllerWorker:
+                  constants.BUILD_TYPE_PRIORITY:
+                  constants.LB_CREATE_NORMAL_PRIORITY,
+                  lib_consts.FLAVOR: flavor,
+-                 lib_consts.AVAILABILITY_ZONE: availability_zone}
++                 lib_consts.AVAILABILITY_ZONE: availability_zone,
++                 constants.AMP_ERR_RETRIES: 0}
+ 
+         topology = lb.topology
+         if (not CONF.nova.enable_anti_affinity or
+@@ -976,7 +977,8 @@ class ControllerWorker:
+             flow_utils.get_update_l7rule_flow,
+             store=store)
+ 
+-    def failover_amphora(self, amphora_id, reraise=False):
++    def failover_amphora(self, amphora_id, reraise=False,
++                         count_error_retries=False):
+         """Perform failover operations for an amphora.
+ 
+         Note: This expects the load balancer to already be in
+@@ -984,6 +986,8 @@ class ControllerWorker:
+ 
+         :param amphora_id: ID for amphora to failover
+         :param reraise: If enabled reraise any caught exception
++        :param count_error_retries: If enabled allows counts Amphora failover
++        on ERROR status
+         :returns: None
+         :raises octavia.common.exceptions.NotFound: The referenced amphora was
+                                                     not found
+@@ -1013,6 +1017,17 @@ class ControllerWorker:
+                                                      amphora_id=amphora.id)
+                 return
+ 
++            if amphora.status == constants.ERROR:
++                amp_err_retries = getattr(
++                    amphora, constants.AMP_ERR_RETRIES, 0
++                )
++                if count_error_retries:
++                    amp_err_retries += 1
++            else:
++                # It's no longer failover on ERROR status,
++                # clean it for new Amphora.
++                amp_err_retries = 0
++
+             loadbalancer = None
+             if amphora.load_balancer_id:
+                 with session.begin():
+@@ -1066,7 +1081,9 @@ class ControllerWorker:
+                              constants.SERVER_GROUP_ID: server_group_id,
+                              constants.LOADBALANCER_ID: lb_id,
+                              constants.VIP: vip_dict,
+-                             constants.ADDITIONAL_VIPS: additional_vip_dicts}
++                             constants.ADDITIONAL_VIPS: additional_vip_dicts,
++                             constants.AMP_ERR_RETRIES: amp_err_retries,
++                             }
+ 
+             self.run_flow(
+                 flow_utils.get_failover_amphora_flow,
+diff --git a/octavia/controller/worker/v2/flows/amphora_flows.py b/octavia/controller/worker/v2/flows/amphora_flows.py
+index 45816b2f7..ff624a8d6 100644
+--- a/octavia/controller/worker/v2/flows/amphora_flows.py
++++ b/octavia/controller/worker/v2/flows/amphora_flows.py
+@@ -94,7 +94,7 @@ class AmphoraFlows:
+         create_amp_for_lb_subflow = linear_flow.Flow(sf_name)
+         create_amp_for_lb_subflow.add(database_tasks.CreateAmphoraInDB(
+             name=sf_name + '-' + constants.CREATE_AMPHORA_INDB,
+-            requires=constants.LOADBALANCER_ID,
++            requires=(constants.LOADBALANCER_ID, constants.AMP_ERR_RETRIES),
+             provides=constants.AMPHORA_ID))
+ 
+         create_amp_for_lb_subflow.add(cert_task.GenerateServerPEMTask(
+diff --git a/octavia/controller/worker/v2/tasks/database_tasks.py b/octavia/controller/worker/v2/tasks/database_tasks.py
+index 48b4d92d4..3ccfcc44b 100644
+--- a/octavia/controller/worker/v2/tasks/database_tasks.py
++++ b/octavia/controller/worker/v2/tasks/database_tasks.py
+@@ -102,7 +102,8 @@ class CreateAmphoraInDB(BaseDatabaseTask):
+                 id=uuidutils.generate_uuid(),
+                 load_balancer_id=loadbalancer_id,
+                 status=constants.PENDING_CREATE,
+-                cert_busy=False)
++                cert_busy=False,
++                **kwargs)
+         if loadbalancer_id:
+             LOG.info("Created Amphora %s in DB for load balancer %s",
+                      amphora.id, loadbalancer_id)
+diff --git a/octavia/db/migration/alembic_migrations/versions/6c59498c8922_add_error_retries.py b/octavia/db/migration/alembic_migrations/versions/6c59498c8922_add_error_retries.py
+new file mode 100644
+index 000000000..a1b51daad
+--- /dev/null
++++ b/octavia/db/migration/alembic_migrations/versions/6c59498c8922_add_error_retries.py
+@@ -0,0 +1,39 @@
++#    Licensed under the Apache License, Version 2.0 (the "License"); you may
++#    not use this file except in compliance with the License. You may obtain
++#    a copy of the License at
++#
++#         http://www.apache.org/licenses/LICENSE-2.0
++#
++#    Unless required by applicable law or agreed to in writing, software
++#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
++#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
++#    License for the specific language governing permissions and limitations
++#    under the License.
++
++"""add error retries
++
++Revision ID: 6c59498c8922
++Revises: db2a73e82626
++Create Date: 2024-11-15 20:31:44.758804
++
++"""
++
++from alembic import op
++import sqlalchemy as sa
++
++
++# revision identifiers, used by Alembic.
++revision = '6c59498c8922'
++down_revision = 'db2a73e82626'
++
++
++def upgrade():
++    op.add_column(
++        'amphora',
++        sa.Column(
++            'error_retries',
++            sa.Integer(),
++            default=0,
++            nullable=False
++        )
++    )
+diff --git a/octavia/db/models.py b/octavia/db/models.py
+index e1ab20ba3..63c109a85 100644
+--- a/octavia/db/models.py
++++ b/octavia/db/models.py
+@@ -703,6 +703,7 @@ class Amphora(base_models.BASE, base_models.IdMixin, models.TimestampMixin):
+     load_balancer = orm.relationship("LoadBalancer", uselist=False,
+                                      back_populates='amphorae')
+     compute_flavor = sa.Column(sa.String(255), nullable=True)
++    error_retries = sa.Column(sa.Integer(), default=0, nullable=False)
+ 
+     def __str__(self):
+         return (f"Amphora(id={self.id!r}, load_balancer_id="
+diff --git a/octavia/db/repositories.py b/octavia/db/repositories.py
+index 48656540e..bed58c450 100644
+--- a/octavia/db/repositories.py
++++ b/octavia/db/repositories.py
+@@ -27,6 +27,8 @@ from oslo_db import exception as db_exception
+ from oslo_log import log as logging
+ from oslo_serialization import jsonutils
+ from oslo_utils import uuidutils
++from sqlalchemy import and_
++from sqlalchemy import or_
+ from sqlalchemy.orm import noload
+ from sqlalchemy.orm import Session
+ from sqlalchemy.orm import subqueryload
+@@ -1605,11 +1607,35 @@ class AmphoraHealthRepository(BaseRepository):
+         # We don't want to attempt to failover amphora that are not
+         # currently in the ALLOCATED or FAILOVER_STOPPED state.
+         # i.e. Not DELETED, PENDING_*, etc.
++        # But if CONF.health_manager.failover_on_error is set, we will allow
++        # performing failover when Amphora on ERROR status with certain
++        # conditions.
++        allow_status = [
++            consts.AMPHORA_ALLOCATED,
++            consts.AMPHORA_FAILOVER_STOPPED
++        ]
++        if CONF.health_manager.failover_on_error:
++            limit = CONF.health_manager.failover_on_error_max_retries
++            error_status = [consts.ERROR]
++            if limit == -1:
++                # No limit on ERROR Amphora retries
++                where_subquery = models.Amphora.status.in_(
++                    allow_status + error_status
++                )
++            else:
++                # Limit on ERROR Amphora retries
++                where_subquery = or_(
++                    models.Amphora.status.in_(allow_status),
++                    and_(
++                        models.Amphora.status.in_(error_status),
++                        models.Amphora.error_retries < limit)
++                )
++        else:
++            where_subquery = models.Amphora.status.in_(allow_status)
++
+         allocated_amp_ids_subquery = (
+-            select(models.Amphora.id).where(
+-                models.Amphora.status.in_(
+-                    [consts.AMPHORA_ALLOCATED,
+-                     consts.AMPHORA_FAILOVER_STOPPED])))
++            select(models.Amphora.id).where(where_subquery)
++        )
+ 
+         # Pick one expired amphora for automatic failover
+         amp_health = lock_session.query(
+diff --git a/releasenotes/notes/allow-error-amphora-failover-ab882982adc05f01.yaml b/releasenotes/notes/allow-error-amphora-failover-ab882982adc05f01.yaml
+new file mode 100644
+index 000000000..5fabe45ff
+--- /dev/null
++++ b/releasenotes/notes/allow-error-amphora-failover-ab882982adc05f01.yaml
+@@ -0,0 +1,24 @@
++---
++features:
++  - |
++    Allow failover on Amphora in ERROR status. Also tracing the retries counts
++    on failover Amphora in ERROR status. The counting is recorded in
++    DB (Amphora.error_retries) and will get cleaned when
++    Amphora able to run failover on non-ERROR status.
++    If retry counts hits max retries limit, it will requires more investigate
++    and running failover manually (if needs).
++    For this feature, we add config `[health_manager]/failover_on_error`
++    (disable by default) to allow health manager pick up any Amphora in both
++    ERROR status and expired on heartbeats conditions when looking for stale
++    Amphora to failover.
++    Also add config `[health_manager]/failover_on_error_max_retries`
++    (default to 0) to control max retries to run failover on error status
++    Amphora. Set to `-1` to allow unlimited retries.
++    Beware that, try to performing failover when ERROR
++    status might not help to solve the ERROR status for Amphora.
++    So use this option with caution.
++
++upgrade:
++  - |
++    Upgrade requires a database migration to update amphora table.
++    Add `error_retries` column for tracing Amphora error status retries.
+-- 
+2.25.1
+

--- a/images/octavia/patches/octavia/0001-Allow-failover-on-error.patch
+++ b/images/octavia/patches/octavia/0001-Allow-failover-on-error.patch
@@ -1,39 +1,31 @@
-From 4a639f5c0f75cc5e58adf2e247808836de9a0d23 Mon Sep 17 00:00:00 2001
+From 7d71aea274218ef09eea97dad8a194faa79ece85 Mon Sep 17 00:00:00 2001
 From: ricolin <rlin@vexxhost.com>
-Date: Mon, 11 Nov 2024 19:04:39 +0800
+Date: Wed, 18 Dec 2024 14:47:49 +0800
 Subject: [PATCH] Allow failover on error
 
-Add config `failover_on_error` to allow Amphora failover with `ERROR`
-status.
-Add config `failover_on_error_max_retries` to allow limit retries for
-Amphora failover with `ERROR` status. Set to -1 to drop the limitation.
-
-Add column `error_retries` to Amphora table for allow tracking error retry
-counts.
-
-A lot of Amphora `ERROR` are able to solved by running failover on LB.
-With nothing change on original scenario, these new configs allow
-environments to do failover automatically for Amphora on ERROR status.
-
-Change-Id: Icff02f7a621cc13a8a0383e1b322f96027c421a6
+Change-Id: I8c1547ff4dfe562e8ef0d52004ac97e495fed788
 ---
- octavia/common/config.py                      | 11 ++++++
+ octavia/common/config.py                      | 11 ++++
  octavia/common/constants.py                   |  3 ++
  octavia/common/data_models.py                 |  4 +-
  .../healthmanager/health_manager.py           |  3 +-
- .../controller/worker/v2/controller_worker.py | 23 +++++++++--
+ .../controller/worker/v2/controller_worker.py | 27 ++++++++--
  .../worker/v2/flows/amphora_flows.py          |  2 +-
  .../worker/v2/tasks/database_tasks.py         |  3 +-
- .../6c59498c8922_add_error_retries.py         | 39 +++++++++++++++++++
+ .../6c59498c8922_add_error_retries.py         | 39 ++++++++++++++
  octavia/db/models.py                          |  1 +
- octavia/db/repositories.py                    | 34 ++++++++++++++--
- ...ror-amphora-failover-ab882982adc05f01.yaml | 24 ++++++++++++
- 15 files changed, 202 insertions(+), 32 deletions(-)
+ octavia/db/repositories.py                    | 34 ++++++++++--
+ .../tests/functional/db/test_repositories.py  | 42 +++++++++++++++
+ .../worker/v2/flows/test_amphora_flows.py     | 27 ++++++----
+ .../v2/flows/test_load_balancer_flows.py      | 12 +++--
+ .../worker/v2/test_controller_worker.py       | 53 ++++++++++++++-----
+ ...ror-amphora-failover-ab882982adc05f01.yaml | 24 +++++++++
+ 15 files changed, 248 insertions(+), 37 deletions(-)
  create mode 100644 octavia/db/migration/alembic_migrations/versions/6c59498c8922_add_error_retries.py
  create mode 100644 releasenotes/notes/allow-error-amphora-failover-ab882982adc05f01.yaml
 
 diff --git a/octavia/common/config.py b/octavia/common/config.py
-index a414b737e..c115f279f 100644
+index 00f09930e..6b574d6bf 100644
 --- a/octavia/common/config.py
 +++ b/octavia/common/config.py
 @@ -309,6 +309,17 @@ health_manager_opts = [
@@ -55,16 +47,19 @@ index a414b737e..c115f279f 100644
  
  oslo_messaging_opts = [
 diff --git a/octavia/common/constants.py b/octavia/common/constants.py
-index 7e31cc2ad..bf0ffd31f 100644
+index 7e31cc2ad..f097d101d 100644
 --- a/octavia/common/constants.py
 +++ b/octavia/common/constants.py
-@@ -977,3 +977,6 @@ NFT_TABLE = 'amphora_table'
- NFT_CHAIN = 'amphora_chain'
- NFT_VIP_CHAIN = 'amphora_vip_chain'
- PROTOCOL = 'protocol'
-+
+@@ -968,6 +968,9 @@ IFLA_IFNAME = 'IFLA_IFNAME'
+ # Amphora network directory
+ AMP_NET_DIR_TEMPLATE = '/etc/octavia/interfaces/'
+ 
 +# Amphora failover retries on ERROR status
 +AMP_ERR_RETRIES = 'error_retries'
++
+ # Amphora nftables constants
+ NFT_ADD = 'add'
+ NFT_CMD = '/usr/sbin/nft'
 diff --git a/octavia/common/data_models.py b/octavia/common/data_models.py
 index b416c25e7..059684561 100644
 --- a/octavia/common/data_models.py
@@ -88,10 +83,10 @@ index b416c25e7..059684561 100644
      def delete(self):
          for amphora in self.load_balancer.amphorae:
 diff --git a/octavia/controller/healthmanager/health_manager.py b/octavia/controller/healthmanager/health_manager.py
-index 1ba19c025..d037564e9 100644
+index 24e1761ac..7902bde73 100644
 --- a/octavia/controller/healthmanager/health_manager.py
 +++ b/octavia/controller/healthmanager/health_manager.py
-@@ -138,7 +138,8 @@ class HealthManager:
+@@ -132,7 +132,8 @@ class HealthManager:
  
              LOG.info("Stale amphora's id is: %s", amp_health.amphora_id)
              fut = self.executor.submit(
@@ -102,7 +97,7 @@ index 1ba19c025..d037564e9 100644
                  functools.partial(update_stats_on_done, stats)
              )
 diff --git a/octavia/controller/worker/v2/controller_worker.py b/octavia/controller/worker/v2/controller_worker.py
-index fa1feb216..1ad6616a0 100644
+index fa1feb216..0a4d9132b 100644
 --- a/octavia/controller/worker/v2/controller_worker.py
 +++ b/octavia/controller/worker/v2/controller_worker.py
 @@ -395,7 +395,8 @@ class ControllerWorker:
@@ -130,7 +125,7 @@ index fa1feb216..1ad6616a0 100644
          :param amphora_id: ID for amphora to failover
          :param reraise: If enabled reraise any caught exception
 +        :param count_error_retries: If enabled allows counts Amphora failover
-+        on ERROR status
++            on ERROR status
          :returns: None
          :raises octavia.common.exceptions.NotFound: The referenced amphora was
                                                      not found
@@ -163,6 +158,17 @@ index fa1feb216..1ad6616a0 100644
  
              self.run_flow(
                  flow_utils.get_failover_amphora_flow,
+@@ -1218,7 +1235,9 @@ class ControllerWorker:
+                                  constants.LB_CREATE_FAILOVER_PRIORITY,
+                              constants.SERVER_GROUP_ID: lb.server_group_id,
+                              constants.LOADBALANCER_ID: lb.id,
+-                             constants.FLAVOR: flavor}
++                             constants.FLAVOR: flavor,
++                             constants.AMP_ERR_RETRIES: 0,
++                             }
+ 
+             if lb.availability_zone:
+                 with session.begin():
 diff --git a/octavia/controller/worker/v2/flows/amphora_flows.py b/octavia/controller/worker/v2/flows/amphora_flows.py
 index 45816b2f7..ff624a8d6 100644
 --- a/octavia/controller/worker/v2/flows/amphora_flows.py
@@ -177,7 +183,7 @@ index 45816b2f7..ff624a8d6 100644
  
          create_amp_for_lb_subflow.add(cert_task.GenerateServerPEMTask(
 diff --git a/octavia/controller/worker/v2/tasks/database_tasks.py b/octavia/controller/worker/v2/tasks/database_tasks.py
-index 48b4d92d4..3ccfcc44b 100644
+index e78ef41d7..ca2cdf2bd 100644
 --- a/octavia/controller/worker/v2/tasks/database_tasks.py
 +++ b/octavia/controller/worker/v2/tasks/database_tasks.py
 @@ -102,7 +102,8 @@ class CreateAmphoraInDB(BaseDatabaseTask):
@@ -248,7 +254,7 @@ index e1ab20ba3..63c109a85 100644
      def __str__(self):
          return (f"Amphora(id={self.id!r}, load_balancer_id="
 diff --git a/octavia/db/repositories.py b/octavia/db/repositories.py
-index 48656540e..bed58c450 100644
+index cc4bd6f8a..f8cd51e71 100644
 --- a/octavia/db/repositories.py
 +++ b/octavia/db/repositories.py
 @@ -27,6 +27,8 @@ from oslo_db import exception as db_exception
@@ -260,7 +266,7 @@ index 48656540e..bed58c450 100644
  from sqlalchemy.orm import noload
  from sqlalchemy.orm import Session
  from sqlalchemy.orm import subqueryload
-@@ -1605,11 +1607,35 @@ class AmphoraHealthRepository(BaseRepository):
+@@ -1579,11 +1581,35 @@ class AmphoraHealthRepository(BaseRepository):
          # We don't want to attempt to failover amphora that are not
          # currently in the ALLOCATED or FAILOVER_STOPPED state.
          # i.e. Not DELETED, PENDING_*, etc.
@@ -300,6 +306,464 @@ index 48656540e..bed58c450 100644
  
          # Pick one expired amphora for automatic failover
          amp_health = lock_session.query(
+diff --git a/octavia/tests/functional/db/test_repositories.py b/octavia/tests/functional/db/test_repositories.py
+index ebb4532cf..e5e47202f 100644
+--- a/octavia/tests/functional/db/test_repositories.py
++++ b/octavia/tests/functional/db/test_repositories.py
+@@ -3957,6 +3957,48 @@ class AmphoraHealthRepositoryTest(BaseRepositoryTest):
+             self.session)
+         self.assertEqual(uuid, stale_amphora.amphora_id)
+ 
++    def test_get_stale_error_amphora(self):
++        conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
++        conf.config(group='health_manager', failover_on_error=True)
++        self._get_stale_error_amphora()
++
++    def _get_stale_error_amphora(self):
++        stale_amphora = self.amphora_health_repo.get_stale_amphora(
++            self.session)
++        self.assertIsNone(stale_amphora)
++
++        uuid = uuidutils.generate_uuid()
++        self.create_amphora(uuid)
++        self.amphora_repo.update(self.session, uuid,
++                                 status=constants.ERROR)
++        self.create_amphora_health(uuid)
++        stale_amphora = self.amphora_health_repo.get_stale_amphora(
++            self.session)
++        self.assertEqual(uuid, stale_amphora.amphora_id)
++
++    def test_get_stale_error_amphora_with_unlimited(self):
++        conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
++        conf.config(group='health_manager', failover_on_error=True)
++        conf.config(group='health_manager', failover_on_error_max_retries=-1)
++        self._get_stale_error_amphora()
++
++    def test_get_stale_error_amphora_with_limit_hit(self):
++        conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
++        conf.config(group='health_manager', failover_on_error=True)
++        conf.config(group='health_manager', failover_on_error_max_retries=0)
++        stale_amphora = self.amphora_health_repo.get_stale_amphora(
++            self.session)
++        self.assertIsNone(stale_amphora)
++
++        uuid = uuidutils.generate_uuid()
++        self.create_amphora(uuid)
++        self.amphora_repo.update(self.session, uuid,
++                                 status=constants.ERROR)
++        self.create_amphora_health(uuid)
++        stale_amphora = self.amphora_health_repo.get_stale_amphora(
++            self.session)
++        self.assertIsNone(stale_amphora)
++
+     def test_get_stale_amphora_past_threshold(self):
+         conf = self.useFixture(oslo_fixture.Config(cfg.CONF))
+         conf.config(group='health_manager', failover_threshold=3)
+diff --git a/octavia/tests/unit/controller/worker/v2/flows/test_amphora_flows.py b/octavia/tests/unit/controller/worker/v2/flows/test_amphora_flows.py
+index 5c3f3fbba..936b2d83e 100644
+--- a/octavia/tests/unit/controller/worker/v2/flows/test_amphora_flows.py
++++ b/octavia/tests/unit/controller/worker/v2/flows/test_amphora_flows.py
+@@ -97,6 +97,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.AVAILABILITY_ZONE, amp_flow.requires)
+         self.assertIn(constants.BUILD_TYPE_PRIORITY, amp_flow.requires)
+         self.assertIn(constants.LOADBALANCER_ID, amp_flow.requires)
++        self.assertIn(constants.AMP_ERR_RETRIES, amp_flow.requires)
+ 
+         self.assertIn(constants.AMPHORA, amp_flow.provides)
+         self.assertIn(constants.AMPHORA_ID, amp_flow.provides)
+@@ -105,7 +106,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.SERVER_PEM, amp_flow.provides)
+ 
+         self.assertEqual(5, len(amp_flow.provides))
+-        self.assertEqual(5, len(amp_flow.requires))
++        self.assertEqual(6, len(amp_flow.requires))
+ 
+     def test_get_cert_create_amphora_for_lb_flow(self, mock_get_net_driver):
+ 
+@@ -120,6 +121,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.AVAILABILITY_ZONE, amp_flow.requires)
+         self.assertIn(constants.BUILD_TYPE_PRIORITY, amp_flow.requires)
+         self.assertIn(constants.LOADBALANCER_ID, amp_flow.requires)
++        self.assertIn(constants.AMP_ERR_RETRIES, amp_flow.requires)
+ 
+         self.assertIn(constants.AMPHORA, amp_flow.provides)
+         self.assertIn(constants.AMPHORA_ID, amp_flow.provides)
+@@ -128,7 +130,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.SERVER_PEM, amp_flow.provides)
+ 
+         self.assertEqual(5, len(amp_flow.provides))
+-        self.assertEqual(5, len(amp_flow.requires))
++        self.assertEqual(6, len(amp_flow.requires))
+ 
+     def test_get_cert_master_create_amphora_for_lb_flow(
+             self, mock_get_net_driver):
+@@ -144,6 +146,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.AVAILABILITY_ZONE, amp_flow.requires)
+         self.assertIn(constants.BUILD_TYPE_PRIORITY, amp_flow.requires)
+         self.assertIn(constants.LOADBALANCER_ID, amp_flow.requires)
++        self.assertIn(constants.AMP_ERR_RETRIES, amp_flow.requires)
+ 
+         self.assertIn(constants.AMPHORA, amp_flow.provides)
+         self.assertIn(constants.AMPHORA_ID, amp_flow.provides)
+@@ -152,7 +155,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.SERVER_PEM, amp_flow.provides)
+ 
+         self.assertEqual(5, len(amp_flow.provides))
+-        self.assertEqual(5, len(amp_flow.requires))
++        self.assertEqual(6, len(amp_flow.requires))
+ 
+     def test_get_cert_master_rest_anti_affinity_create_amphora_for_lb_flow(
+             self, mock_get_net_driver):
+@@ -170,6 +173,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.BUILD_TYPE_PRIORITY, amp_flow.requires)
+         self.assertIn(constants.LOADBALANCER_ID, amp_flow.requires)
+         self.assertIn(constants.SERVER_GROUP_ID, amp_flow.requires)
++        self.assertIn(constants.AMP_ERR_RETRIES, amp_flow.requires)
+ 
+         self.assertIn(constants.AMPHORA, amp_flow.provides)
+         self.assertIn(constants.AMPHORA_ID, amp_flow.provides)
+@@ -178,7 +182,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.SERVER_PEM, amp_flow.provides)
+ 
+         self.assertEqual(5, len(amp_flow.provides))
+-        self.assertEqual(5, len(amp_flow.requires))
++        self.assertEqual(6, len(amp_flow.requires))
+         self.conf.config(group="nova", enable_anti_affinity=False)
+ 
+     def test_get_cert_backup_create_amphora_for_lb_flow(
+@@ -194,6 +198,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.AVAILABILITY_ZONE, amp_flow.requires)
+         self.assertIn(constants.BUILD_TYPE_PRIORITY, amp_flow.requires)
+         self.assertIn(constants.LOADBALANCER_ID, amp_flow.requires)
++        self.assertIn(constants.AMP_ERR_RETRIES, amp_flow.requires)
+ 
+         self.assertIn(constants.AMPHORA, amp_flow.provides)
+         self.assertIn(constants.AMPHORA_ID, amp_flow.provides)
+@@ -202,7 +207,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.SERVER_PEM, amp_flow.provides)
+ 
+         self.assertEqual(5, len(amp_flow.provides))
+-        self.assertEqual(5, len(amp_flow.requires))
++        self.assertEqual(6, len(amp_flow.requires))
+ 
+     def test_get_cert_bogus_create_amphora_for_lb_flow(
+             self, mock_get_net_driver):
+@@ -217,6 +222,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.AVAILABILITY_ZONE, amp_flow.requires)
+         self.assertIn(constants.BUILD_TYPE_PRIORITY, amp_flow.requires)
+         self.assertIn(constants.LOADBALANCER_ID, amp_flow.requires)
++        self.assertIn(constants.AMP_ERR_RETRIES, amp_flow.requires)
+ 
+         self.assertIn(constants.AMPHORA, amp_flow.provides)
+         self.assertIn(constants.AMPHORA_ID, amp_flow.provides)
+@@ -225,7 +231,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.SERVER_PEM, amp_flow.provides)
+ 
+         self.assertEqual(5, len(amp_flow.provides))
+-        self.assertEqual(5, len(amp_flow.requires))
++        self.assertEqual(6, len(amp_flow.requires))
+ 
+     def test_get_cert_backup_rest_anti_affinity_create_amphora_for_lb_flow(
+             self, mock_get_net_driver):
+@@ -242,6 +248,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.BUILD_TYPE_PRIORITY, amp_flow.requires)
+         self.assertIn(constants.LOADBALANCER_ID, amp_flow.requires)
+         self.assertIn(constants.SERVER_GROUP_ID, amp_flow.requires)
++        self.assertIn(constants.AMP_ERR_RETRIES, amp_flow.requires)
+ 
+         self.assertIn(constants.AMPHORA_ID, amp_flow.provides)
+         self.assertIn(constants.SERVER_GROUP_ID, amp_flow.requires)
+@@ -250,7 +257,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.SERVER_PEM, amp_flow.provides)
+ 
+         self.assertEqual(5, len(amp_flow.provides))
+-        self.assertEqual(5, len(amp_flow.requires))
++        self.assertEqual(6, len(amp_flow.requires))
+         self.conf.config(group="nova", enable_anti_affinity=False)
+ 
+     def test_get_delete_amphora_flow(self, mock_get_net_driver):
+@@ -280,6 +287,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.LOADBALANCER, amp_flow.requires)
+         self.assertIn(constants.LOADBALANCER_ID, amp_flow.requires)
+         self.assertIn(constants.VIP, amp_flow.requires)
++        self.assertIn(constants.AMP_ERR_RETRIES, amp_flow.requires)
+ 
+         self.assertIn(constants.UPDATED_PORTS, amp_flow.provides)
+         self.assertIn(constants.AMP_VRRP_INT, amp_flow.provides)
+@@ -296,7 +304,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.SERVER_PEM, amp_flow.provides)
+         self.assertIn(constants.VIP_SG_ID, amp_flow.provides)
+ 
+-        self.assertEqual(8, len(amp_flow.requires))
++        self.assertEqual(9, len(amp_flow.requires))
+         self.assertEqual(14, len(amp_flow.provides))
+ 
+     def test_get_failover_flow_standalone(self, mock_get_net_driver):
+@@ -316,6 +324,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.LOADBALANCER, amp_flow.requires)
+         self.assertIn(constants.LOADBALANCER_ID, amp_flow.requires)
+         self.assertIn(constants.VIP, amp_flow.requires)
++        self.assertIn(constants.AMP_ERR_RETRIES, amp_flow.requires)
+ 
+         self.assertIn(constants.UPDATED_PORTS, amp_flow.provides)
+         self.assertIn(constants.AMPHORA, amp_flow.provides)
+@@ -331,7 +340,7 @@ class TestAmphoraFlows(base.TestCase):
+         self.assertIn(constants.SERVER_PEM, amp_flow.provides)
+         self.assertIn(constants.VIP_SG_ID, amp_flow.provides)
+ 
+-        self.assertEqual(8, len(amp_flow.requires))
++        self.assertEqual(9, len(amp_flow.requires))
+         self.assertEqual(13, len(amp_flow.provides))
+ 
+     def test_get_failover_flow_bogus_role(self, mock_get_net_driver):
+diff --git a/octavia/tests/unit/controller/worker/v2/flows/test_load_balancer_flows.py b/octavia/tests/unit/controller/worker/v2/flows/test_load_balancer_flows.py
+index fc48ce8b9..e36da6597 100644
+--- a/octavia/tests/unit/controller/worker/v2/flows/test_load_balancer_flows.py
++++ b/octavia/tests/unit/controller/worker/v2/flows/test_load_balancer_flows.py
+@@ -270,6 +270,7 @@ class TestLoadBalancerFlows(base.TestCase):
+         self.assertIn(constants.FLAVOR, create_flow.requires)
+         self.assertIn(constants.AVAILABILITY_ZONE, create_flow.requires)
+         self.assertIn(constants.SERVER_GROUP_ID, create_flow.requires)
++        self.assertIn(constants.AMP_ERR_RETRIES, create_flow.requires)
+ 
+         self.assertIn(constants.LISTENERS, create_flow.provides)
+         self.assertIn(constants.SUBNET, create_flow.provides)
+@@ -287,7 +288,7 @@ class TestLoadBalancerFlows(base.TestCase):
+         self.assertIn(constants.ADDITIONAL_VIPS, create_flow.provides)
+         self.assertIn(constants.AMPHORAE_NETWORK_CONFIG, create_flow.provides)
+ 
+-        self.assertEqual(6, len(create_flow.requires))
++        self.assertEqual(7, len(create_flow.requires))
+         self.assertEqual(15, len(create_flow.provides))
+ 
+     @mock.patch('octavia.common.rpc.NOTIFIER',
+@@ -306,6 +307,7 @@ class TestLoadBalancerFlows(base.TestCase):
+         self.assertIn(constants.LOADBALANCER_ID, create_flow.requires)
+         self.assertIn(constants.SERVER_GROUP_ID, create_flow.requires)
+         self.assertIn(constants.UPDATE_DICT, create_flow.requires)
++        self.assertIn(constants.AMP_ERR_RETRIES, create_flow.requires)
+ 
+         self.assertIn(constants.UPDATED_PORTS, create_flow.provides)
+         self.assertIn(constants.AMP_DATA, create_flow.provides)
+@@ -326,7 +328,7 @@ class TestLoadBalancerFlows(base.TestCase):
+         self.assertIn(constants.VIP, create_flow.provides)
+         self.assertIn(constants.ADDITIONAL_VIPS, create_flow.provides)
+ 
+-        self.assertEqual(6, len(create_flow.requires), create_flow.requires)
++        self.assertEqual(7, len(create_flow.requires), create_flow.requires)
+         self.assertEqual(18, len(create_flow.provides),
+                          create_flow.provides)
+ 
+@@ -344,6 +346,7 @@ class TestLoadBalancerFlows(base.TestCase):
+         self.assertIn(constants.FLAVOR, failover_flow.requires)
+         self.assertIn(constants.LOADBALANCER, failover_flow.requires)
+         self.assertIn(constants.LOADBALANCER_ID, failover_flow.requires)
++        self.assertIn(constants.AMP_ERR_RETRIES, failover_flow.requires)
+ 
+         self.assertIn(constants.UPDATED_PORTS, failover_flow.provides)
+         self.assertIn(constants.AMPHORA, failover_flow.provides)
+@@ -363,7 +366,7 @@ class TestLoadBalancerFlows(base.TestCase):
+         self.assertIn(constants.SUBNET, failover_flow.provides)
+         self.assertIn(constants.NEW_AMPHORAE, failover_flow.provides)
+ 
+-        self.assertEqual(6, len(failover_flow.requires),
++        self.assertEqual(7, len(failover_flow.requires),
+                          failover_flow.requires)
+         self.assertEqual(17, len(failover_flow.provides),
+                          failover_flow.provides)
+@@ -423,6 +426,7 @@ class TestLoadBalancerFlows(base.TestCase):
+         self.assertIn(constants.FLAVOR, failover_flow.requires)
+         self.assertIn(constants.LOADBALANCER, failover_flow.requires)
+         self.assertIn(constants.LOADBALANCER_ID, failover_flow.requires)
++        self.assertIn(constants.AMP_ERR_RETRIES, failover_flow.requires)
+ 
+         self.assertIn(constants.UPDATED_PORTS, failover_flow.provides)
+         self.assertIn(constants.AMPHORA, failover_flow.provides)
+@@ -443,7 +447,7 @@ class TestLoadBalancerFlows(base.TestCase):
+         self.assertIn(constants.SUBNET, failover_flow.provides)
+         self.assertIn(constants.NEW_AMPHORAE, failover_flow.provides)
+ 
+-        self.assertEqual(6, len(failover_flow.requires),
++        self.assertEqual(7, len(failover_flow.requires),
+                          failover_flow.requires)
+         self.assertEqual(17, len(failover_flow.provides),
+                          failover_flow.provides)
+diff --git a/octavia/tests/unit/controller/worker/v2/test_controller_worker.py b/octavia/tests/unit/controller/worker/v2/test_controller_worker.py
+index 71285ce39..ea7cc2639 100644
+--- a/octavia/tests/unit/controller/worker/v2/test_controller_worker.py
++++ b/octavia/tests/unit/controller/worker/v2/test_controller_worker.py
+@@ -540,6 +540,7 @@ class TestControllerWorker(base.TestCase):
+             constants.FLAVOR: None,
+             constants.SERVER_GROUP_ID: None,
+             constants.AVAILABILITY_ZONE: None,
++            constants.AMP_ERR_RETRIES: 0,
+         }
+         lb_mock = mock.MagicMock()
+         lb_mock.listeners = []
+@@ -581,6 +582,7 @@ class TestControllerWorker(base.TestCase):
+             constants.FLAVOR: None,
+             constants.SERVER_GROUP_ID: None,
+             constants.AVAILABILITY_ZONE: None,
++            constants.AMP_ERR_RETRIES: 0,
+         }
+         setattr(mock_lb_repo_get.return_value, 'topology',
+                 constants.TOPOLOGY_ACTIVE_STANDBY)
+@@ -627,6 +629,7 @@ class TestControllerWorker(base.TestCase):
+             constants.FLAVOR: None,
+             constants.SERVER_GROUP_ID: None,
+             constants.AVAILABILITY_ZONE: None,
++            constants.AMP_ERR_RETRIES: 0,
+         }
+ 
+         cw = controller_worker.ControllerWorker()
+@@ -674,6 +677,7 @@ class TestControllerWorker(base.TestCase):
+             constants.FLAVOR: None,
+             constants.SERVER_GROUP_ID: None,
+             constants.AVAILABILITY_ZONE: None,
++            constants.AMP_ERR_RETRIES: 0,
+         }
+ 
+         cw = controller_worker.ControllerWorker()
+@@ -721,6 +725,7 @@ class TestControllerWorker(base.TestCase):
+             constants.FLAVOR: None,
+             constants.SERVER_GROUP_ID: None,
+             constants.AVAILABILITY_ZONE: None,
++            constants.AMP_ERR_RETRIES: 0,
+         }
+ 
+         cw = controller_worker.ControllerWorker()
+@@ -1560,7 +1565,9 @@ class TestControllerWorker(base.TestCase):
+             constants.LOADBALANCER_ID: LB_ID,
+             constants.SERVER_GROUP_ID: None,
+             constants.VIP: mock_lb.vip.to_dict(),
+-            constants.ADDITIONAL_VIPS: []}
++            constants.ADDITIONAL_VIPS: [],
++            constants.AMP_ERR_RETRIES: 0
++        }
+ 
+         cw = controller_worker.ControllerWorker()
+         cw.services_controller.reset_mock()
+@@ -1617,7 +1624,9 @@ class TestControllerWorker(base.TestCase):
+             constants.LOADBALANCER_ID: LB_ID,
+             constants.SERVER_GROUP_ID: None,
+             constants.VIP: mock_lb.vip.to_dict(),
+-            constants.ADDITIONAL_VIPS: []}
++            constants.ADDITIONAL_VIPS: [],
++            constants.AMP_ERR_RETRIES: 0
++        }
+ 
+         cw = controller_worker.ControllerWorker()
+         cw.services_controller.reset_mock()
+@@ -1674,7 +1683,9 @@ class TestControllerWorker(base.TestCase):
+             constants.LOADBALANCER_ID: LB_ID,
+             constants.SERVER_GROUP_ID: SERVER_GROUP_ID,
+             constants.VIP: mock_lb.vip.to_dict(),
+-            constants.ADDITIONAL_VIPS: []}
++            constants.ADDITIONAL_VIPS: [],
++            constants.AMP_ERR_RETRIES: 0
++        }
+ 
+         cw = controller_worker.ControllerWorker()
+         cw.services_controller.reset_mock()
+@@ -1727,7 +1738,9 @@ class TestControllerWorker(base.TestCase):
+             constants.LOADBALANCER_ID: LB_ID,
+             constants.SERVER_GROUP_ID: SERVER_GROUP_ID,
+             constants.VIP: mock_lb.vip.to_dict(),
+-            constants.ADDITIONAL_VIPS: []}
++            constants.ADDITIONAL_VIPS: [],
++            constants.AMP_ERR_RETRIES: 0
++        }
+ 
+         cw = controller_worker.ControllerWorker()
+         cw.services_controller.reset_mock()
+@@ -1784,7 +1797,9 @@ class TestControllerWorker(base.TestCase):
+             constants.LOADBALANCER_ID: LB_ID,
+             constants.SERVER_GROUP_ID: None,
+             constants.VIP: mock_lb.vip.to_dict(),
+-            constants.ADDITIONAL_VIPS: []}
++            constants.ADDITIONAL_VIPS: [],
++            constants.AMP_ERR_RETRIES: 0
++        }
+         mock_get_flavor_meta.return_value = {'taste': 'spicy'}
+ 
+         cw = controller_worker.ControllerWorker()
+@@ -1842,7 +1857,9 @@ class TestControllerWorker(base.TestCase):
+             constants.LOADBALANCER_ID: LB_ID,
+             constants.SERVER_GROUP_ID: None,
+             constants.VIP: mock_lb.vip.to_dict(),
+-            constants.ADDITIONAL_VIPS: []}
++            constants.ADDITIONAL_VIPS: [],
++            constants.AMP_ERR_RETRIES: 0
++        }
+         mock_get_az_meta.return_value = {'planet': 'jupiter'}
+ 
+         cw = controller_worker.ControllerWorker()
+@@ -1903,7 +1920,9 @@ class TestControllerWorker(base.TestCase):
+             constants.ADDITIONAL_VIPS: [
+                 add_vips.to_dict()
+                 for add_vips in mock_additional_vips
+-            ]}
++            ],
++            constants.AMP_ERR_RETRIES: 0
++        }
+ 
+         cw = controller_worker.ControllerWorker()
+         cw.services_controller.reset_mock()
+@@ -2016,7 +2035,9 @@ class TestControllerWorker(base.TestCase):
+                                   constants.LOADBALANCER_ID: None,
+                                   constants.SERVER_GROUP_ID: None,
+                                   constants.VIP: {},
+-                                  constants.ADDITIONAL_VIPS: []}
++                                  constants.ADDITIONAL_VIPS: [],
++                                  constants.AMP_ERR_RETRIES: 0
++                                  }
+ 
+         cw = controller_worker.ControllerWorker()
+         cw.services_controller.reset_mock()
+@@ -2217,7 +2238,9 @@ class TestControllerWorker(base.TestCase):
+                                    _load_balancer_mock[
+                                        constants.SERVER_GROUP_ID],
+                                constants.FLAVOR: expected_flavor,
+-                               constants.AVAILABILITY_ZONE: {}}
++                               constants.AVAILABILITY_ZONE: {},
++                               constants.AMP_ERR_RETRIES: 0
++                               }
+ 
+         cw = controller_worker.ControllerWorker()
+         cw.failover_loadbalancer(LB_ID)
+@@ -2269,7 +2292,9 @@ class TestControllerWorker(base.TestCase):
+                                constants.SERVER_GROUP_ID:
+                                    load_balancer_mock.server_group_id,
+                                constants.FLAVOR: expected_flavor,
+-                               constants.AVAILABILITY_ZONE: {}}
++                               constants.AVAILABILITY_ZONE: {},
++                               constants.AMP_ERR_RETRIES: 0
++                               }
+ 
+         cw = controller_worker.ControllerWorker()
+         cw.failover_loadbalancer(LB_ID)
+@@ -2370,7 +2395,9 @@ class TestControllerWorker(base.TestCase):
+                                constants.SERVER_GROUP_ID:
+                                    load_balancer_mock.server_group_id,
+                                constants.AVAILABILITY_ZONE: {
+-                                   'planet': 'jupiter'}}
++                                   'planet': 'jupiter'},
++                               constants.AMP_ERR_RETRIES: 0
++                               }
+ 
+         cw = controller_worker.ControllerWorker()
+         cw.failover_loadbalancer(LB_ID)
+@@ -2424,7 +2451,9 @@ class TestControllerWorker(base.TestCase):
+                                constants.FLAVOR: expected_flavor,
+                                constants.SERVER_GROUP_ID:
+                                    load_balancer_mock.server_group_id,
+-                               constants.AVAILABILITY_ZONE: {}}
++                               constants.AVAILABILITY_ZONE: {},
++                               constants.AMP_ERR_RETRIES: 0
++                               }
+ 
+         cw = controller_worker.ControllerWorker()
+         cw.failover_loadbalancer(LB_ID)
 diff --git a/releasenotes/notes/allow-error-amphora-failover-ab882982adc05f01.yaml b/releasenotes/notes/allow-error-amphora-failover-ab882982adc05f01.yaml
 new file mode 100644
 index 000000000..5fabe45ff

--- a/roles/octavia/vars/main.yml
+++ b/roles/octavia/vars/main.yml
@@ -118,6 +118,7 @@ _octavia_helm_values:
       health_manager:
         controller_ip_port_list: "{{ _octavia_controller_ip_port_list | sort | join(',') }}"
         heartbeat_key: "{{ octavia_heartbeat_key }}"
+        failover_on_error: true
       oslo_messaging_notifications:
         driver: noop
       neutron:


### PR DESCRIPTION
add health_manager.failover_on_error config to allow running failover when an Amphora is expired with heartbeats and in ERROR status. ref: https://review.opendev.org/c/openstack/octavia/+/934638