### PR TITLE
[ATMOSPHERE-606] replace value of dnsmasq_dns_servers to 1.1.1.1

### DIFF
--- a/roles/neutron/vars/main.yml
+++ b/roles/neutron/vars/main.yml
@@ -58,7 +58,6 @@ __neutron_helm_values:
         driver: noop
       service_providers:
         service_provider: VPN:strongswan:neutron_vpnaas.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default
-      neutron_default_dns_servers: 10.96.0.20
     dhcp_agent:
       DEFAULT:
         dnsmasq_dns_servers: "{{ neutron_coredns_cluster_ip | default('10.96.0.20') }}"
@@ -94,10 +93,6 @@ __neutron_ovn_helm_values:
         ovn_emit_need_to_frag: true
       service_providers:
         service_provider: VPN:strongswan:neutron_vpnaas.services.vpn.service_drivers.ovn_ipsec.IPsecOvnVPNDriver:default
-    dhcp_agent:
-      DEFAULT:
-        dnsmasq_dns_servers: "{{ neutron_coredns_cluster_ip | default('1.1.1.1') }}"
-        enable_isolated_metadata: true
     ovn_metadata_agent:
       DEFAULT:
         metadata_proxy_shared_secret: "{{ openstack_helm_endpoints['compute_metadata']['secret'] }}"

--- a/roles/neutron/vars/main.yml
+++ b/roles/neutron/vars/main.yml
@@ -58,9 +58,10 @@ __neutron_helm_values:
         driver: noop
       service_providers:
         service_provider: VPN:strongswan:neutron_vpnaas.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default
+      neutron_default_dns_servers: 10.96.0.20
     dhcp_agent:
       DEFAULT:
-        dnsmasq_dns_servers: "{{ neutron_coredns_cluster_ip | default('1.1.1.1') }}"
+        dnsmasq_dns_servers: "{{ neutron_coredns_cluster_ip | default('10.96.0.20') }}"
         enable_isolated_metadata: true
     l3_agent:
       AGENT:
@@ -93,6 +94,10 @@ __neutron_ovn_helm_values:
         ovn_emit_need_to_frag: true
       service_providers:
         service_provider: VPN:strongswan:neutron_vpnaas.services.vpn.service_drivers.ovn_ipsec.IPsecOvnVPNDriver:default
+    dhcp_agent:
+      DEFAULT:
+        dnsmasq_dns_servers: "{{ neutron_coredns_cluster_ip | default('1.1.1.1') }}"
+        enable_isolated_metadata: true
     ovn_metadata_agent:
       DEFAULT:
         metadata_proxy_shared_secret: "{{ openstack_helm_endpoints['compute_metadata']['secret'] }}"

--- a/roles/neutron/vars/main.yml
+++ b/roles/neutron/vars/main.yml
@@ -58,7 +58,6 @@ __neutron_helm_values:
         driver: noop
       service_providers:
         service_provider: VPN:strongswan:neutron_vpnaas.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default
-      neutron_default_dns_servers: 10.96.0.20
     dhcp_agent:
       DEFAULT:
         dnsmasq_dns_servers: "{{ neutron_coredns_cluster_ip | default('10.96.0.20') }}"

--- a/roles/neutron/vars/main.yml
+++ b/roles/neutron/vars/main.yml
@@ -60,7 +60,7 @@ __neutron_helm_values:
         service_provider: VPN:strongswan:neutron_vpnaas.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default
     dhcp_agent:
       DEFAULT:
-        dnsmasq_dns_servers: "{{ neutron_coredns_cluster_ip | default('10.96.0.20') }}"
+        dnsmasq_dns_servers: "{{ neutron_coredns_cluster_ip | default('1.1.1.1') }}"
         enable_isolated_metadata: true
     l3_agent:
       AGENT:

--- a/roles/neutron/vars/main.yml
+++ b/roles/neutron/vars/main.yml
@@ -58,10 +58,10 @@ __neutron_helm_values:
         driver: noop
       service_providers:
         service_provider: VPN:strongswan:neutron_vpnaas.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default
+      neutron_default_dns_servers: 10.96.0.20
     dhcp_agent:
       DEFAULT:
         dnsmasq_dns_servers: "{{ neutron_coredns_cluster_ip | default('10.96.0.20') }}"
-        enable_isolated_metadata: true
     l3_agent:
       AGENT:
         extensions: vpnaas
@@ -93,6 +93,9 @@ __neutron_ovn_helm_values:
         ovn_emit_need_to_frag: true
       service_providers:
         service_provider: VPN:strongswan:neutron_vpnaas.services.vpn.service_drivers.ovn_ipsec.IPsecOvnVPNDriver:default
+    dhcp_agent:
+      DEFAULT:
+        dnsmasq_dns_servers: "{{ neutron_coredns_cluster_ip | default('1.1.1.1') }}"
     ovn_metadata_agent:
       DEFAULT:
         metadata_proxy_shared_secret: "{{ openstack_helm_endpoints['compute_metadata']['secret'] }}"


### PR DESCRIPTION
The bug was detected when customer env use OVN and they got 10.96.0.20 for nameserves from DHCP Agent. We can unset in on [atmosphere/roles/neutron/vars/main.yml at main · vexxhost/atmosphere](https://github.com/vexxhost/atmosphere/blob/main/roles/neutron/vars/main.yml) line 63 or replace that value with public DNS, e.g. 1.1.1.1.