### PR TITLE
Fix Ingress when user costume the rook cluster name

### DIFF
--- a/roles/rook_ceph_cluster/tasks/main.yml
+++ b/roles/rook_ceph_cluster/tasks/main.yml
@@ -129,6 +129,6 @@
     name: openstack_helm_ingress
   vars:
     openstack_helm_ingress_endpoint: rook_ceph_cluster
-    openstack_helm_ingress_service_name: rook-ceph-rgw-ceph
+    openstack_helm_ingress_service_name: rook-ceph-rgw-{{ rook_ceph_cluster_name }}
     openstack_helm_ingress_service_port: 80
     openstack_helm_ingress_annotations: "{{ _rook_ceph_cluster_radosgw_annotations | combine(rook_ceph_cluster_radosgw_annotations, recursive=True) }}"


### PR DESCRIPTION
variable `rook-ceph-rgw-ceph` cannot be static like this since user can naming the rook cluster name through `rook_ceph_cluster_name` variable