### PR TITLE
add orphan-delete role

### DIFF
--- a/roles/memcached/tasks/main.yml
+++ b/roles/memcached/tasks/main.yml
@@ -12,6 +12,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Delete old resources
+  ansible.builtin.include_role:
+    name: orphan_delete
+  vars:
+    orphan_delete_deployments: memcached-memcached
+  when: memcached_orphan_delete
+
 - name: Deploy Helm chart
   run_once: true
   kubernetes.core.helm:

--- a/roles/orphan_delete/README.md
+++ b/roles/orphan_delete/README.md
@@ -1,0 +1,8 @@
+# `orphan_delete`
+
+The `orphan_delete` Ansible role provides a reusable mechanism to delete
+Kubernetes resources (Deployments, StatefulSets, etc.) without removing
+their underlying pods or workloads. It uses the `Orphan` propagation policy
+to ensure that resources are deleted while leaving the pods in place, making
+it ideal for scenarios like upgrading Helm charts where immutability of
+certain fields (e.g., labels) can cause failures.

--- a/roles/orphan_delete/defaults/main.yml
+++ b/roles/orphan_delete/defaults/main.yml
@@ -12,12 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-memcached_helm_release_name: memcached
-memcached_helm_chart_path: "../../charts/memcached/"
-memcached_helm_chart_ref: /usr/local/src/memcached
+# Deployments to be deleted in orphan policy
+orphan_delete_deployments: []
 
-memcached_helm_release_namespace: openstack
-memcached_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
-memcached_helm_values: {}
-
-memcached_orphan_delete: "{{ atmosphere_orphan_delete }}"
+# StatefulSets to be deleted in orphan policy
+orphan_delete_statefulsets: []

--- a/roles/orphan_delete/meta/main.yml
+++ b/roles/orphan_delete/meta/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 VEXXHOST, Inc.
+# Copyright (c) 2022 VEXXHOST, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -12,12 +12,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-memcached_helm_release_name: memcached
-memcached_helm_chart_path: "../../charts/memcached/"
-memcached_helm_chart_ref: /usr/local/src/memcached
-
-memcached_helm_release_namespace: openstack
-memcached_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
-memcached_helm_values: {}
-
-memcached_orphan_delete: "{{ atmosphere_orphan_delete }}"
+galaxy_info:
+  author: VEXXHOST, Inc.
+  description: Ansible role for deleting Kubernetes resources with orphan deletion policy
+  license: Apache-2.0
+  min_ansible_version: 5.5.0
+  standalone: false
+  platforms:
+    - name: Ubuntu
+      versions:
+        - focal

--- a/roles/orphan_delete/tasks/main.yml
+++ b/roles/orphan_delete/tasks/main.yml
@@ -12,12 +12,23 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-memcached_helm_release_name: memcached
-memcached_helm_chart_path: "../../charts/memcached/"
-memcached_helm_chart_ref: /usr/local/src/memcached
 
-memcached_helm_release_namespace: openstack
-memcached_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
-memcached_helm_values: {}
+- name: Delete deployments
+  kubernetes.core.k8s:
+    name: testing
+    api_version: apps/v1
+    kind: Deployment
+    state: absent
+    delete_options:
+      propagationPolicy: Orphan
+  loop: {{ orphan_delete_deployments}}
 
-memcached_orphan_delete: "{{ atmosphere_orphan_delete }}"
+- name: Delete statefulsets
+  kubernetes.core.k8s:
+    name: testing
+    api_version: apps/v1
+    kind: StatefulSet
+    state: absent
+    delete_options:
+      propagationPolicy: Orphan
+  loop: {{ orphan_delete_statefulsets}}


### PR DESCRIPTION
To handle scenarios where a Helm upgrade introduces new labels, we rely on maual process to decide whether to perform orphan deletion. We can enable this by setting the `atmosphere_orphan_delete` boolean variable at the release level.

Each role also has its own specific `xxxx_orphan_delete` boolean variable, which defaults to the value of atmosphere_orphan_delete. This allows users to apply orphan deletion differently for each role as needed.

This approach provides flexibility while ensuring consistency across roles, enabling users to customize behavior for their specific use case.





