### PR TITLE
fix oidc validate keycloak access token issue

### DIFF
--- a/doc/source/user/auth.rst
+++ b/doc/source/user/auth.rst
@@ -221,3 +221,165 @@ issued by an identity provider which exists in the Keycloak realm.
 
    You can then use the project-scoped token to interact with the OpenStack APIs,
    such as creating a server, listing servers, etc.
+
+
+***********************************************
+OpenStack CLI with OIDC identity provider users
+***********************************************
+
+Since OpenStack is configured to trust Keycloak as an identity provider, you will
+need to generate a token from Keycloak and use it to authenticate with the OpenStack
+API.
+
+AUTH TYPE v3oidcpassword
+========================
+
+If you have users managed by Keycloak, then you can use the username and password of
+the user to intract with OpenStack API using *v3oidcpassword* AUTH TYPE which is
+supported by Keystone.
+
+.. admonition:: User and project role setup
+    :class: info
+
+    You need keycloak admin credentials to create user and set password in atmosphere realm
+    using the keycloak web UI, then assign member or admin role to the user in the scope of
+    a project in atmosphere domain using OpenStack CLI.
+
+After adding roles to the user in the domain integrated with identity provider, the user can
+login to OpenStack dashboard with Horizon redirect you to keycloak to login. If you want to
+use the user credentials with OpenStack CLI, then set your openrc-oidcpassword.rc like below.
+Use it wih the OpenStack CLI, which will auth with keycloak to get the Keycloak access token
+and authenticate with OpenStack keystone to get the project-scoped token.
+
+.. code-block:: sh
+
+   export OS_AUTH_URL="https://identity.thedomain.com/v3"
+   export OS_PROJECT_NAME="user-project"
+   export OS_PROJECT_DOMAIN_NAME="atmosphere"
+   export OS_USERNAME="username"
+   export OS_PASSWORD="the-password-of-user-in-keycloak"
+   export OS_INTERFACE=public
+   export OS_IDENTITY_API_VERSION=3
+   export OS_AUTH_TYPE=v3oidcpassword
+   export OS_CLIENT_ID=keystone
+   export OS_CLIENT_SECRET="anystringhere"
+   export OS_IDENTITY_PROVIDER=atmosphere
+   export OS_PROTOCOL=openid
+   export OS_DISCOVERY_ENDPOINT=https://keycloak.thedomain.com/realms/atmosphere/.well-known/openid-configuration
+
+.. list-table::
+   :widths: 40 90
+   :header-rows: 1
+
+   * - Environment variable
+     - Description
+   * - OS_AUTH_URL
+     - The URL of the OpenStack Identity service.
+   * - OS_PROJECT_NAME
+     - The name of the project user belongs to.
+   * - OS_PROJECT_DOMAIN_NAME
+     - The domain name of the project.
+   * - OS_USERNAME
+     - The username of the user in Keycloak.
+   * - OS_PASSWORD
+     - The password of the user in Keycloak.
+   * - OS_INTERFACE
+     - The API endpoint interface to use for the OpenStack CLI.
+   * - OS_IDENTITY_API_VERSION
+     - The version of the Identity API to use.
+   * - OS_AUTH_TYPE
+     - The authentication type to use by OpenStack client.
+   * - OS_CLIENT_ID
+     - The client ID of the OpenStack keystone client in keycloak.
+   * - OS_CLIENT_SECRET
+     - Required by OpenStack client, can be any string for this auth type.
+   * - OS_IDENTITY_PROVIDER
+     - The name of the corresponding identity provider object as created in the Keystone API.
+   * - OS_PROTOCOL
+     - The protocol to use for the authentication with keycloak.
+   * - OS_DISCOVERY_ENDPOINT
+     - Identity provider keycloak API endpoints
+
+The above configuration work with the default installation of Atmosphere which creates an
+domain *atmosphere* and integrate it with the keycloak server through OIDC protocol. If you
+use a different domain name, then replace the domain name and identity provider in the above
+configuration.
+
+
+AUTH TYPE v3oidcdeviceauthz
+===========================
+
+
+If you are using Keycloak with an external OpenID Connect (OIDC) identity provider,
+like Microsoft Azure, Google, or Okta, then all authentication requests will be
+redirected to the external identity provider for authentication. In this case, you
+can't use the user credentials to authenticate with OpenStack API. Instead, you can
+use the *v3oidcdeviceauthz* AUTH TYPE which is supported by Keystone.
+
+In this scenario, you will need to use the OpenID Connect token issued by the external
+identity provider to exchange for a device code url which can be used to authenticate
+with a web browser, after the user authenticate with the external identity provider
+and authorize the device code using the browser,the user will get a keystone unscoped
+token to authenticate with OpenStack, then the user can exchange the unscoped token
+for a project-scoped token to interact with OpenStack API using the OpenStack CLI.
+This is very useful when you want to use the OpenStack CLI with an external identity
+provider for some specific operations.
+
+.. mermaid::
+   :align: center
+   :config: {"theme": "forest"}
+
+   sequenceDiagram
+       participant Client
+       participant OIDC Provider
+       participant Keycloak
+       participant Browser
+       participant Keystone
+       participant OpenStack
+
+
+       Client->>Keycloak: OAUTH device auth code request
+       Keycloak-->>Client: Returns device code URL
+
+       Client->>Browser: Authenticate with external OIDC provider
+       Keycloak->>Client: Returns Keycloak access_token
+
+       Client->>Keystone: Authenticate with Keycloak Token
+       Keystone-->>Client: Returns Keystone Token
+
+       Client->>OpenStack: Use Keystone Token
+       OpenStack-->>Client: OpenStack API Access Granted
+
+You can use the following script to get the OpenID connect token from the external
+identity provider and authenticate with OpenStack API. Save it as openrc-oidcdeviceauthz.sh
+and source it to set the environment variables. It will prompt you a device code url,
+which you can use to authenticate with a web browser. After login to the external identity
+provider and authorize the device code, you will get a keystone unscoped token, as shown
+in the script, we store it to environment variables OS_TOKEN, with the token, then we use
+*v3token* auth type. You can then use any OpenStack CLI supported commands to interact with
+OpenStack API.
+
+
+.. code-block:: sh
+
+   #!/usr/bin/env bash
+   _output=$(mktemp)
+   export OS_AUTH_URL="https://identity.thedomain.com/v3"
+   export OS_IDENTITY_API_VERSION=3
+   export OS_PROJECT_NAME="user-project"
+   export OS_PROJECT_DOMAIN_NAME="atmosphere"
+   export OS_AUTH_TYPE="v3token"
+   unset OS_TOKEN
+   openstack token issue -f value -c id \
+     --os-auth-type v3oidcdeviceauthz \
+     --os-identity-provider atmosphere \
+     --os-protocol openid \
+     --os-code-challenge-method 'S256' \
+     --os-discovery-endpoint https://keycloak.thedomain.com/realms/atmosphere/.well-known/openid-configuration \
+     --os-client-id keystone \
+     --os-client-secret anystring | tee -a $_output
+
+   if [ -s $_output ]; then
+     export OS_TOKEN=$(tail -1 $_output)
+   fi
+   rm -f $_output

--- a/images/keystone/Dockerfile
+++ b/images/keystone/Dockerfile
@@ -22,7 +22,7 @@ apt-get install -qq -y --no-install-recommends \
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF
-ARG MOD_AUTH_OPENIDC_VERSION=2.4.12.1
+ARG MOD_AUTH_OPENIDC_VERSION=2.4.14.4
 ARG TARGETARCH
 RUN <<EOF bash -xe
 # TODO(mnaser): mod_auth_openidc does not have aarch64 builds

--- a/plugins/filter/keystone_domains.py
+++ b/plugins/filter/keystone_domains.py
@@ -59,6 +59,18 @@ def keystone_domains_to_mounts(domains):
     ]
 
 
+def keystone_domains_idp_cert_to_mounts(domains):
+    return [
+        {
+            "name": "keystone-openid-metadata",
+            "mountPath": "/var/lib/apache2/oauth_certs/%s.pem"
+            % (domains[d]["idp_oauth_kid"]),
+            "subPath": "%s-oauth-cert" % (d),
+        }
+        for d in domains
+    ]
+
+
 def keystone_domains_to_idp_mappings(domains):
     return [
         {"label": d["label"], "name": d["name"], "idp": d["name"], "protocol": "openid"}
@@ -71,6 +83,7 @@ class FilterModule(object):
         return {
             "issuer_from_domain": issuer_from_domain,
             "keystone_domains_to_mounts": keystone_domains_to_mounts,
+            "keystone_domains_idp_cert_to_mounts": keystone_domains_idp_cert_to_mounts,
             "keystone_domains_to_idp_mappings": keystone_domains_to_idp_mappings,
             "to_ks_domains": to_ks_domains,
             "urlencoded_issuer_from_domain": urlencoded_issuer_from_domain,

--- a/plugins/lookup/idp_oauth_keys.py
+++ b/plugins/lookup/idp_oauth_keys.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2025 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+import requests
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables=None, **kwargs):
+        keystone_domains = terms[0]
+        validate_certs = kwargs.get("validate_certs", True)
+        validate_certs = validate_certs != "Off"
+
+        if not isinstance(keystone_domains, list):
+            raise AnsibleError("Expected a list of keystone domains.")
+
+        result = {}
+
+        for domain in keystone_domains:
+            try:
+                domain_name = domain["name"]
+                url, realm = domain["keycloak_server_url"], domain["keycloak_realm"]
+                well_known_url = (
+                    f"{url}/realms/{realm}/.well-known/openid-configuration"
+                )
+                # Fetch OpenID configuration
+                response = requests.get(well_known_url, verify=validate_certs)
+                response.raise_for_status()
+                openid_config = response.json()
+
+                # Fetch JWKS URI
+                jwks_uri = openid_config.get("jwks_uri")
+                if not jwks_uri:
+                    raise AnsibleError(
+                        f"No 'jwks_uri' found in OpenID config for domain {domain_name}"
+                    )
+
+                jwks_response = requests.get(jwks_uri, verify=validate_certs)
+                jwks_response.raise_for_status()
+                jwks_data = jwks_response.json()
+
+                # Extract 'kid' for signing keys
+                kid_list = [
+                    key["kid"]
+                    for key in jwks_data.get("keys", [])
+                    if key.get("use") == "sig"
+                ]
+                if not kid_list:
+                    raise AnsibleError(
+                        f"No signing keys found for domain {domain_name}"
+                    )
+
+                kid_cert_list = [
+                    key["x5c"][0]
+                    for key in jwks_data.get("keys", [])
+                    if key.get("use") == "sig"
+                ]
+                if not kid_cert_list:
+                    raise AnsibleError(
+                        f"No signing cert found for domain {domain_name}"
+                    )
+
+                # for keycloak, there is only one signing key id and x509 certificate
+                result[domain_name] = {
+                    "idp_oauth_kid_cert": kid_cert_list[0],
+                    "idp_oauth_kid": kid_list[0],
+                    "idp_oauth_kid_cert_path": f"{kid_list[0]}#/var/lib/apache2/oauth_certs/{kid_list[0]}.pem",
+                }
+
+            except requests.exceptions.RequestException as e:
+                raise AnsibleError(
+                    f"Request failed from IDP for domain {domain_name}: {str(e)}"
+                )
+            except (KeyError, json.JSONDecodeError) as e:
+                raise AnsibleError(
+                    f"Error processing IDP cert data for domain {domain_name}: {str(e)}"
+                )
+
+        return [result]

--- a/releasenotes/notes/fix-keystone-oidc-92d2329079894537.yaml
+++ b/releasenotes/notes/fix-keystone-oidc-92d2329079894537.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Resolve a configuration issue that prevents Keystone from validating Keycloak
+    access tokens when using the OIDC authentication with OAUTH.
+upgrade:
+  - |
+    Bump Keycloak from 2.4.12.1 to 2.4.14.4 to support OIDCOAuthVerifyCertFiles
+    option.

--- a/roles/keystone/defaults/main.yml
+++ b/roles/keystone/defaults/main.yml
@@ -75,3 +75,5 @@ keystone_oidc_redirect_uri: "https://{{ openstack_helm_endpoints_keystone_api_ho
 keystone_oidc_redirect_urls_allowed:
   - "^https://{{ openstack_helm_endpoints_keystone_api_host }}/v3/auth/OS-FEDERATION/identity_providers/({{ keystone_domains | map(attribute='name') | join('|') }})/protocols/openid/websso" # noqa: yaml[line-length]
   - "^https://{{ openstack_helm_endpoints_horizon_api_host }}/auth/logout/$"
+
+keystone_oauth2_kid_cert_list: "{{ lookup('vexxhost.atmosphere.idp_oauth_keys', keystone_domains, validate_certs=keystone_oidc_ssl_validate_server).values() | map(attribute='idp_oauth_kid_cert_path') | join(' ') }}"

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -72,6 +72,9 @@
   no_log: true
   run_once: true
   community.general.keycloak_client:
+    # keystone client oauth setting
+    attributes:
+      "oauth2.device.authorization.grant.enabled": "true"
     # Keycloak settings
     auth_keycloak_url: "{{ item.keycloak_server_url }}"
     auth_realm: "{{ item.keycloak_user_realm_name }}"

--- a/roles/keystone/templates/configmap-openid-metadata.yml.j2
+++ b/roles/keystone/templates/configmap-openid-metadata.yml.j2
@@ -10,4 +10,9 @@ data:
   {{ domain.name }}-oidc-client: '{"client_id":"{{ domain.keycloak_client_id }}","client_secret":"{{ domain.keycloak_client_secret }}","response_type":"id_token"}'
   {{ domain.name }}-oidc-conf: '{"scope":"{{ domain.keycloak_scopes }}"}'
   {{ domain.name }}-oidc-provider: '{{ lookup('url', domain.keycloak_server_url ~ "/realms/" ~ domain.keycloak_realm ~ "/.well-known/openid-configuration", validate_certs=keystone_oidc_ssl_validate_server) }}'
+  {{ domain.name }}-oauth-key-id: "{{ lookup('vexxhost.atmosphere.idp_oauth_keys', keystone_domains, validate_certs=keystone_oidc_ssl_validate_server)[domain.name]['idp_oauth_kid'] }}"
+  {{ domain.name }}-oauth-cert: |
+    -----BEGIN CERTIFICATE-----
+  {{ lookup('vexxhost.atmosphere.idp_oauth_keys', keystone_domains, validate_certs=keystone_oidc_ssl_validate_server)[domain.name]['idp_oauth_kid_cert'] | indent(4, true)}}
+    -----END CERTIFICATE-----
 {% endfor %}

--- a/roles/keystone/vars/main.yml
+++ b/roles/keystone/vars/main.yml
@@ -22,7 +22,16 @@ _keystone_helm_values:
     mounts:
       keystone_api:
         keystone_api:
-          volumeMounts: "{{ keystone_domains | vexxhost.atmosphere.keystone_domains_to_mounts + [{'name': 'ca-certificates', 'mountPath': '/etc/ssl/certs/ca-certificates.crt', 'readOnly': true}] }}"
+          volumeMounts: "{{ lookup('vexxhost.atmosphere.idp_oauth_keys', keystone_domains, validate_certs=keystone_oidc_ssl_validate_server)
+              | vexxhost.atmosphere.keystone_domains_idp_cert_to_mounts + keystone_domains
+              | vexxhost.atmosphere.keystone_domains_to_mounts + [
+                      {
+                        'name': 'ca-certificates',
+                        'mountPath': '/etc/ssl/certs/ca-certificates.crt',
+                        'readOnly': true
+                      }
+                    ]
+              }}"
           volumes:
             - name: keystone-openid-metadata
               configMap:
@@ -73,6 +82,7 @@ _keystone_helm_values:
         OIDCMetadataDir /var/lib/apache2/oidc
         OIDCSSLValidateServer "{{ keystone_oidc_ssl_validate_server }}"
         OIDCCryptoPassphrase {{ keystone_oidc_crypto_passphrase }}
+        OIDCOAuthVerifyCertFiles "{{ keystone_oauth2_kid_cert_list }}"
         OIDCRedirectURI {{ keystone_oidc_redirect_uri }}
         OIDCRedirectURLsAllowed {{ keystone_oidc_redirect_urls_allowed | join(' ') }}
         # NOTE(mnaser): These are Atmosphere specific settings.
@@ -89,7 +99,7 @@ _keystone_helm_values:
         {% for domain in keystone_domains %}
         <Location /v3/OS-FEDERATION/identity_providers/{{ domain.name }}/protocols/openid/auth>
           Require valid-user
-          AuthType oauth20
+          AuthType auth-openidc
         </Location>
         <Location /v3/auth/OS-FEDERATION/identity_providers/{{ domain.name }}/protocols/openid/websso>
           Require valid-user


### PR DESCRIPTION
fix keystone IDP config to support multi providers certs of oauth, bump apache2 mod openidc to 2.14.4

Change-Id: I2e2248f6a2411f689bf3515317f3464a5d4dcfc6