### PR TITLE
feat: add safe helm upgrade role for openstack-helm charts

### DIFF
--- a/releasenotes/notes/add-helm_upgrade-role-76fe2dbece657683.yaml
+++ b/releasenotes/notes/add-helm_upgrade-role-76fe2dbece657683.yaml
@@ -1,0 +1,5 @@
+
+---
+features:
+  - |
+    Add a new role helm_upgrade for safely upgrading helm charts.

--- a/roles/memcached/tasks/main.yml
+++ b/roles/memcached/tasks/main.yml
@@ -13,14 +13,15 @@
 # under the License.
 
 - name: Deploy Helm chart
-  run_once: true
-  kubernetes.core.helm:
-    name: "{{ memcached_helm_release_name }}"
-    chart_ref: "{{ memcached_helm_chart_ref }}"
-    release_namespace: "{{ memcached_helm_release_namespace }}"
-    create_namespace: true
-    kubeconfig: "{{ memcached_helm_kubeconfig }}"
-    values: "{{ _memcached_helm_values | combine(memcached_helm_values, recursive=True) }}"
+  ansible.builtin.include_role:
+    name: openstack_helm_upgrade
+  vars:
+    openstack_helm_upgrade_release_name: "{{ memcached_helm_release_name }}"
+    openstack_helm_upgrade_chart_ref: "{{ memcached_helm_chart_ref }}"
+    openstack_helm_upgrade_release_namespace: "{{ memcached_helm_release_namespace }}"
+    openstack_helm_upgrade_create_namespace: true
+    openstack_helm_upgrade_kubeconfig: "{{ memcached_helm_kubeconfig }}"
+    openstack_helm_upgrade_values: "{{ _memcached_helm_values | combine(memcached_helm_values, recursive=True) }}"
 
 - name: Apply manifests for monitoring
   run_once: true

--- a/roles/openstack_helm_upgrade/README.md
+++ b/roles/openstack_helm_upgrade/README.md
@@ -1,0 +1,3 @@
+# `openstack_helm_upgrade`
+
+This is for safe helm install/upgrade of Openstack-Helm charts.

--- a/roles/openstack_helm_upgrade/defaults/main.yml
+++ b/roles/openstack_helm_upgrade/defaults/main.yml
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+openstack_helm_upgrade_values: {}
+
+# openstack_helm_upgrade_release_name: ""
+# openstack_helm_upgrade_chart_ref: ""
+openstack_helm_upgrade_create_namespace: true
+
+openstack_helm_upgrade_release_namespace: openstack
+
+openstack_helm_upgrade_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"

--- a/roles/openstack_helm_upgrade/meta/main.yml
+++ b/roles/openstack_helm_upgrade/meta/main.yml
@@ -1,0 +1,29 @@
+# Copyright (c) 2024 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+galaxy_info:
+  author: VEXXHOST, Inc.
+  description: Ansible role for safe Helm release install/upgrade for Openstack-Helm
+  license: Apache-2.0
+  min_ansible_version: 5.5.0
+  standalone: false
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy

--- a/roles/openstack_helm_upgrade/tasks/main.yml
+++ b/roles/openstack_helm_upgrade/tasks/main.yml
@@ -1,0 +1,52 @@
+# Copyright (c) 2023 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Check if Helm release exists
+  block:
+    - name: Get helm release information
+      kubernetes.core.helm_info:
+        name: "{{ openstack_helm_upgrade_release_name }}"
+        namespace: "{{ openstack_helm_upgrade_release_namespace }}"
+        kubeconfig: "{{ openstack_helm_upgrade_kubeconfig }}"
+      register: _openstack_helm_upgrade_release_info
+      changed_when: false
+
+    - name: Set fact to indicate if Helm release exists
+      ansible.builtin.set_fact:
+        _openstack_helm_upgrade_release_exists: "{{ _openstack_helm_upgrade_release_info.status is defined }}"
+
+- name: Set helm values for new install
+  openstack_helm_upgrade_values: "{{ openstack_helm_upgrade_values | combine({'pod': {'labels': {'include_app_kubernetes_io': false}}}, recursive=True) }}"
+  when: not _openstack_helm_upgrade_release_exists
+
+- name: Set helm values for upgrade
+  when: _openstack_helm_upgrade_release_exists
+  block:
+    - name: Set fact for include_app_kubernetes_io existence
+      set_fact:
+        _openstack_helm_upgrade_include_labels_exists: "{{ 'pod' in _openstack_helm_upgrade_release_info.status.values and 'labels' in _openstack_helm_upgrade_release_info.status.values.pod and 'include_app_kubernetes_io' in _openstack_helm_upgrade_release_info.status.values.pod.labels }}"
+
+    - name: Set helm values for new install
+      openstack_helm_upgrade_values: "{{ openstack_helm_upgrade_values | combine({'pod': {'labels': {'include_app_kubernetes_io': false}}}, recursive=True) }}"
+      when: not _openstack_helm_upgrade_include_labels_exists
+
+- name: Deploy Helm chart
+  run_once: true
+  kubernetes.core.helm:
+    name: "{{ openstack_helm_upgrade_release_name }}"
+    chart_ref: "{{ openstack_helm_upgrade_chart_ref }}"
+    release_namespace: "{{ openstack_helm_upgrade_release_namespace }}"
+    create_namespace: "{{ openstack_helm_upgrade_create_namespace }}"
+    kubeconfig: "{{ openstack_helm_upgrade_kubeconfig }}"
+    values: "{{ openstack_helm_upgrade_values }}"


### PR DESCRIPTION
- Helm Release Check: Confirms if the release exists.
- Detect include_app_kubernetes_io label in helm release
- set include_app_kubernetes_io when new install or include_app_kubernetes_io doesn't exist in helm release