### PR TITLE
Fix releasenote CI job

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           dir_names: true
       - uses: actions/github-script@v6
-        if: "!contains(steps.changed-files.outputs.added_files, 'releasenotes/notes/')"
+        if: "!contains(steps.changed-files.outputs.added_files, 'releasenotes/notes')"
         with:
           script: |
             core.setFailed("Pull requests without the 'skip-release-notes' label must add a release note with reno.")


### PR DESCRIPTION
The change files should contains no `/` like `releasenotes/notes`

See debug output: https://github.com/vexxhost/atmosphere/actions/runs/14440569828/job/40489584969

Change-Id: I261a941b2810bc01f46c8b494b6b937545a56228