### PR TITLE
Allow uses allocation_pools for openstack.subnet

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -15,7 +15,7 @@ dependencies:
   community.general: 7.3.0
   community.mysql: 3.6.0
   kubernetes.core: 2.4.0
-  openstack.cloud: ">=2.0.0"
+  openstack.cloud: ">=4.2.0"
   vexxhost.ceph: 3.0.1
   vexxhost.kubernetes: ">=2.0.1"
 tags:

--- a/molecule/default/requirements.txt
+++ b/molecule/default/requirements.txt
@@ -1,3 +1,3 @@
 molecule==3.5.2 # https://github.com/ansible-community/molecule/issues/3435
-openstacksdk
+openstacksdk==4.2.0
 netaddr

--- a/playbooks/generate_workspace.yml
+++ b/playbooks/generate_workspace.yml
@@ -276,8 +276,9 @@
               - name: public-subnet
                 cidr: 10.96.250.0/24
                 gateway_ip: 10.96.250.10
-                allocation_pool_start: 10.96.250.200
-                allocation_pool_end: 10.96.250.220
+                allocation_pools:
+                  - start: 10.96.250.200
+                    end: 10.96.250.220
                 enable_dhcp: true
 
     - name: Write new Neutron configuration file to disk

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansible-core>=2.15.9
 jmespath>=1.0.1
-openstacksdk>1
+openstacksdk>1,<=4.2.0
 docker-image-py>=0.1.12
 rjsonnet>=0.5.2
 netaddr>=0.8.0

--- a/roles/ironic/tasks/network/create.yml
+++ b/roles/ironic/tasks/network/create.yml
@@ -31,5 +31,6 @@
     network_name: "{{ ironic_bare_metal_subnet_name }}"
     name: "{{ ironic_bare_metal_subnet_name }}"
     cidr: "{{ ironic_bare_metal_subnet_cidr }}"
+    allocation_pool: "{{ ironic_bare_metal_subnet_allocation_pools | default(omit) }}"
     allocation_pool_start: "{{ ironic_bare_metal_subnet_allocation_pool_start | default(omit) }}"
     allocation_pool_end: "{{ ironic_bare_metal_subnet_allocation_pool_end | default(omit) }}"

--- a/roles/neutron/tasks/main.yml
+++ b/roles/neutron/tasks/main.yml
@@ -97,6 +97,7 @@
         cidr: "{{ item.1.cidr | default(omit) }}"
         gateway_ip: "{{ item.1.gateway_ip | default(omit) }}"
         no_gateway_ip: "{{ item.1.no_gateway_ip | default(omit) }}"
+        allocation_pools: "{{ item.1.allocation_pools | default(omit) }}"
         allocation_pool_start: "{{ item.1.allocation_pool_start | default(omit) }}"
         allocation_pool_end: "{{ item.1.allocation_pool_end | default(omit) }}"
         dns_nameservers: "{{ item.1.dns_nameservers | default(omit) }}"

--- a/roles/openstacksdk/defaults/main.yml
+++ b/roles/openstacksdk/defaults/main.yml
@@ -12,4 +12,4 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-# openstacksdk_version:
+openstacksdk_version: "4.2.0"

--- a/roles/rook_ceph_cluster/tasks/main.yml
+++ b/roles/rook_ceph_cluster/tasks/main.yml
@@ -95,6 +95,7 @@
     name: "{{ openstack_helm_endpoints.identity.auth.rgw.username }}"
     password: "{{ openstack_helm_endpoints.identity.auth.rgw.password }}"
     domain: service
+  register: service_user
 
 # NOTE(mnaser): https://storyboard.openstack.org/#!/story/2010579
 - name: Grant access to "service" project
@@ -105,7 +106,7 @@
     openstack role add \
       --user-domain service \
       --project service \
-      --user {{ openstack_helm_endpoints.identity.auth.rgw.username }} \
+      --user {{ service_user.id }} \
       admin
   args:
     executable: /bin/bash


### PR DESCRIPTION
* Bump openstack ansible collection to 2.4.1
* Bump openstacksdk to 4.2.0

Related: ATMOSPHERE-642

Change-Id: I2ffc11ac3f41c46c53bd4ea24c1fdb135d371262