### PR TITLE
[ATMOSPHERE-161] Add Ceph OSD exporter support

### DIFF
--- a/.charts.yml
+++ b/.charts.yml
@@ -22,6 +22,10 @@ charts:
     version: 3.11.0
     repository:
       url: https://ceph.github.io/csi-charts
+  - name: ceph-osd-exporter
+    version: 0.1.0
+    repository:
+      url: https://TBD/ceph-osd-exporter
   - name: ceph-provisioners
     version: 0.1.8
     repository: *openstack_helm_infra_repository

--- a/charts/ceph-osd-exporter/.helmignore
+++ b/charts/ceph-osd-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+
+OWNERS

--- a/charts/ceph-osd-exporter/Chart.yaml
+++ b/charts/ceph-osd-exporter/Chart.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+appVersion: 0.1.0
+description: Vexxhost Ceph OSD exporter
+name: ceph-osd-exporter
+version: 0.1.0
+home: https://github.com/vexxhost/ceph_osd_exporter
+sources:
+  - https://github.com/vexxhost/ceph_osd_exporter
+maintainers:
+  - name: Vexxhost

--- a/charts/ceph-osd-exporter/templates/_helpers.tpl
+++ b/charts/ceph-osd-exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ceph_osd_exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ceph_osd_exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ceph_osd_exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ceph_osd_exporter.labels" -}}
+helm.sh/chart: {{ include "ceph_osd_exporter.chart" . }}
+{{ include "ceph_osd_exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ceph_osd_exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ceph_osd_exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ceph_osd_exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ceph_osd_exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/ceph-osd-exporter/templates/clusterrole.yaml
+++ b/charts/ceph-osd-exporter/templates/clusterrole.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.rbac.create .Values.rbac.clusterscoped }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "ceph_osd_exporter.fullname" . }}-clusterrole
+  labels:
+    {{- include "ceph_osd_exporter.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list"]
+{{- end }}

--- a/charts/ceph-osd-exporter/templates/clusterrolebinding.yaml
+++ b/charts/ceph-osd-exporter/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.rbac.create .Values.rbac.clusterscoped }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "ceph_osd_exporter.fullname" . }}-clusterrolebinding
+  labels:
+    {{- include "ceph_osd_exporter.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "ceph_osd_exporter.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "ceph_osd_exporter.fullname" . }}-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/ceph-osd-exporter/templates/daemonset.yaml
+++ b/charts/ceph-osd-exporter/templates/daemonset.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2024 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+{{- $mounts_ceph_osd_exporter := .Values.pod.mounts.ceph_osd_exporter.ceph_osd_exporter }}
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "ceph_osd_exporter.fullname" . }}
+  namespace: monitoring
+  labels:
+    {{- include "ceph_osd_exporter.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ceph_osd_exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "ceph_osd_exporter.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "ceph_osd_exporter.serviceAccountName" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: ceph-osd-exporter
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.ceph_osd_exporter.port }}
+          volumeMounts:
+            - name: run-ceph
+              mountPath: /var/run/ceph
+{{ if $mounts_ceph_osd_exporter.volumeMounts }}{{ toYaml $mounts_ceph_osd_exporter.volumeMounts | indent 12 }}{{ end }}
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: {{ .Values.ceph_osd_exporter.port }}
+              scheme: HTTP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: {{ .Values.ceph_osd_exporter.port }}
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+      volumes:
+        - name: run-ceph
+          hostPath:
+            path: /var/run/ceph
+{{ if $mounts_ceph_osd_exporter.volumes }}{{ toYaml $mounts_ceph_osd_exporter.volumes | indent 8 }}{{ end }}

--- a/charts/ceph-osd-exporter/templates/ingress.yaml
+++ b/charts/ceph-osd-exporter/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "ceph_osd_exporter.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "ceph_osd_exporter.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/ceph-osd-exporter/templates/prometheusrule.yaml
+++ b/charts/ceph-osd-exporter/templates/prometheusrule.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "ceph_osd_exporter.fullname" . }}
+  {{- if .Values.prometheusRule.namespace }}
+  namespace: {{ .Values.prometheusRule.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
+  labels:
+    {{- include "ceph_osd_exporter.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.prometheusRule.rules }}
+  groups:
+    - name: {{ template "ceph_osd_exporter.name" $ }}
+      rules: {{- tpl (toYaml .) $ | nindent 8 }}
+  {{- end }}
+{{- end }}

--- a/charts/ceph-osd-exporter/templates/role.yaml
+++ b/charts/ceph-osd-exporter/templates/role.yaml
@@ -1,0 +1,20 @@
+{{- if or .Values.podSecurityPolicy.enabled (not .Values.rbac.clusterscoped) }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "ceph_osd_exporter.fullname" . }}-pod-security-policy
+  labels:
+    {{- include "ceph_osd_exporter.labels" . | nindent 4 }}
+rules:
+{{- if not .Values.rbac.clusterscoped }}
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list"]
+{{- end }}
+{{- if .Values.podSecurityPolicy.enabled }}
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: [{{ .Values.podSecurityPolicy.policyName | quote }}]
+    verbs: ["use"]
+{{- end }}
+{{- end }}

--- a/charts/ceph-osd-exporter/templates/rolebinding.yaml
+++ b/charts/ceph-osd-exporter/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if or .Values.podSecurityPolicy.enabled (not .Values.rbac.clusterscoped) }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "ceph_osd_exporter.fullname" . }}-pod-security-policy
+  labels:
+    {{- include "ceph_osd_exporter.labels" . | nindent 4 }}
+roleRef:
+  kind: Role
+  name: {{ include "ceph_osd_exporter.fullname" . }}-pod-security-policy
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "ceph_osd_exporter.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/ceph-osd-exporter/templates/service.yaml
+++ b/charts/ceph-osd-exporter/templates/service.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ceph_osd_exporter.fullname" . }}
+  namespace: monitoring
+  labels:
+    {{- include "ceph_osd_exporter.labels" . | nindent 4 }}
+{{- with .Values.service.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: {{ .Values.ceph_osd_exporter.port }}
+      targetPort: metrics
+  selector:
+    {{- include "ceph_osd_exporter.selectorLabels" . | nindent 4 }}

--- a/charts/ceph-osd-exporter/templates/serviceaccount.yaml
+++ b/charts/ceph-osd-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ceph_osd_exporter.serviceAccountName" . }}
+  labels:
+    {{- include "ceph_osd_exporter.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/ceph-osd-exporter/templates/servicemonitor.yaml
+++ b/charts/ceph-osd-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "ceph_osd_exporter.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "ceph_osd_exporter.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.serviceMonitor.selector }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: http
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- if .Values.serviceMonitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
+  jobLabel: name
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "ceph_osd_exporter.selectorLabels" . | nindent 6 }}
+{{- end -}}

--- a/charts/ceph-osd-exporter/values.yaml
+++ b/charts/ceph-osd-exporter/values.yaml
@@ -1,0 +1,135 @@
+# Copyright (c) 2024 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+image:
+  repository: registry.atmosphere.dev/library/ceph-osd-exporter
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+rbac:
+  create: true
+  clusterscoped: true
+
+service:
+  port: 9282
+  annotations: {}
+  labels: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+serviceAccount:
+  create: true
+  name:
+
+ceph_osd_exporter:
+  port: 9282
+
+extraEnv: []
+
+## Set a priorityClassName for the pod. If left blank a default priority will be set.
+priorityClassName:
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+podAnnotations: {}
+
+podLabels: {}
+
+updateStrategy: {}
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxUnavailable: 1
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector:
+  ceph-osd-exporter: enabled
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+## Enable this if pod security policy enabled in your cluster
+## It will bind ServiceAccount with unrestricted podSecurityPolicy
+## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+podSecurityPolicy:
+  enabled: false
+  policyName: unrestricted-psp
+
+## Set security context of the ceph_osd_exporter container
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+containerSecurityContext:
+  runAsUser: 0
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+
+pod:
+  mounts:
+    ceph_osd_exporter:
+      init_container: null
+      ceph_osd_exporter:
+        volumeMounts:
+        volumes:
+
+serviceMonitor:
+  enabled: false
+  selector:
+    prometheus: "kube-prometheus"
+  # namespace: monitoring
+  interval: 30s
+  # honorLabels: true
+
+## Custom PrometheusRule to be defined
+## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
+prometheusRule:
+  enabled: false
+  rules:
+    - alert: ceph_osd_exporter_nodes_unhealthy
+      expr: |
+        sum(ceph_osd_exporter_nodes_health_total{job="{{ template "ceph_osd_exporter.fullname" . }}", status="unhealthy"})
+        BY (instance, ceph_osd_exporter_instance) > 0
+      for: 5m
+      annotations:
+        description: |
+          Goldpinger instance {{ "{{ $labels.ceph_osd_exporter_instance }}" }} has been reporting unhealthy nodes for at least 5 minutes.
+        summary: Instance {{ "{{ $labels.instance }}" }} down
+      labels:
+        severity: warning

--- a/molecule/aio/group_vars/all/molecule.yml
+++ b/molecule/aio/group_vars/all/molecule.yml
@@ -239,3 +239,8 @@ horizon_helm_values:
   pod:
     replicas:
       server: 1
+
+ceph_osd_exporter_helm_values:
+  pod:
+    replicas:
+      ceph_osd_exporter: 1

--- a/playbooks/monitoring.yml
+++ b/playbooks/monitoring.yml
@@ -43,3 +43,7 @@
     - role: prometheus_pushgateway
       tags:
         - prometheus-pushgateway
+
+    - role: ceph_osd_exporter
+      tags:
+        - ceph-osd-exporter

--- a/releasenotes/notes/add-ceph-osd-exporter-549d5b00bb5f2e45.yaml
+++ b/releasenotes/notes/add-ceph-osd-exporter-549d5b00bb5f2e45.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Add ceph osd exporter (https://github.com/vexxhost/ceph_osd_exporter)
+    to Atmosphere.
+    This provides better way to collect Bluestore fragmentation rating
+    for Ceph OSDs.
+    And add two new alerts;
+    * BluestoreFragmentationRateingConsiderable (rating > 0.7, 1 min, P4)
+    * BluestoreFragmentationRateingHigh (rating > 0.9, 1 min, P3)

--- a/roles/ceph_osd_exporter/README.md
+++ b/roles/ceph_osd_exporter/README.md
@@ -1,0 +1,1 @@
+# `ceph_osd_exporter`

--- a/roles/ceph_osd_exporter/defaults/main.yml
+++ b/roles/ceph_osd_exporter/defaults/main.yml
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+ceph_osd_exporter_helm_release_name: ceph-osd-exporter
+ceph_osd_exporter_helm_chart_path: "../../charts/ceph-osd-exporter/"
+ceph_osd_exporter_helm_chart_ref: /usr/local/src/ceph-osd-exporter
+
+ceph_osd_exporter_helm_release_namespace: monitoring
+ceph_osd_exporter_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
+ceph_osd_exporter_helm_values: {}

--- a/roles/ceph_osd_exporter/meta/main.yml
+++ b/roles/ceph_osd_exporter/meta/main.yml
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+galaxy_info:
+  author: VEXXHOST, Inc.
+  description: Ansible role for Ceph OSD exporter
+  license: Apache-2.0
+  min_ansible_version: 5.5.0
+  standalone: false
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+
+dependencies:
+  - role: defaults
+  - role: vexxhost.kubernetes.upload_helm_chart
+    vars:
+      upload_helm_chart_src: "{{ ceph_osd_exporter_helm_chart_path }}"
+      upload_helm_chart_dest: "{{ ceph_osd_exporter_helm_chart_ref }}"

--- a/roles/ceph_osd_exporter/tasks/main.yml
+++ b/roles/ceph_osd_exporter/tasks/main.yml
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+
+- name: Deploy Helm chart
+  run_once: true
+  kubernetes.core.helm:
+    name: "{{ ceph_osd_exporter_helm_release_name }}"
+    chart_ref: "{{ ceph_osd_exporter_helm_chart_ref }}"
+    release_namespace: "{{ ceph_osd_exporter_helm_release_namespace }}"
+    create_namespace: true
+    kubeconfig: "{{ ceph_osd_exporter_helm_kubeconfig }}"
+    values: "{{ _ceph_osd_exporter_helm_values | combine(ceph_osd_exporter_helm_values, recursive=True) }}"

--- a/roles/ceph_osd_exporter/vars/main.yml
+++ b/roles/ceph_osd_exporter/vars/main.yml
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+_ceph_osd_exporter_helm_values:
+  image:
+    repository: "{{ atmosphere_images['ceph_osd_exporter'] | vexxhost.kubernetes.docker_image('name') }}"
+    tag: "{{ atmosphere_images['ceph_osd_exporter'] | vexxhost.kubernetes.docker_image('tag') }}"

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -21,6 +21,7 @@ _atmosphere_images:
   bootstrap: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
   ceph_config_helper: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/libvirtd:{{ atmosphere_release }}"
   ceph: "{{ atmosphere_image_prefix }}quay.io/ceph/ceph:v18.2.2"
+  ceph_osd_exporter: registry.atmosphere.dev/library/ceph-osd-exporter:latest
   cert_manager_cainjector: "{{ atmosphere_image_prefix }}quay.io/jetstack/cert-manager-cainjector:v1.12.10"
   cert_manager_cli: "{{ atmosphere_image_prefix }}quay.io/jetstack/cert-manager-ctl:v1.12.10"
   cert_manager_controller: "{{ atmosphere_image_prefix }}quay.io/jetstack/cert-manager-controller:v1.12.10"

--- a/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
@@ -95,6 +95,39 @@ local mixins = {
             },
           ],
         },
+        {
+          name: 'bluestore-fragmentation-rating',
+          rules: [
+            {
+              alert: 'BluestoreFragmentationRateingConsiderable',
+              annotations: {
+                description: 'Bluestore fragmentation rating for OSD {{ $labels.osd }} on host {{ $labels.instance }} is currently at {{ $value }}. If it continue to goes higher then 0.9, it will impact other running services.',
+                summary: '[{{ $labels.osd }}] reaching a considerable value: {{ $value }}',
+              },
+              'for': '1m',
+              expr: |||
+                ceph_osd_fragmentation_rating > 0.7
+              |||,
+              labels: {
+                severity: 'warning',
+              },
+            },
+            {
+              alert: 'BluestoreFragmentationRateingHigh',
+              annotations: {
+                description: 'Bluestore fragmentation rating for OSD {{ $labels.osd }} on host {{ $labels.instance }} is currently at {{ $value }}. It might impact other running services.',
+                summary: '[{{ $labels.osd }}] reaching a high value: {{ $value }}',
+              },
+              'for': '1m',
+              expr: |||
+                ceph_osd_fragmentation_rating > 0.9
+              |||,
+              labels: {
+                severity: 'P3',
+              },
+            }
+          ],
+        },
       ],
     }
   },

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -483,6 +483,24 @@ _kube_prometheus_stack_helm_values:
         endpoints:
           - port: metrics
             relabelings: *relabelings_instance_to_node_name
+      - name: ceph-osd-exporter
+        jobLabel: jobLabel
+        namespaceSelector:
+          matchNames:
+            - monitoring
+        selector:
+          matchLabels:
+            app.kubernetes.io/instance: ceph-osd-exporter
+            app.kubernetes.io/name: ceph-osd-exporter
+        endpoints:
+          - port: metrics
+            interval: 1m
+            relabelings:
+              - action: replace
+                regex: (.*)
+                replacement: default
+                targetLabel: instance
+            scrapeTimeout: 30s
       - name: openstack-exporter
         jobLabel: jobLabel
         namespaceSelector:

--- a/roles/kubernetes_node_labels/defaults/main.yml
+++ b/roles/kubernetes_node_labels/defaults/main.yml
@@ -24,4 +24,7 @@ kubernetes_node_labels: |
   {%   set _ = res.update({'openstack-compute-node': 'enabled'}) %}
   {%   set _ = res.update({'openvswitch': 'enabled'}) %}
   {% endif %}
+  {% if inventory_hostname in groups.get('cephs', []) %}
+  {%   set _ = res.update({'ceph-osd-exporter': 'enabled'}) %}
+  {% endif %}
   {{ res }}


### PR DESCRIPTION
Depends-On: https://github.com/vexxhost/ceph_osd_exporter/pull/4

TODO: release .chart repo.url for ceph osd exporter once it is released as charts.

Change-Id: Ib12e369388fef60604357aa89375765245052500