### PR TITLE
fix lintner job to exclude github actions directory 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: "^(roles/kube_prometheus_stack/files/jsonnet|charts)"
+exclude: "^(roles/kube_prometheus_stack/files/jsonnet|charts|.github)"
 
 repos:
   - repo: local


### PR DESCRIPTION
(cherry picked from commit 3f6b4cdfb24890f9d73c4182d95bcff465effa8b)