### PR TITLE
Check transaction before begin

### DIFF
--- a/.charts.yml
+++ b/.charts.yml
@@ -18,6 +18,7 @@ charts:
         review.opendev.org:
           - 916034
           - 944975
+          - 947782
   - name: ceph-csi-rbd
     version: 3.11.0
     repository:

--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -1,2 +1,3 @@
 backport
 [Bb]ackports
+kek

--- a/charts/barbican/templates/bin/_simple_crypto_kek_rewrap.py.tpl
+++ b/charts/barbican/templates/bin/_simple_crypto_kek_rewrap.py.tpl
@@ -53,7 +53,10 @@ class KekRewrap(object):
         )
 
     def rewrap_kek(self, project, kek):
-        with self.db_session.begin():
+        db_begin_fn = self.db_session.begin_nested if (
+            self.db_session.in_transaction()) else self.db_session.begin
+        with db_begin_fn():
+
             plugin_meta = kek.plugin_meta
 
             # try to unwrap with the target kek, and if successful, skip
@@ -89,7 +92,9 @@ class KekRewrap(object):
 
     def get_keks_for_project(self, project):
         keks = []
-        with self.db_session.begin() as transaction:
+        db_begin_fn = self.db_session.begin_nested if (
+            self.db_session.in_transaction()) else self.db_session.begin
+        with db_begin_fn() as transaction:
             print('Retrieving KEKs for Project {}'.format(project.external_id))
             query = transaction.session.query(models.KEKDatum)
             query = query.filter_by(project_id=project.id)
@@ -103,7 +108,9 @@ class KekRewrap(object):
         print('Retrieving all available projects')
 
         projects = []
-        with self.db_session.begin() as transaction:
+        db_begin_fn = self.db_session.begin_nested if (
+            self.db_session.in_transaction()) else self.db_session.begin
+        with db_begin_fn() as transaction:
             projects = transaction.session.query(models.Project).all()
 
         return projects

--- a/releasenotes/notes/improve-barbican-kek-db-session-92ae79da699adc6d.yaml
+++ b/releasenotes/notes/improve-barbican-kek-db-session-92ae79da699adc6d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Checking DB transaction already starts in barbican kek rewrap.
+    And use nested transaction if DB session already starts it's
+    root transaction.


### PR DESCRIPTION
Allow using nested transaction if db session already starts root transaction. Check if DB transaction already starts in barbican kek rewrap. And use nested transaction if DB session already starts it's root transaction.

related: https://github.com/vexxhost/atmosphere/issues/2492

Change-Id: I829698ad55011c1a429920d85eb29f7de9e30e0b