### PR TITLE
Bump max_allowed_packet to 64M

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -1,3 +1,4 @@
 backport
 [Bb]ackports
 kek
+[Mm]ysql

--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -1,4 +1,4 @@
 backport
 [Bb]ackports
 kek
-[Mm]ysql
+MySQL

--- a/releasenotes/notes/honor-defult-max_allowed_packet-5c583ddeebcea7b4.yaml
+++ b/releasenotes/notes/honor-defult-max_allowed_packet-5c583ddeebcea7b4.yaml
@@ -1,7 +1,6 @@
 ---
 upgrade:
   - |
-    Previously ``max_allowed_packet`` was change from 4M (default value in mysql 5.x)
-    to 16M to increase the tolerance. As ``max_allowed_packet`` get bump
-    to new default 64M in Mysql 8.x, adjust ``max_allowed_packet`` in
-    atmosphere accordingly.
+    Previously ``max_allowed_packet`` was changed from ``4M`` (default value in MySQL 5.x)
+    to 16M to allow for larger queries. As ``max_allowed_packet`` was bumped to a new default
+    of 64M in MySQL 8.x, this value has been removed from the configuration.

--- a/releasenotes/notes/honor-defult-max_allowed_packet-5c583ddeebcea7b4.yaml
+++ b/releasenotes/notes/honor-defult-max_allowed_packet-5c583ddeebcea7b4.yaml
@@ -1,6 +1,6 @@
 ---
 upgrade:
   - |
-    Previously ``max_allowed_packet`` was changed from ``4M`` (default value in MySQL 5.x)
-    to 16M to allow for larger queries. As ``max_allowed_packet`` was bumped to a new default
-    of 64M in MySQL 8.x, this value has been removed from the configuration.
+    The ``max_allowed_packet`` setting increased from ``4M`` (the default in
+    MySQL 5.x) to ``16M`` to support larger queries. Because MySQL 8.x uses
+    a new default of ``64M``, the configuration no longer specifies this setting.

--- a/releasenotes/notes/honor-defult-max_allowed_packet-5c583ddeebcea7b4.yaml
+++ b/releasenotes/notes/honor-defult-max_allowed_packet-5c583ddeebcea7b4.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    Previously ``max_allowed_packet`` was change from 4M (default value in mysql 5.x)
+    to 16M to increase the tolerance. As ``max_allowed_packet`` get bump
+    to new default 64M in Mysql 8.x, adjust ``max_allowed_packet`` in
+    atmosphere accordingly.

--- a/roles/percona_xtradb_cluster/vars/main.yml
+++ b/roles/percona_xtradb_cluster/vars/main.yml
@@ -9,7 +9,6 @@ _percona_xtradb_cluster_spec:
       [mysqld]
       max_connections=8192
       innodb_buffer_pool_size=4096M
-      max_allowed_packet=64M
       # Skip reverse DNS lookup of clients
       skip-name-resolve
       pxc_strict_mode=MASTER

--- a/roles/percona_xtradb_cluster/vars/main.yml
+++ b/roles/percona_xtradb_cluster/vars/main.yml
@@ -9,7 +9,7 @@ _percona_xtradb_cluster_spec:
       [mysqld]
       max_connections=8192
       innodb_buffer_pool_size=4096M
-      max_allowed_packet=16M
+      max_allowed_packet=64M
       # Skip reverse DNS lookup of clients
       skip-name-resolve
       pxc_strict_mode=MASTER

--- a/roles/percona_xtradb_cluster/vars_test.go
+++ b/roles/percona_xtradb_cluster/vars_test.go
@@ -85,7 +85,7 @@ func TestPerconaXtraDBClusterPXCConfiguration(t *testing.T) {
 	section := cfg.Section("mysqld")
 	assert.Equal(t, 8192, section.Key("max_connections").MustInt())
 	assert.Equal(t, "4096M", section.Key("innodb_buffer_pool_size").String())
-	assert.Equal(t, "16M", section.Key("max_allowed_packet").String())
+	assert.Equal(t, "64M", section.Key("max_allowed_packet").String())
 	assert.Equal(t, true, section.Key("skip-name-resolve").MustBool())
 }
 

--- a/roles/percona_xtradb_cluster/vars_test.go
+++ b/roles/percona_xtradb_cluster/vars_test.go
@@ -85,7 +85,6 @@ func TestPerconaXtraDBClusterPXCConfiguration(t *testing.T) {
 	section := cfg.Section("mysqld")
 	assert.Equal(t, 8192, section.Key("max_connections").MustInt())
 	assert.Equal(t, "4096M", section.Key("innodb_buffer_pool_size").String())
-	assert.Equal(t, "64M", section.Key("max_allowed_packet").String())
 	assert.Equal(t, true, section.Key("skip-name-resolve").MustBool())
 }
 


### PR DESCRIPTION
This change max_allowed_packet to honor new default value since mysql 8.x.

ref https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html

Change-Id: Iebe04b21cedad7c793f84c1e43f13d18a9789b75