### PR TITLE
[stable/zed]Fix manila multiattach

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -1,0 +1,3 @@
+Glance
+Nova
+Manila

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,6 +1,7 @@
 StylesPath = .github/styles
 MinAlertLevel = suggestion
 Packages = Microsoft
+Vocab = Base
 
 [*.{rst,yaml}]
 BasedOnStyles = Vale, Microsoft

--- a/releasenotes/notes/fix-manila-multiattach-f86725dc81792a28.yaml
+++ b/releasenotes/notes/fix-manila-multiattach-f86725dc81792a28.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Manila now uses Nova micro-version 2.60 by default. This change
+    enables support for attaching multiple volumes to an instance.
+  - |
+    Manila now connects to the internal Nova and Glance endpoints
+    instead of the public ones. This improves performance and reduces
+    reliance on external network paths.

--- a/roles/manila/vars/main.yml
+++ b/roles/manila/vars/main.yml
@@ -62,6 +62,13 @@ _manila_helm_values:
         service_instance_security_group: manila-service-security-group
       oslo_messaging_notifications:
         driver: noop
+      nova:
+        api_microversion: 2.60
+        endpoint_type: internalURL
+        region_name: "{{ openstack_helm_endpoints_nova_region_name }}"
+      glance:
+        endpoint_type: internalURL
+        region_name: "{{ openstack_helm_endpoints_glance_region_name }}"
   manifests:
     ingress_api: false
     service_ingress_api: false


### PR DESCRIPTION
Bump nova microversion in manila to support multiattach feature. Also use internalURL instead of publicURL to keep manila-nova communication in internal.

Change-Id: I11fdc56abbabdac6b660fe6521ad74eb2027f089