### PR TITLE
[stable/2023.1] Drop max_allowed_packet config

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -1,3 +1,4 @@
 Glance
 Nova
 Manila
+MySQL

--- a/releasenotes/notes/honor-defult-max_allowed_packet-5c583ddeebcea7b4.yaml
+++ b/releasenotes/notes/honor-defult-max_allowed_packet-5c583ddeebcea7b4.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The ``max_allowed_packet`` setting increased from ``4M`` (the default in
+    MySQL 5.x) to ``16M`` to support larger queries. Because MySQL 8.x uses
+    a new default of ``64M``, the configuration no longer specifies this setting.

--- a/roles/percona_xtradb_cluster/vars/main.yml
+++ b/roles/percona_xtradb_cluster/vars/main.yml
@@ -9,7 +9,6 @@ _percona_xtradb_cluster_spec:
       [mysqld]
       max_connections=8192
       innodb_buffer_pool_size=4096M
-      max_allowed_packet=16M
       # Skip reverse DNS lookup of clients
       skip-name-resolve
       pxc_strict_mode=MASTER

--- a/roles/percona_xtradb_cluster/vars_test.go
+++ b/roles/percona_xtradb_cluster/vars_test.go
@@ -85,7 +85,6 @@ func TestPerconaXtraDBClusterPXCConfiguration(t *testing.T) {
 	section := cfg.Section("mysqld")
 	assert.Equal(t, 8192, section.Key("max_connections").MustInt())
 	assert.Equal(t, "4096M", section.Key("innodb_buffer_pool_size").String())
-	assert.Equal(t, "16M", section.Key("max_allowed_packet").String())
 	assert.Equal(t, true, section.Key("skip-name-resolve").MustBool())
 }
 


### PR DESCRIPTION
Backport from https://github.com/vexxhost/atmosphere/pull/2546

Change-Id: Ibb2a18d1e3744b22abbd61f86b7d4a43cfa790c8