### PR TITLE
feat: enable auth token cache in rook (#2653)

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -1,3 +1,5 @@
+CRD
+Ceph
 Glance
 Manila
 MySQL
@@ -12,3 +14,4 @@ backport
 kek
 liveness
 readiness
+tracker.ceph.com

--- a/molecule/aio/prepare.yml
+++ b/molecule/aio/prepare.yml
@@ -42,4 +42,4 @@
         name: ceph-volume
         state: present
   vars:
-    ceph_version: 18.2.1
+    ceph_version: 18.2.7

--- a/playbooks/csi.yml
+++ b/playbooks/csi.yml
@@ -19,5 +19,5 @@
       tags:
         - csi
   environment:
-    CEPH_CONTAINER_IMAGE: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('18.2.1'))) }}"
+    CEPH_CONTAINER_IMAGE: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('18.2.7'))) }}"
     CEPH_CONTAINER_BINARY: docker

--- a/playbooks/openstack.yml
+++ b/playbooks/openstack.yml
@@ -60,7 +60,7 @@
       tags:
         - placement
   environment:
-    CEPH_CONTAINER_IMAGE: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('18.2.1'))) }}"
+    CEPH_CONTAINER_IMAGE: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('18.2.7'))) }}"
     CEPH_CONTAINER_BINARY: docker
 
 - name: Configure operating system

--- a/releasenotes/notes/enable-auth-token-cache-in-rook-9e15863e87fbe4ba.yaml
+++ b/releasenotes/notes/enable-auth-token-cache-in-rook-9e15863e87fbe4ba.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Atmosphere previously deactivated the Keystone auth token cache due to bug
+    https://tracker.ceph.com/issues/64094. This issue is now resolved upstream,
+    making it safe to reactivate the cache in the new version of Ceph which
+    includes the fix (18.2.7).

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -20,7 +20,7 @@ _atmosphere_images:
   barbican_db_sync: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/barbican:{{ atmosphere_release }}"
   bootstrap: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/heat:{{ atmosphere_release }}"
   ceph_config_helper: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/libvirtd:{{ atmosphere_release }}"
-  ceph: "{{ atmosphere_image_prefix }}quay.io/ceph/ceph:v18.2.2"
+  ceph: "{{ atmosphere_image_prefix }}quay.io/ceph/ceph:v18.2.7"
   cert_manager_cainjector: "{{ atmosphere_image_prefix }}quay.io/jetstack/cert-manager-cainjector:v1.12.10"
   cert_manager_cli: "{{ atmosphere_image_prefix }}quay.io/jetstack/cert-manager-ctl:v1.12.10"
   cert_manager_controller: "{{ atmosphere_image_prefix }}quay.io/jetstack/cert-manager-controller:v1.12.10"

--- a/roles/rook_ceph_cluster/vars/main.yml
+++ b/roles/rook_ceph_cluster/vars/main.yml
@@ -46,8 +46,6 @@ _rook_ceph_cluster_radosgw_spec:
 
 _rook_ceph_cluster_helm_values:
   clusterName: "{{ rook_ceph_cluster_name }}"
-  # NOTE(mnaser): We need to disable the token cache until the the backported
-  #               fix https://tracker.ceph.com/issues/64094 is released.
   configOverride: |
     [client]
     rgw keystone api version = 3
@@ -59,7 +57,6 @@ _rook_ceph_cluster_helm_values:
     rgw keystone implicit tenants = true
     rgw keystone accepted roles = member,admin,reader
     rgw_keystone accepted admin roles = admin
-    rgw keystone token cache size = 0
     rgw s3 auth use keystone = true
     rgw swift account in url = true
     rgw swift versioning enabled = true


### PR DESCRIPTION
(cherry picked from commit 31544c7ac36b9724302f8e8b3fe2f9cb86c3610c)