### PR TITLE
✨ feat: add support for switching OpenStackCluster filter to ID transition

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,6 +6,28 @@ variable "TAG" {
     default = "main"
 }
 
+target "cluster-api-provider-openstack-source" {
+    context = "images/source-patch"
+
+    contexts = {
+        "git" = "https://github.com/kubernetes-sigs/cluster-api-provider-openstack.git#v0.11.6"
+        "patches" = "patches/kubernetes-sigs/cluster-api-provider-openstack"
+    }
+}
+
+target "cluster-api-provider-openstack" {
+    context = "images/cluster-api-provider-openstack"
+    platforms = ["linux/amd64", "linux/arm64"]
+
+    contexts = {
+        "source" = "target:cluster-api-provider-openstack-source"
+    }
+
+    tags = [
+        "${REGISTRY}/capi-openstack-controller:${TAG}"
+    ]
+}
+
 target "ubuntu" {
     context = "images/ubuntu"
     platforms = ["linux/amd64", "linux/arm64"]

--- a/images/cluster-api-provider-openstack/Dockerfile
+++ b/images/cluster-api-provider-openstack/Dockerfile
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: © 2025 VEXXHOST, Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Atmosphere-Rebuild-Time: 2024-06-25T22:49:25Z
+
+FROM golang:1.22.12 AS builder
+WORKDIR /workspace
+RUN \
+  --mount=type=bind,from=source,source=/,target=/workspace/src,readwrite \
+  --mount=type=cache,target=/go/pkg/mod \
+  --mount=type=cache,target=/root/.cache/go-build <<EOF sh -xe
+make -C /workspace/src binaries
+mv /workspace/src/bin /workspace/bin
+EOF
+
+FROM scratch
+COPY --from=builder /workspace/bin/manager /manager
+USER 65532
+ENTRYPOINT ["/manager"]

--- a/images/source-patch/Dockerfile
+++ b/images/source-patch/Dockerfile
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: © 2025 VEXXHOST, Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+FROM alpine/git:v2.47.2 AS clone
+COPY --from=git / /src
+RUN --mount=type=bind,from=patches,source=/,target=/patches <<EOF sh -xe
+git -C /src apply --verbose /patches/*
+EOF
+
+FROM scratch
+COPY --from=clone /src /

--- a/patches/kubernetes-sigs/cluster-api-provider-openstack/allow-switching-filter-name-to-id.patch
+++ b/patches/kubernetes-sigs/cluster-api-provider-openstack/allow-switching-filter-name-to-id.patch
@@ -1,0 +1,412 @@
+From 60f18058b239edac7aad3cf7b1effafae460794c Mon Sep 17 00:00:00 2001
+From: okozachenko1203 <okozachenko@vexxhost.com>
+Date: Wed, 16 Apr 2025 20:40:41 +1000
+Subject: [PATCH] allow switching from filter.name to id in
+ openstackclusterspec network and subnets
+
+---
+ pkg/webhooks/openstackcluster_webhook.go      |  68 ++++
+ pkg/webhooks/openstackcluster_webhook_test.go | 304 ++++++++++++++++++
+ 2 files changed, 372 insertions(+)
+
+diff --git a/pkg/webhooks/openstackcluster_webhook.go b/pkg/webhooks/openstackcluster_webhook.go
+index 910f761ebb..6334b0a419 100644
+--- a/pkg/webhooks/openstackcluster_webhook.go
++++ b/pkg/webhooks/openstackcluster_webhook.go
+@@ -72,6 +72,60 @@ func (*openStackClusterWebhook) ValidateCreate(_ context.Context, objRaw runtime
+ 	return aggregateObjErrors(newObj.GroupVersionKind().GroupKind(), newObj.Name, allErrs)
+ }
+ 
++// allowSubnetFilterToIDTransition checks if changes to OpenStackCluster.Spec.Subnets
++// are transitioning from a Filter-based definition to an ID-based one, and whether
++// those transitions are valid based on the current status.network.subnets.
++//
++// This function only allows Filter → ID transitions when the filter name in the old
++// spec matches the subnet name in status, and the new ID matches the corresponding subnet ID.
++//
++// Returns true if all such transitions are valid; false otherwise.
++func allowSubnetFilterToIDTransition(oldObj, newObj *infrav1.OpenStackCluster) bool {
++	if newObj.Spec.Network == nil || oldObj.Spec.Network == nil || oldObj.Status.Network == nil {
++		return false
++	}
++
++	if len(newObj.Spec.Subnets) != len(oldObj.Spec.Subnets) || len(oldObj.Status.Network.Subnets) == 0 {
++		return false
++	}
++
++	for i := range newObj.Spec.Subnets {
++		oldSubnet := oldObj.Spec.Subnets[i]
++		newSubnet := newObj.Spec.Subnets[i]
++
++		// Allow Filter → ID only if both values match a known subnet in status
++		if oldSubnet.Filter != nil && newSubnet.ID != nil && newSubnet.Filter == nil {
++			matchFound := false
++			for _, statusSubnet := range oldObj.Status.Network.Subnets {
++				if oldSubnet.Filter.Name == statusSubnet.Name && *newSubnet.ID == statusSubnet.ID {
++					matchFound = true
++					break
++				}
++			}
++			if !matchFound {
++				return false
++			}
++		}
++
++		// Reject any change from ID → Filter
++		if oldSubnet.ID != nil && newSubnet.Filter != nil {
++			return false
++		}
++
++		// Reject changes to Filter or ID if they do not match the old values
++		if oldSubnet.Filter != nil && newSubnet.Filter != nil &&
++			oldSubnet.Filter.Name != newSubnet.Filter.Name {
++			return false
++		}
++		if oldSubnet.ID != nil && newSubnet.ID != nil &&
++			*oldSubnet.ID != *newSubnet.ID {
++			return false
++		}
++	}
++
++	return true
++}
++
+ // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
+ func (*openStackClusterWebhook) ValidateUpdate(_ context.Context, oldObjRaw, newObjRaw runtime.Object) (admission.Warnings, error) {
+ 	var allErrs field.ErrorList
+@@ -154,6 +208,20 @@ func (*openStackClusterWebhook) ValidateUpdate(_ context.Context, oldObjRaw, new
+ 		oldObj.Spec.APIServerFloatingIP = nil
+ 	}
+ 
++	// Allow changes from filter to id for spec.network and spec.subnets
++	if newObj.Spec.Network != nil && oldObj.Spec.Network != nil && oldObj.Status.Network != nil {
++		// Allow change from spec.network.subnets from filter to id if it matches the current subnets.
++		if allowSubnetFilterToIDTransition(oldObj, newObj) {
++			oldObj.Spec.Subnets = nil
++			newObj.Spec.Subnets = nil
++		}
++		// Allow change from spec.network.filter to spec.network.id only if it matches the current network.
++		if ptr.Deref(newObj.Spec.Network.ID, "") == oldObj.Status.Network.ID {
++			newObj.Spec.Network = nil
++			oldObj.Spec.Network = nil
++		}
++	}
++
+ 	if !reflect.DeepEqual(oldObj.Spec, newObj.Spec) {
+ 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "cannot be modified"))
+ 	}
+diff --git a/pkg/webhooks/openstackcluster_webhook_test.go b/pkg/webhooks/openstackcluster_webhook_test.go
+index a448a903b1..4bfe006b8d 100644
+--- a/pkg/webhooks/openstackcluster_webhook_test.go
++++ b/pkg/webhooks/openstackcluster_webhook_test.go
+@@ -510,6 +510,310 @@ func TestOpenStackCluster_ValidateUpdate(t *testing.T) {
+ 			},
+ 			wantErr: false,
+ 		},
++		{
++			name: "Switching OpenStackCluster.Spec.Network from filter.name to id is allowed when they refer to the same network",
++			oldTemplate: &infrav1.OpenStackCluster{
++				Spec: infrav1.OpenStackClusterSpec{
++					IdentityRef: infrav1.OpenStackIdentityReference{
++						Name:      "foobar",
++						CloudName: "foobar",
++					},
++					Network: &infrav1.NetworkParam{
++						Filter: &infrav1.NetworkFilter{
++							Name: "testnetworkname",
++						},
++					},
++				},
++				Status: infrav1.OpenStackClusterStatus{
++					Network: &infrav1.NetworkStatusWithSubnets{
++						NetworkStatus: infrav1.NetworkStatus{
++							ID:   "testnetworkid",
++							Name: "testnetworkname",
++						},
++					},
++				},
++			},
++			newTemplate: &infrav1.OpenStackCluster{
++				Spec: infrav1.OpenStackClusterSpec{
++					IdentityRef: infrav1.OpenStackIdentityReference{
++						Name:      "foobar",
++						CloudName: "foobar",
++					},
++					Network: &infrav1.NetworkParam{
++						ID: ptr.To("testnetworkid"),
++					},
++				},
++				Status: infrav1.OpenStackClusterStatus{
++					Network: &infrav1.NetworkStatusWithSubnets{
++						NetworkStatus: infrav1.NetworkStatus{
++							ID:   "testnetworkid",
++							Name: "testnetworkname",
++						},
++					},
++				},
++			},
++			wantErr: false,
++		},
++		{
++			name: "Switching OpenStackCluster.Spec.Network from filter.name to id is not allowed when they refer to different networks",
++			oldTemplate: &infrav1.OpenStackCluster{
++				Spec: infrav1.OpenStackClusterSpec{
++					IdentityRef: infrav1.OpenStackIdentityReference{
++						Name:      "foobar",
++						CloudName: "foobar",
++					},
++					Network: &infrav1.NetworkParam{
++						Filter: &infrav1.NetworkFilter{
++							Name: "testetworkname",
++						},
++					},
++				},
++				Status: infrav1.OpenStackClusterStatus{
++					Network: &infrav1.NetworkStatusWithSubnets{
++						NetworkStatus: infrav1.NetworkStatus{
++							ID:   "testetworkid1",
++							Name: "testnetworkname",
++						},
++					},
++				},
++			},
++			newTemplate: &infrav1.OpenStackCluster{
++				Spec: infrav1.OpenStackClusterSpec{
++					IdentityRef: infrav1.OpenStackIdentityReference{
++						Name:      "foobar",
++						CloudName: "foobar",
++					},
++					Network: &infrav1.NetworkParam{
++						ID: ptr.To("testetworkid2"),
++					},
++				},
++				Status: infrav1.OpenStackClusterStatus{
++					Network: &infrav1.NetworkStatusWithSubnets{
++						NetworkStatus: infrav1.NetworkStatus{
++							ID:   "testetworkid1",
++							Name: "testnetworkname",
++						},
++					},
++				},
++			},
++			wantErr: true,
++		},
++		{
++			name: "Switching OpenStackCluster.Spec.Subnets from filter.name to id is allowed when they refer to the same subnet",
++			oldTemplate: &infrav1.OpenStackCluster{
++				Spec: infrav1.OpenStackClusterSpec{
++					IdentityRef: infrav1.OpenStackIdentityReference{
++						Name:      "foobar",
++						CloudName: "foobar",
++					},
++					Network: &infrav1.NetworkParam{
++						ID: ptr.To("net-123"),
++					},
++					Subnets: []infrav1.SubnetParam{
++						{
++							Filter: &infrav1.SubnetFilter{
++								Name: "test-subnet",
++							},
++						},
++					},
++				},
++				Status: infrav1.OpenStackClusterStatus{
++					Network: &infrav1.NetworkStatusWithSubnets{
++						NetworkStatus: infrav1.NetworkStatus{
++							ID:   "net-123",
++							Name: "testnetwork",
++						},
++						Subnets: []infrav1.Subnet{
++							{
++								ID:   "subnet-123",
++								Name: "test-subnet",
++							},
++						},
++					},
++				},
++			},
++			newTemplate: &infrav1.OpenStackCluster{
++				Spec: infrav1.OpenStackClusterSpec{
++					IdentityRef: infrav1.OpenStackIdentityReference{
++						Name:      "foobar",
++						CloudName: "foobar",
++					},
++					Network: &infrav1.NetworkParam{
++						ID: ptr.To("net-123"),
++					},
++					Subnets: []infrav1.SubnetParam{
++						{
++							ID: ptr.To("subnet-123"),
++						},
++					},
++				},
++				Status: infrav1.OpenStackClusterStatus{
++					Network: &infrav1.NetworkStatusWithSubnets{
++						NetworkStatus: infrav1.NetworkStatus{
++							ID:   "net-123",
++							Name: "testnetwork",
++						},
++						Subnets: []infrav1.Subnet{
++							{
++								ID:   "subnet-123",
++								Name: "test-subnet",
++							},
++						},
++					},
++				},
++			},
++			wantErr: false,
++		},
++		{
++			name: "Switching OpenStackCluster.Spec.Subnets from filter.name to id is not allowed when they refer to different subnets",
++			oldTemplate: &infrav1.OpenStackCluster{
++				Spec: infrav1.OpenStackClusterSpec{
++					IdentityRef: infrav1.OpenStackIdentityReference{
++						Name:      "foobar",
++						CloudName: "foobar",
++					},
++					Network: &infrav1.NetworkParam{
++						ID: ptr.To("net-123"),
++					},
++					Subnets: []infrav1.SubnetParam{
++						{
++							Filter: &infrav1.SubnetFilter{
++								Name: "test-subnet",
++							},
++						},
++					},
++				},
++				Status: infrav1.OpenStackClusterStatus{
++					Network: &infrav1.NetworkStatusWithSubnets{
++						NetworkStatus: infrav1.NetworkStatus{
++							ID:   "net-123",
++							Name: "testnetwork",
++						},
++						Subnets: []infrav1.Subnet{
++							{
++								ID:   "subnet-123",
++								Name: "test-subnet",
++							},
++						},
++					},
++				},
++			},
++			newTemplate: &infrav1.OpenStackCluster{
++				Spec: infrav1.OpenStackClusterSpec{
++					IdentityRef: infrav1.OpenStackIdentityReference{
++						Name:      "foobar",
++						CloudName: "foobar",
++					},
++					Network: &infrav1.NetworkParam{
++						ID: ptr.To("net-123"),
++					},
++					Subnets: []infrav1.SubnetParam{
++						{
++							ID: ptr.To("wrong-subnet"),
++						},
++					},
++				},
++				Status: infrav1.OpenStackClusterStatus{
++					Network: &infrav1.NetworkStatusWithSubnets{
++						NetworkStatus: infrav1.NetworkStatus{
++							ID:   "net-123",
++							Name: "testnetwork",
++						},
++						Subnets: []infrav1.Subnet{
++							{
++								ID:   "subnet-123",
++								Name: "test-subnet",
++							},
++						},
++					},
++				},
++			},
++			wantErr: true,
++		},
++		{
++			name: "Switching one OpenStackCluster.Spec.Subnets entry from filter to a mismatched ID (from another subnet) should be rejected, even if other subnets remain unchanged",
++			oldTemplate: &infrav1.OpenStackCluster{
++				Spec: infrav1.OpenStackClusterSpec{
++					IdentityRef: infrav1.OpenStackIdentityReference{
++						Name:      "foobar",
++						CloudName: "foobar",
++					},
++					Network: &infrav1.NetworkParam{
++						ID: ptr.To("net-123"),
++					},
++					Subnets: []infrav1.SubnetParam{
++						{
++							Filter: &infrav1.SubnetFilter{
++								Name: "test-subnet-1",
++							},
++						},
++						{
++							Filter: &infrav1.SubnetFilter{
++								Name: "test-subnet-2",
++							},
++						},
++					},
++				},
++				Status: infrav1.OpenStackClusterStatus{
++					Network: &infrav1.NetworkStatusWithSubnets{
++						NetworkStatus: infrav1.NetworkStatus{
++							ID:   "net-123",
++							Name: "testnetwork",
++						},
++						Subnets: []infrav1.Subnet{
++							{
++								ID:   "test-subnet-id-1",
++								Name: "test-subnet-1",
++							},
++							{
++								ID:   "test-subnet-id-2",
++								Name: "test-subnet-2",
++							},
++						},
++					},
++				},
++			},
++			newTemplate: &infrav1.OpenStackCluster{
++				Spec: infrav1.OpenStackClusterSpec{
++					IdentityRef: infrav1.OpenStackIdentityReference{
++						Name:      "foobar",
++						CloudName: "foobar",
++					},
++					Network: &infrav1.NetworkParam{
++						ID: ptr.To("net-123"),
++					},
++					Subnets: []infrav1.SubnetParam{
++						{
++							ID: ptr.To("test-subnet-id-2"),
++						},
++						{
++							Filter: &infrav1.SubnetFilter{
++								Name: "test-subnet-2",
++							},
++						},
++					},
++				},
++				Status: infrav1.OpenStackClusterStatus{
++					Network: &infrav1.NetworkStatusWithSubnets{
++						NetworkStatus: infrav1.NetworkStatus{
++							ID:   "net-123",
++							Name: "testnetwork",
++						},
++						Subnets: []infrav1.Subnet{
++							{
++								ID:   "test-subnet-id-1",
++								Name: "test-subnet-1",
++							},
++							{
++								ID:   "test-subnet-id-2",
++								Name: "test-subnet-2",
++							},
++						},
++					},
++				},
++			},
++			wantErr: true,
++		},
+ 	}
+ 	for _, tt := range tests {
+ 		t.Run(tt.name, func(t *testing.T) {

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -39,7 +39,7 @@ _atmosphere_images:
   cluster_api_controller: "{{ atmosphere_image_prefix }}registry.k8s.io/cluster-api/cluster-api-controller:v1.8.4"
   cluster_api_kubeadm_bootstrap_controller: "{{ atmosphere_image_prefix }}registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.8.4"
   cluster_api_kubeadm_control_plane_controller: "{{ atmosphere_image_prefix }}registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.8.4"
-  cluster_api_openstack_controller: "{{ atmosphere_image_prefix }}registry.k8s.io/capi-openstack/capi-openstack-controller:v0.11.2"
+  cluster_api_openstack_controller: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/capi-openstack-controller:{{ atmosphere_release }}"
   csi_node_driver_registrar: "{{ atmosphere_image_prefix }}registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0"
   csi_rbd_attacher: "{{ atmosphere_image_prefix }}registry.k8s.io/sig-storage/csi-attacher:v4.5.0"
   csi_rbd_plugin: "{{ atmosphere_image_prefix }}quay.io/cephcsi/cephcsi:v3.11.0"


### PR DESCRIPTION
- Implemented logic to allow transitioning from filter.name to ID in
  OpenStackCluster.Spec.Network and Spec.Subnets.
- Updated validation logic in webhook to enforce transition rules.
- Added tests to cover various scenarios for filter to ID transitions.
