### PR TITLE
fix: grant enough permission to c-vol

### DIFF
--- a/roles/cinder/vars/main.yml
+++ b/roles/cinder/vars/main.yml
@@ -29,6 +29,12 @@ __cinder_helm_values:
           volumes:
             - name: cinder-tmp
               emptyDir: {}
+    security_context:
+      cinder_volume:
+        pod:
+          cinder_volume:
+            privileged: true
+
   conf:
     policy: {}
     cinder:


### PR DESCRIPTION
volume creation from qcow2 image fails with this error

```sh
raise FailedToDropPrivileges(msg)\n', 'oslo_privsep.daemon.FailedToDropPrivileges: Privsep daemon failed to start\n']
```