### PR TITLE
[stable/2023.2]add missing cinder.auth_type

### DIFF
--- a/releasenotes/notes/Fix-cinder-auth-type-9ea017879a578f2a.yaml
+++ b/releasenotes/notes/Fix-cinder-auth-type-9ea017879a578f2a.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The ``[cinder]/auth_type`` configuration value wasn't set resulting in
+    the entire Cinder section not render in the configuration file, it
+    is now set to ``password`` which will fully render the Cinder section
+    for OpenStack Nova.

--- a/roles/nova/vars/main.yml
+++ b/roles/nova/vars/main.yml
@@ -62,10 +62,7 @@ _nova_helm_values:
       cache:
         backend: oslo_cache.memcache_pool
       cinder:
-        catalog_info: volumev3::internalURL
-        os_region_name: "{{ openstack_helm_endpoints_nova_region_name }}"
-        username: "nova-{{ openstack_helm_endpoints_nova_region_name }}"
-        password: "{{ openstack_helm_endpoints_nova_keystone_password }}"
+        auth_type: password
       conductor:
         workers: 8
       compute:


### PR DESCRIPTION
[stable/2023.2]add missing cinder.auth_type

Change-Id: Idfa71708a45c1a3db9115601ba580432883cbbec
Signed-off-by: ricolin <rlin@vexxhost.com>