### PR TITLE
[Backport stable/2023.1]chore: upgrade portworx csi operator to latest stable (#2798)

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -2,6 +2,7 @@ ACL
 ACME
 BGP
 CRD
+CSI
 Ceph
 DNS
 Glance
@@ -11,12 +12,14 @@ LUN
 Manila
 MySQL
 Nova
+OCI
 Percona
 QEMU
 SST
 TLS
 VNC
 [Bb]ackports
+[Pp]ortworx
 backport
 kek
 liveness

--- a/releasenotes/notes/bump-portworx-csi-2fa5859c1e5cb901.yaml
+++ b/releasenotes/notes/bump-portworx-csi-2fa5859c1e5cb901.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    - Upgraded Portworx CSI operator to version 25.2.1 from 23.10.5 for improved stability and performance.
+    - Updated Portworx OCI monitor to version 25.4.0 from 3.1.1 to support the latest operator features.

--- a/roles/portworx/templates/portworx.yml
+++ b/roles/portworx/templates/portworx.yml
@@ -51,7 +51,7 @@ spec:
       containers:
       - name: portworx-operator
         imagePullPolicy: Always
-        image: portworx/px-operator:23.10.5
+        image: portworx/px-operator:25.2.1
         command:
         - /operator
         - --verbose

--- a/roles/portworx/templates/storage_cluster.yml
+++ b/roles/portworx/templates/storage_cluster.yml
@@ -6,11 +6,11 @@ metadata:
   namespace: portworx
   annotations:
     portworx.io/install-source: "https://install.portworx.com/?operator=true&mc=false&kbver=1.28.0&ns=portworx&oem=esse&user=2487eaa2-e557-4f68-8e87-9b56c0a4498f&b=true&iop=6&s=%22size%3D150%22&pureSanType=FC&ce=pure&c=px-cluster-567cacc6-e39c-49da-9d35-2bafacfcf18c&stork=true&csi=true&mon=true&tel=true&st=k8s&promop=true"
-    portworx.io/misc-args: "--oem esse"
+    portworx.io/misc-args: "--oem px-csi"
     portworx.io/disable-storage-class: "true"
     portworx.io/pvc-controller-secure-port: "20257"
 spec:
-  image: portworx/oci-monitor:3.1.1
+  image: portworx/oci-monitor:25.4.0
   imagePullPolicy: Always
   kvdb:
     internal: true
@@ -19,11 +19,11 @@ spec:
     - size=150
   secretsProvider: k8s
   stork:
-    enabled: true
+    enabled: false
     args:
       webhook-controller: "true"
   autopilot:
-    enabled: true
+    enabled: false
   runtimeOptions:
     default-io-profile: "6"
   csi:


### PR DESCRIPTION
(cherry picked from commit bd40b10419417c9e992cd8dcb83693a44504442d) (cherry picked from commit 0a86143ee653ee2d871796e7080ca3c57542528c)