### PR TITLE
[Backport stable/2024.1]Fix cinder auth in nova conf (#2805)

### DIFF
--- a/.charts.yml
+++ b/.charts.yml
@@ -160,6 +160,10 @@ charts:
     version: 0.3.46
     repository: *openstack_helm_repository
     dependencies: *openstack_helm_dependencies
+    patches:
+      gerrit:
+        review.opendev.org:
+          - 954211
   - name: octavia
     version: 0.2.9
     repository: *openstack_helm_repository

--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -13,6 +13,8 @@ Manila
 MySQL
 Nova
 OCI
+OVN
+OpenStack
 Percona
 QEMU
 SST

--- a/charts/nova/values.yaml
+++ b/charts/nova/values.yaml
@@ -1435,6 +1435,7 @@ conf:
       auth_type: password
       auth_version: v3
     cinder:
+      auth_type: password
       catalog_info: volumev3::internalURL
     database:
       max_retries: -1
@@ -1856,6 +1857,22 @@ endpoints:
     port:
       api:
         default: 9292
+        public: 80
+  volumev3:
+    name: cinderv3
+    hosts:
+      default: cinder-api
+      public: cinder
+    host_fqdn_override:
+      default: null
+    path:
+      default: '/v3/%(tenant_id)s'
+      healthcheck: /healthcheck
+    scheme:
+      default: http
+    port:
+      api:
+        default: 8776
         public: 80
   compute:
     name: nova

--- a/releasenotes/notes/fix-cinder-auth-in-nova-adead5a3a276781a.yaml
+++ b/releasenotes/notes/fix-cinder-auth-in-nova-adead5a3a276781a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Corrected Cinder authentication configuration handling in Nova.
+    Nova now respects authentication overrides defined in OpenStack Helm endpoints,
+    such as ``openstack_helm_endpoints_nova_region_name``.

--- a/roles/nova/vars/main.yml
+++ b/roles/nova/vars/main.yml
@@ -61,8 +61,6 @@ _nova_helm_values:
         barbican_endpoint_type: internal
       cache:
         backend: oslo_cache.memcache_pool
-      cinder:
-        auth_type: password
       conductor:
         workers: 8
       compute:


### PR DESCRIPTION
(cherry picked from commit 07775611842d7c0ab09ea915cd9555fad81f2a3a)