### PR TITLE
deps: upgrade k8s collection to 2.3.2

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,28 +6,29 @@ variable "TAG" {
     default = "main"
 }
 
-target "cluster-api-provider-openstack-source" {
-    context = "images/source-patch"
-    platforms = ["linux/amd64", "linux/arm64"]
+# NOTE(oleksandr1203): We keep this commented out for now as we'll need patch in the future.
+# target "cluster-api-provider-openstack-source" {
+#     context = "images/source-patch"
+#     platforms = ["linux/amd64", "linux/arm64"]
 
-    contexts = {
-        "git" = "https://github.com/kubernetes-sigs/cluster-api-provider-openstack.git#v0.11.6"
-        "patches" = "patches/kubernetes-sigs/cluster-api-provider-openstack"
-    }
-}
+#     contexts = {
+#         "git" = "https://github.com/kubernetes-sigs/cluster-api-provider-openstack.git#v0.12.4"
+#         "patches" = "patches/kubernetes-sigs/cluster-api-provider-openstack"
+#     }
+# }
 
-target "cluster-api-provider-openstack" {
-    context = "images/cluster-api-provider-openstack"
-    platforms = ["linux/amd64", "linux/arm64"]
+# target "cluster-api-provider-openstack" {
+#     context = "images/cluster-api-provider-openstack"
+#     platforms = ["linux/amd64", "linux/arm64"]
 
-    contexts = {
-        "source" = "target:cluster-api-provider-openstack-source"
-    }
+#     contexts = {
+#         "source" = "target:cluster-api-provider-openstack-source"
+#     }
 
-    tags = [
-        "${REGISTRY}/capi-openstack-controller:${TAG}"
-    ]
-}
+#     tags = [
+#         "${REGISTRY}/capi-openstack-controller:${TAG}"
+#     ]
+# }
 
 target "ubuntu" {
     context = "images/ubuntu"
@@ -294,7 +295,7 @@ target "openstack" {
 
 group "default" {
     targets = [
-        "cluster-api-provider-openstack",
+        # "cluster-api-provider-openstack",
         "keepalived",
         "libvirtd",
         "netoffload",

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ license:
   - GPL-3.0-or-later
 dependencies:
   ansible.netcommon: 1.2.0
-  ansible.posix: 1.3.0
+  ansible.posix: 1.6.0
   ansible.utils: ">=2.9.0"
   community.crypto: 2.2.3
   community.general: 7.3.0
@@ -17,7 +17,7 @@ dependencies:
   kubernetes.core: 2.4.0
   openstack.cloud: ">=2.0.0"
   vexxhost.ceph: ">=3.1.2"
-  vexxhost.kubernetes: ">=2.0.1"
+  vexxhost.kubernetes: ">=2.3.2"
 tags:
   - application
   - cloud

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -39,7 +39,7 @@ _atmosphere_images:
   cluster_api_controller: "{{ atmosphere_image_prefix }}registry.k8s.io/cluster-api/cluster-api-controller:v1.8.4"
   cluster_api_kubeadm_bootstrap_controller: "{{ atmosphere_image_prefix }}registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.8.4"
   cluster_api_kubeadm_control_plane_controller: "{{ atmosphere_image_prefix }}registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.8.4"
-  cluster_api_openstack_controller: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/capi-openstack-controller:{{ atmosphere_release }}"
+  cluster_api_openstack_controller: "{{ atmosphere_image_prefix }}registry.k8s.io/capi-openstack/capi-openstack-controller:v0.12.4"
   csi_node_driver_registrar: "{{ atmosphere_image_prefix }}registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0"
   csi_rbd_attacher: "{{ atmosphere_image_prefix }}registry.k8s.io/sig-storage/csi-attacher:v4.5.0"
   csi_rbd_plugin: "{{ atmosphere_image_prefix }}quay.io/cephcsi/cephcsi:v3.11.0"


### PR DESCRIPTION
This PR is based on the assumption that k8s collection 2.3.2 will be released after this PR is merged https://github.com/vexxhost/ansible-collection-kubernetes/pull/194

We don't need to keep local patch for capo image build so this PR uses the upstream image