### PR TITLE
ensure necessary kernel modules are loaded

### DIFF
--- a/playbooks/openstack.yml
+++ b/playbooks/openstack.yml
@@ -67,6 +67,10 @@
   hosts: controllers:computes
   become: true
   roles:
+    - role: kernel_modules
+      tags:
+        - kernel_modules
+
     - role: lpfc
       tags:
         - lpfc

--- a/roles/kernel_modules/README.md
+++ b/roles/kernel_modules/README.md
@@ -1,0 +1,1 @@
+# `kernel_modules`

--- a/roles/kernel_modules/tasks/main.yml
+++ b/roles/kernel_modules/tasks/main.yml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: © 2025 VEXXHOST, Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Load Necessary Kernel Modules
+  ansible.builtin.modprobe:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - nbd
+    - nvme
+
+- name: Ensure NBD and NVMe Modules Are Loaded at Boot
+  ansible.builtin.copy:
+    dest: /etc/modules-load.d/vexxhost.conf
+    content: |
+      nbd
+      nvme
+    owner: root
+    group: root
+    mode: '0644'


### PR DESCRIPTION
kernel module nvme are used in latest os_brick library 
nbd module is required for Trilio snapshot mount and file search