### PR TITLE
feat: add manila share type configuration

### DIFF
--- a/releasenotes/notes/add-manila-share-types-12fa414e15ef0b6b.yaml
+++ b/releasenotes/notes/add-manila-share-types-12fa414e15ef0b6b.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - Add support for Manila share types configuration with default extra
+    specs for snapshot support.

--- a/roles/manila/defaults/main.yml
+++ b/roles/manila/defaults/main.yml
@@ -41,3 +41,9 @@ manila_image_disk_format: qcow2
 
 # Service instance authentication
 manila_ssh_key: "{{ undef('You must provide a private SSH key using manila_ssh_key') }}"
+
+manila_share_types:
+  - name: default
+    extra_specs:
+      snapshot_support: true
+      create_share_from_snapshot_support: true

--- a/roles/manila/tasks/main.yml
+++ b/roles/manila/tasks/main.yml
@@ -52,3 +52,53 @@
     gigabytes: -1
     security_group: -1
     security_group_rule: -1
+
+- name: Create share types
+  when: manila_share_types | length > 0
+  block:
+    - name: Wait until share service ready
+      kubernetes.core.k8s_info:
+        api_version: apps/v1
+        kind: Deployment
+        name: manila-api
+        namespace: openstack
+        wait_sleep: 10
+        wait_timeout: 600
+        wait: true
+        wait_condition:
+          type: Available
+          status: true
+
+    - name: Create share types
+      changed_when: false
+      ansible.builtin.shell: |
+        set -o posix
+        source /etc/profile.d/atmosphere.sh
+        openstack share type show {{ item.name }} ||
+        openstack share type create \
+          --public {{ item.is_public | default(true) }} \
+          {{ item.name }} {{ item.driver_handles_share_servers | default(true) }}
+        # Set additional settings
+        {% if item.description is defined %}
+        openstack share type set {{ item.name }} \
+          --description "{{ item.description }}"
+        {% endif %}
+        openstack share type set {{ item.name }} \
+          --public {{ item.is_public | default(true) }}
+        # Set all extra specs
+        {% if item.extra_specs is defined %}
+        {% for key, value in item.extra_specs.items() %}
+        openstack share type set {{ item.name }} \
+          --extra-specs {{ key }}={{ value }}
+        {% endfor %}
+        {% endif %}
+      args:
+        executable: /bin/bash
+      environment:
+        OS_CLOUD: atmosphere
+      loop: "{{ manila_share_types }}"
+      register: configure_manila_share_types
+      retries: 60
+      delay: 5
+      until: configure_manila_share_types.rc == 0
+      failed_when: configure_manila_share_types.rc != 0


### PR DESCRIPTION
Related to: https://github.com/vexxhost/magnum-cluster-api/pull/795/commits/da57db95b933af340fb559b8e170fc92f7502ac9

Also handy if we need more extra specs like:
```
openstack share type create manila-generic-share true \
    --extra-specs share_backend_name=ANOTHER_BACKEND
```
