### PR TITLE
feat: enable PCI device tracking in placement

### DIFF
--- a/releasenotes/notes/nova-pci-in-placement-b37710f22bceea12.yaml
+++ b/releasenotes/notes/nova-pci-in-placement-b37710f22bceea12.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Nova's Peripheral Component Interconnect (PCI) in placement feature is now
+    enabled by default. This feature improves device resource tracking and
+    scheduling by integrating these devices with the placement service. The
+    scheduler can now make more intelligent decisions about device
+    allocation using placement's allocation candidates API.
+  - |
+    The placement service user now also has the 'service' role alongside
+    the 'admin' role. Nova compute services need this role to
+    report device inventory to placement and make allocation requests.

--- a/roles/nova/vars/main.yml
+++ b/roles/nova/vars/main.yml
@@ -90,6 +90,7 @@ _nova_helm_values:
           FailureDomainFilter
         image_properties_default_architecture: x86_64
         max_instances_per_host: 200
+        pci_in_placement: true
       glance:
         enable_rbd_download: true
       libvirt:
@@ -106,6 +107,8 @@ _nova_helm_values:
         driver: noop
       os_vif_ovs:
         ovsdb_connection: unix:/run/openvswitch/db.sock
+      pci:
+        report_in_placement: true
       privsep_osbrick:
         helper_command: sudo nova-rootwrap /etc/nova/rootwrap.conf privsep-helper --config-file /etc/nova/nova.conf
       scheduler:

--- a/roles/openstack_helm_endpoints/vars/main.yml
+++ b/roles/openstack_helm_endpoints/vars/main.yml
@@ -146,6 +146,7 @@ _openstack_helm_endpoints_placement:
   identity:
     auth:
       placement:
+        role: admin,service
         region_name: "{{ openstack_helm_endpoints_placement_region_name }}"
         username: "placement-{{ openstack_helm_endpoints_placement_region_name }}"
         password: "{{ openstack_helm_endpoints_placement_keystone_password }}"


### PR DESCRIPTION
## Summary
- Enables Nova's PCI-in-placement feature for better PCI device resource tracking
- Adds required 'service' role to placement user for proper Nova compute integration

## Changes
1. **Nova Configuration** (`roles/nova/vars/main.yml`):
   - Added `[filter_scheduler]/pci_in_placement: true` - Enables placement-aware PCI scheduling
   - Added `[pci]/report_in_placement: true` - Reports PCI device inventory to placement

2. **Placement User Role** (`roles/openstack_helm_endpoints/vars/main.yml`):
   - Added `role: admin,service` to placement user - Required for Nova compute services to interact with placement API

## Why these changes are needed

### PCI-in-Placement Feature
The PCI-in-placement feature represents a significant improvement in how Nova handles PCI devices:

- **Better Resource Tracking**: PCI devices are tracked as resource providers in placement, providing a unified view of all resources
- **Improved Scheduling**: The scheduler can make more intelligent decisions using placement's allocation candidates API
- **Resource Allocation**: Proper tracking of PCI device allocations prevents over-subscription
- **Performance**: Reduces the load on nova-scheduler by leveraging placement's optimized queries

### Service Role Requirement
The placement user needs the 'service' role because:
- Nova compute services need to report PCI device inventory to placement
- The compute services authenticate using the placement service user credentials
- Without the 'service' role, compute nodes cannot properly update PCI device inventory or make allocation requests

This aligns with other OpenStack services (Nova, Neutron, Cinder) that also use `admin,service` roles for their service users.

🤖 Generated with [Claude Code](https://claude.ai/code)