### PR TITLE
fix: switch to rancher's kubectl image

### DIFF
--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -121,7 +121,7 @@ _atmosphere_images:
   kube_scheduler: "{{ atmosphere_image_prefix }}registry.k8s.io/kube-scheduler:v1.22.17"
   kube_state_metrics: "{{ atmosphere_image_prefix }}registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0"
   kube_vip: "{{ atmosphere_image_prefix }}ghcr.io/kube-vip/kube-vip:v0.6.4"
-  kubectl: "{{ atmosphere_image_prefix }}docker.io/bitnami/kubectl:1.27.3"
+  kubectl: "{{ atmosphere_image_prefix }}docker.io/rancher/kubectl:v1.34.1"
   libvirt: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/libvirtd:{{ atmosphere_release }}"
   libvirt_tls_sidecar: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/libvirt-tls-sidecar:latest"
   libvirt_exporter: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/libvirtd-exporter:latest"


### PR DESCRIPTION
As announced in many sources `bitnami` registry is moved to `bitnamilegacy` and freezed already. We need this change ASAP.