### PR TITLE
[stable/2024.2] feat: add taas plugin for neutron to support port mirroring

### DIFF
--- a/images/neutron/Dockerfile
+++ b/images/neutron/Dockerfile
@@ -27,6 +27,10 @@ RUN git -C /src/neutron-policy-server fetch --unshallow
 ARG LOG_PASER_GIT_REF=3895d8f9d004e612c71b4f798d31c758e113946b
 ADD --keep-git-dir=true https://github.com/vexxhost/neutron-ovn-network-logging-parser.git#${LOG_PASER_GIT_REF} /src/neutron-ovn-network-logging-parser
 RUN git -C /src/neutron-ovn-network-logging-parser fetch --unshallow
+# renovate: name=openstack/tap-as-a-service repo=https://opendev.org/openstack/tap-as-a-service.git branch=stable/2024.2
+ARG TAP_AS_A_SERVICE_GIT_REF=9018b18e47468ab4fd158bc204941e7fb57c5e63
+ADD --keep-git-dir=true https://opendev.org/openstack/tap-as-a-service.git#${TAP_AS_A_SERVICE_GIT_REF} /src/tap-as-a-service
+RUN git -C /src/tap-as-a-service fetch --unshallow
 RUN \
   --mount=type=bind,from=neutron-source,source=/,target=/src/neutron,readwrite \
   --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
@@ -39,6 +43,7 @@ uv pip install \
         /src/networking-generic-switch \
         /src/neutron-policy-server \
         /src/neutron-ovn-network-logging-parser \
+        /src/tap-as-a-service \
         pymemcache
 EOF
 

--- a/images/python-openstackclient/Dockerfile
+++ b/images/python-openstackclient/Dockerfile
@@ -17,7 +17,8 @@ uv pip install \
         python-neutronclient \
         python-octaviaclient \
         python-openstackclient \
-        python-swiftclient
+        python-swiftclient \
+        tap-as-a-service
 EOF
 
 FROM python-base

--- a/releasenotes/notes/support-port-mirroring-16c65750d723ca0e.yaml
+++ b/releasenotes/notes/support-port-mirroring-16c65750d723ca0e.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add required neutron plugin to support port mirroring with OVN backend.


### PR DESCRIPTION
## Summary
- Backport of #2795 to stable/2024.2 branch
- Adds tap-as-a-service plugin for neutron to support port mirroring with OVN backend
- Updates branch references from master to stable/2024.2

🤖 Generated with [Claude Code](https://claude.ai/code)