### PR TITLE
fix: update OctaviaAmphoraNotReady alert to accept ALLOCATED status

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -1,5 +1,6 @@
 ACL
 ACME
+ALLOCATED
 Ansible
 BGP
 Bitnami
@@ -25,6 +26,7 @@ OVN
 OpenStack
 Percona
 QEMU
+READY
 SST
 Staffeln
 TLS

--- a/releasenotes/notes/fix-octavia-amphora-alert-valid-statuses-e1d3c99b6ca945eb.yaml
+++ b/releasenotes/notes/fix-octavia-amphora-alert-valid-statuses-e1d3c99b6ca945eb.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix ``OctaviaAmphoraNotReady`` monitoring rule to recognize both ``READY`` and ``ALLOCATED``
+    as valid Amphora statuses. Previously, the monitoring rule fired for Amphora instances in ``ALLOCATED``
+    status, which is a normal operational state. The monitoring rule now uses the name
+    ``OctaviaAmphoraNotOperational`` to better reflect its purpose of detecting
+    non-operational Amphora instances.

--- a/roles/kube_prometheus_stack/files/jsonnet/openstack.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/openstack.libsonnet
@@ -344,12 +344,12 @@
               },
             },
             {
-              alert: 'OctaviaAmphoraNotReady',
+              alert: 'OctaviaAmphoraNotOperational',
               annotations: {
-                summary: 'Octavia Amphora not ready',
-                description: 'Amphora with ID {{ $labels.id }} stuck in non-ready state for more then 1 hour.',
+                summary: 'Octavia Amphora not operational',
+                description: 'Amphora with ID {{ $labels.id }} stuck in non-operational state for more then 1 hour.',
               },
-              expr: 'count by (id,name) (openstack_loadbalancer_amphora_status{status!="READY"}) > 0',
+              expr: 'count by (id,name) (openstack_loadbalancer_amphora_status{status!~"READY|ALLOCATED"}) > 0',
               'for': '1h',
               labels: {
                 severity: 'P3',

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -232,11 +232,22 @@ tests:
         values: '3x60'
     alert_rule_test:
       - eval_time: 1h
-        alertname: OctaviaAmphoraNotReady
+        alertname: OctaviaAmphoraNotOperational
         exp_alerts:
           - exp_labels:
               severity: P3
               id: 7f890893-ced0-46ed-8697-33415d070e5a
             exp_annotations:
-              summary: Octavia Amphora not ready
-              description: Amphora with ID 7f890893-ced0-46ed-8697-33415d070e5a stuck in non-ready state for more then 1 hour.
+              summary: Octavia Amphora not operational
+              description: Amphora with ID 7f890893-ced0-46ed-8697-33415d070e5a stuck in non-operational state for more then 1 hour.
+
+  - interval: 1m
+    input_series:
+      - series: 'openstack_loadbalancer_amphora_status{cert_expiration="2020-08-08T23:44:31Z",compute_id="667bb225-69aa-44b1-8908-694dc624c267",ha_ip="10.0.0.6",id="45f40289-0551-483a-b089-47214bc2a8a4",lb_network_ip="192.168.0.6",loadbalancer_id="882f2a9d-9d53-4bd0-b0e9-08e9d0de11f9",role="MASTER",status="READY"}'
+        values: '2x60'
+      - series: 'openstack_loadbalancer_amphora_status{cert_expiration="2020-08-08T23:44:30Z",compute_id="9cd0f9a2-fe12-42fc-a7e3-5b6fbbe20395",ha_ip="10.0.0.6",id="7f890893-ced0-46ed-8697-33415d070e5a",lb_network_ip="192.168.0.17",loadbalancer_id="882f2a9d-9d53-4bd0-b0e9-08e9d0de11f9",role="BACKUP",status="ALLOCATED"}'
+        values: '3x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: OctaviaAmphoraNotOperational
+        exp_alerts: []


### PR DESCRIPTION
## Summary
- Fixed OctaviaAmphoraNotReady alert to recognize both READY and ALLOCATED as valid Amphora statuses
- Renamed alert to OctaviaAmphoraNotOperational to better reflect its purpose
- Added test cases to verify ALLOCATED status doesn't trigger the alert

The alert was incorrectly firing for Amphoras in ALLOCATED status, which is a normal operational state in Octavia.

🤖 Generated with [Claude Code](https://claude.ai/code)