### PR TITLE
[Backport stable/2024.1.] fix: ca bundle path for EL family (#3051)

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -1,3 +1,5 @@
+(?i)pem
+(?i)tls
 ACL
 ACME
 ALLOCATED
@@ -25,7 +27,8 @@ QEMU
 READY
 SDK
 SST
-TLS
+Staffeln
+VLAN
 VNC
 Valkey
 [Bb]ackports

--- a/releasenotes/notes/fix-ca-bundle-path-d33352911b65e755.yaml
+++ b/releasenotes/notes/fix-ca-bundle-path-d33352911b65e755.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - Fixed containers failing to validate TLS certificates on
+    Red Hat-based systems. The issue occurred when mounting the OpenSSL
+    trusted certificate bundle (``/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt``)
+    which uses the "TRUSTED CERTIFICATE" format that's incompatible with
+    Go applications. The configuration now uses the standard PEM format
+    bundle (``/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem``) on
+    Red Hat systems, which resolves certificate validation errors.

--- a/roles/defaults/defaults/main.yml
+++ b/roles/defaults/defaults/main.yml
@@ -27,4 +27,4 @@ atmosphere_network_backend: openvswitch
 atmosphere_image_overrides: {}
 
 defaults_ca_certificates_path: >-
-  {{ '/etc/ssl/certs/ca-certificates.crt' if ansible_facts['os_family'] in ['Debian'] else '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt' }}
+  {{ '/etc/ssl/certs/ca-certificates.crt' if ansible_facts['os_family'] in ['Debian'] else '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem' }}

--- a/roles/openstack_cli/templates/atmosphere.sh.j2
+++ b/roles/openstack_cli/templates/atmosphere.sh.j2
@@ -6,7 +6,7 @@ alias osc='nerdctl run --rm --network host \
       in ['Debian'] else '/etc/pki/ca-trust/source/anchors/atmosphere.crt:/usr/local/share/ca-certificates/atmosphere.crt:ro' }} \
 {% elif cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
       --volume {{ '/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro' if ansible_facts['os_family']
-      in ['Debian'] else '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt:/etc/ssl/certs/ca-certificates.crt:ro' }} \
+      in ['Debian'] else '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/ssl/certs/ca-certificates.crt:ro' }} \
 {% endif %}
       --env-file <(env | grep OS_) \
       {{ atmosphere_images['openstack_cli'] }}'


### PR DESCRIPTION
(cherry picked from commit ac46d25f93e8d3dde029310672ee11bcb8065705)