### PR TITLE
[Backport stable/2023.2] Add openstack resource controller image and version

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -37,14 +37,17 @@ Valkey
 agent
 alert
 allowed-address-pair
+atmosphere_images
 backend
 backport
 boolean
 cgroup
 etcd
+image_manifest
 kek
 libvirt
 liveness
+openstack_resource_controller
 readiness
 subnet
 tracker.ceph.com

--- a/releasenotes/notes/fix-openstack_resource_controller-b9e234f40f6b5686.yaml
+++ b/releasenotes/notes/fix-openstack_resource_controller-b9e234f40f6b5686.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Add ``openstack_resource_controller`` in the ``atmosphere_images`` variable this
+    way the ``image_manifest`` also is able to pickup this image to mirror the
+    image to a local registry.

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -185,6 +185,7 @@ _atmosphere_images:
   octavia_housekeeping: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/octavia:{{ atmosphere_release }}"
   octavia_worker: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/octavia:{{ atmosphere_release }}"
   openstack_cli: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/python-openstackclient:{{ atmosphere_release }}"
+  openstack_resource_controller: "{{ atmosphere_image_prefix }}quay.io/orc/openstack-resource-controller:v2.2.0"
   openvswitch_db_server: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/openvswitch:v3.3.6-6"
   openvswitch_vswitchd: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/openvswitch:v3.3.6-6"
   ovn_controller: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/ovn-host:{{ atmosphere_release }}"

--- a/roles/magnum/meta/main.yml
+++ b/roles/magnum/meta/main.yml
@@ -45,3 +45,5 @@ dependencies:
       cluster_api_infrastructure_version: 0.12.4
       cluster_api_node_selector:
         openstack-control-plane: enabled
+      openstack_resource_controller_image: "{{ atmosphere_images['openstack_resource_controller'] | vexxhost.kubernetes.docker_image('name') }}"
+      openstack_resource_controller_image_tag: "{{ atmosphere_images['openstack_resource_controller'] | vexxhost.kubernetes.docker_image('tag') }}"


### PR DESCRIPTION
## Summary
Backport of #3174 to stable/2023.2

This adds the openstack_resource_controller image and version to the atmosphere_images variable so that the image_manifest can also pick up this image to mirror it to a local registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)