### PR TITLE
[Backport stable/2023.2] fix: remove hardcoded backup image from database documentation

### DIFF
--- a/doc/source/admin/database-backups.rst
+++ b/doc/source/admin/database-backups.rst
@@ -36,7 +36,6 @@ example below:
 
   percona_xtradb_cluster_spec:
     backup:
-      image: percona/percona-xtradb-cluster-operator:1.14.0-pxc8.0-backup-pxb8.0.35
       storages:
         fs-pvc:
           type: filesystem
@@ -80,7 +79,6 @@ S3-compatible storage with 3 backups kept.
 
   percona_xtradb_cluster_spec:
     backup:
-      image: percona/percona-xtradb-cluster-operator:1.14.0-pxc8.0-backup-pxb8.0.35
       storages:
         s3-bck:
           type: s3

--- a/releasenotes/notes/fix-percona-xtrabackup-docs-8f70a2862efba2fd.yaml
+++ b/releasenotes/notes/fix-percona-xtrabackup-docs-8f70a2862efba2fd.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Percona backup operations now use a default backup image, eliminating
+    the need to specify an image for each individual backup job. This
+    streamlines the backup configuration process and reduces configuration
+    overhead for operators managing database backups.
+    The default image is automatically applied to all backup jobs unless
+    explicitly overridden, ensuring consistent backup tooling across the
+    cluster while maintaining flexibility for advanced use cases.

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -198,6 +198,7 @@ _atmosphere_images:
   percona_xtradb_cluster_haproxy: "{{ atmosphere_image_prefix }}docker.io/percona/haproxy:2.8.14"
   percona_xtradb_cluster_operator: "{{ atmosphere_image_prefix }}docker.io/percona/percona-xtradb-cluster-operator:1.17.0"
   percona_xtradb_cluster: "{{ atmosphere_image_prefix }}docker.io/percona/percona-xtradb-cluster:8.0.41-32.1"
+  percona_xtradb_cluster_backup: "{{ atmosphere_image_prefix }}docker.io/percona/percona-xtradb-cluster-operator:1.17.0-pxc8.0-backup-pxb8.0.35"
   placement_db_sync: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/placement:{{ atmosphere_release }}"
   placement: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/placement:{{ atmosphere_release }}"
   pod_tls_sidecar: "{{ atmosphere_image_prefix }}registry.atmosphere.dev/library/pod-tls-sidecar:latest"

--- a/roles/percona_xtradb_cluster/vars/main.yml
+++ b/roles/percona_xtradb_cluster/vars/main.yml
@@ -5,6 +5,8 @@ _percona_xtradb_cluster_spec:
   crVersion: "1.17.0"
   secretsName: percona-xtradb
   enableVolumeExpansion: true
+  backup:
+    image: "{{ atmosphere_images['percona_xtradb_cluster_backup'] | vexxhost.kubernetes.docker_image('ref') }}"
   pxc:
     size: 3
     image: "{{ atmosphere_images['percona_xtradb_cluster'] | vexxhost.kubernetes.docker_image('ref') }}"


### PR DESCRIPTION
(cherry picked from commit bdd5f6fb0e949ca7f318072d3cc1e688dbca8087)