### PR TITLE
Bump ubuntu cloud archive to flamingo

### DIFF
--- a/images/ubuntu-cloud-archive/Dockerfile
+++ b/images/ubuntu-cloud-archive/Dockerfile
@@ -5,5 +5,5 @@
 FROM ubuntu
 COPY trusted.gpg.d/ubuntu-cloud-keyring.gpg /etc/apt/trusted.gpg.d/ubuntu-cloud-keyring.gpg
 COPY <<EOF /etc/apt/sources.list.d/cloudarchive.list
-deb http://ubuntu-cloud.archive.canonical.com/ubuntu noble-updates/epoxy main
+deb http://ubuntu-cloud.archive.canonical.com/ubuntu noble-updates/flamingo main
 EOF

--- a/releasenotes/notes/update-cloud-archive-f01428ad4dea14db.yaml
+++ b/releasenotes/notes/update-cloud-archive-f01428ad4dea14db.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    Update the container image base package archive to ``flamingo``.
+    This update aligns general packages in container builds with the
+    OpenStack ``Flamingo`` release, ensuring the latest dependencies,
+    security updates, and feature compatibility.


### PR DESCRIPTION
Change-Id: I4ad46e4450fef14255671b9a4f5fe449031bfeec

upgrade:
  - |
    Update the container image base package archive to ``flamingo``.  
    This update aligns general packages in container builds with the OpenStack ``Flamingo`` release, ensuring the latest dependencies, security updates, and feature compatibility.