### PR TITLE
fix: Add branch-specific uv cache to prevent build conflicts

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,6 +6,10 @@ variable "TAG" {
     default = "main"
 }
 
+variable "UV_CACHE_ID" {
+    default = "uv-${TAG}"
+}
+
 target "ubuntu" {
     context = "images/ubuntu"
     platforms = ["linux/amd64", "linux/arm64"]
@@ -47,6 +51,10 @@ target "python-base" {
 target "openstack-venv-builder" {
     context = "images/openstack-venv-builder"
     platforms = ["linux/amd64", "linux/arm64"]
+
+    args = {
+        UV_CACHE_ID = "${UV_CACHE_ID}"
+    }
 
     contexts = {
         "ubuntu-cloud-archive" = "target:ubuntu-cloud-archive"
@@ -171,6 +179,10 @@ target "python-openstackclient" {
     context = "images/python-openstackclient"
     platforms = ["linux/amd64", "linux/arm64"]
 
+    args = {
+        UV_CACHE_ID = "${UV_CACHE_ID}"
+    }
+
     contexts = {
         "openstack-venv-builder" = "target:openstack-venv-builder"
         "python-base" = "target:python-base"
@@ -198,6 +210,7 @@ target "neutron" {
 
     args = {
         PROJECT = "neutron"
+        UV_CACHE_ID = "${UV_CACHE_ID}"
     }
 
     contexts = {
@@ -240,6 +253,7 @@ target "openstack" {
 
     args = {
         PROJECT = "${service}"
+        UV_CACHE_ID = "${UV_CACHE_ID}"
     }
 
     contexts = {

--- a/images/barbican/Dockerfile
+++ b/images/barbican/Dockerfile
@@ -7,7 +7,8 @@ FROM openstack-venv-builder AS build
 ARG BARBICAN_GIT_REF=3416cdce80f63f3e499c226531e1184bc8a621f2
 ADD --keep-git-dir=true https://github.com/openstack/barbican.git#${BARBICAN_GIT_REF} /src/barbican
 RUN git -C /src/barbican fetch --unshallow
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/barbican \

--- a/images/cinder/Dockerfile
+++ b/images/cinder/Dockerfile
@@ -9,7 +9,8 @@ ADD --keep-git-dir=true https://github.com/openstack/cinder.git#${CINDER_GIT_REF
 RUN git -C /src/cinder fetch --unshallow
 COPY patches/cinder /patches/cinder
 RUN git -C /src/cinder apply --verbose /patches/cinder/*
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/cinder \

--- a/images/designate/Dockerfile
+++ b/images/designate/Dockerfile
@@ -9,7 +9,8 @@ ADD --keep-git-dir=true https://github.com/openstack/designate.git#${DESIGNATE_G
 RUN git -C /src/designate fetch --unshallow
 COPY patches/designate /patches/designate
 RUN git -C /src/designate apply --verbose /patches/designate/*
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/designate

--- a/images/glance/Dockerfile
+++ b/images/glance/Dockerfile
@@ -11,7 +11,8 @@ RUN git -C /src/glance fetch --unshallow
 ARG GLANCE_STORE_GIT_REF=e7b3523e469921382fb4d8236dfedd80f3f7a68c
 ADD --keep-git-dir=true https://github.com/openstack/glance_store.git#${GLANCE_STORE_GIT_REF} /src/glance_store
 RUN git -C /src/glance_store fetch --unshallow
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/glance \

--- a/images/heat/Dockerfile
+++ b/images/heat/Dockerfile
@@ -7,7 +7,8 @@ FROM openstack-venv-builder AS build
 ARG HEAT_GIT_REF=46cbda240558f5b8a6e27ef6111b7b26e4b65ff1
 ADD --keep-git-dir=true https://github.com/openstack/heat.git#${HEAT_GIT_REF} /src/heat
 RUN git -C /src/heat fetch --unshallow
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/heat

--- a/images/horizon/Dockerfile
+++ b/images/horizon/Dockerfile
@@ -37,7 +37,8 @@ ADD --keep-git-dir=true https://github.com/openstack/octavia-dashboard.git#${OCT
 RUN git -C /src/octavia-dashboard fetch --unshallow
 COPY patches/magnum-ui /patches/magnum-ui
 RUN git -C /src/magnum-ui apply --verbose /patches/magnum-ui/*
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/designate-dashboard \

--- a/images/ironic/Dockerfile
+++ b/images/ironic/Dockerfile
@@ -7,7 +7,8 @@ FROM openstack-venv-builder AS build
 ARG IRONIC_GIT_REF=88245b5ec392c9acee3ef1c3b9772153aae6a81e
 ADD --keep-git-dir=true https://github.com/openstack/ironic.git#${IRONIC_GIT_REF} /src/ironic
 RUN git -C /src/ironic fetch --unshallow
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/ironic \

--- a/images/keystone/Dockerfile
+++ b/images/keystone/Dockerfile
@@ -7,7 +7,8 @@ FROM openstack-venv-builder AS build
 ARG KEYSTONE_GIT_REF=5a60aad8ab1790851057312400a0ce61f35c33a1
 ADD --keep-git-dir=true https://github.com/openstack/keystone.git#${KEYSTONE_GIT_REF} /src/keystone
 RUN git -C /src/keystone fetch --unshallow
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/keystone[ldap] \

--- a/images/magnum/Dockerfile
+++ b/images/magnum/Dockerfile
@@ -15,7 +15,8 @@ FROM openstack-venv-builder AS build
 ARG MAGNUM_GIT_REF=aa954f9adbca132c5229e73ee8dda4b118268269
 ADD --keep-git-dir=true https://github.com/openstack/magnum.git#${MAGNUM_GIT_REF} /src/magnum
 RUN git -C /src/magnum fetch --unshallow
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/magnum \

--- a/images/manila/Dockerfile
+++ b/images/manila/Dockerfile
@@ -7,7 +7,8 @@ FROM openstack-venv-builder AS build
 ARG MANILA_GIT_REF=c7921409a299a7412b88e025fec126c5ed5bb6d2
 ADD --keep-git-dir=true https://github.com/openstack/manila.git#${MANILA_GIT_REF} /src/manila
 RUN git -C /src/manila fetch --unshallow
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/manila

--- a/images/neutron/Dockerfile
+++ b/images/neutron/Dockerfile
@@ -31,9 +31,10 @@ RUN git -C /src/neutron-ovn-network-logging-parser fetch --unshallow
 ARG TAP_AS_A_SERVICE_GIT_REF=22dbac79c303b45332c061e2325a8ccffe404ca5
 ADD --keep-git-dir=true https://opendev.org/openstack/tap-as-a-service.git#${TAP_AS_A_SERVICE_GIT_REF} /src/tap-as-a-service
 RUN git -C /src/tap-as-a-service fetch --unshallow
+ARG UV_CACHE_ID=uv-default
 RUN \
   --mount=type=bind,from=neutron-source,source=/,target=/src/neutron,readwrite \
-  --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+  --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/neutron \

--- a/images/nova/Dockerfile
+++ b/images/nova/Dockerfile
@@ -11,7 +11,8 @@ RUN git -C /src/nova fetch --unshallow
 ARG SCHEDULER_FILTERS_GIT_REF=77ed1c2ca70f4166a6d0995c7d3d90822f0ca6c0
 ADD --keep-git-dir=true https://github.com/vexxhost/nova-scheduler-filters.git#${SCHEDULER_FILTERS_GIT_REF} /src/nova-scheduler-filters
 RUN git -C /src/nova-scheduler-filters fetch --unshallow
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/nova \

--- a/images/octavia/Dockerfile
+++ b/images/octavia/Dockerfile
@@ -11,7 +11,8 @@ RUN git -C /src/octavia fetch --unshallow
 ARG OVN_OCTAVIA_PROVIDER_GIT_REF=92094c803598968559ea4351f112a3e960f038fa
 ADD --keep-git-dir=true https://github.com/openstack/ovn-octavia-provider.git#${OVN_OCTAVIA_PROVIDER_GIT_REF} /src/ovn-octavia-provider
 RUN git -C /src/ovn-octavia-provider fetch --unshallow
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/octavia[redis] \

--- a/images/openstack-venv-builder/Dockerfile
+++ b/images/openstack-venv-builder/Dockerfile
@@ -31,9 +31,10 @@ rm -rf /var/lib/apt/lists/*
 EOF
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 COPY --from=requirements --link /upper-constraints.txt /upper-constraints.txt
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv venv --system-site-packages /var/lib/openstack
-uv pip install --refresh \
+uv pip install \
     --constraint /upper-constraints.txt \
         confluent-kafka \
         cryptography \

--- a/images/ovn-bgp-agent/Dockerfile
+++ b/images/ovn-bgp-agent/Dockerfile
@@ -9,7 +9,8 @@ ADD --keep-git-dir=true https://github.com/openstack/ovn-bgp-agent.git#${OVN_BGP
 RUN git -C /src/ovn-bgp-agent fetch --unshallow
 COPY patches/ovn-bgp-agent /patches/ovn-bgp-agent
 RUN git -C /src/ovn-bgp-agent apply --verbose /patches/ovn-bgp-agent/*
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/ovn-bgp-agent[frr_k8s]

--- a/images/placement/Dockerfile
+++ b/images/placement/Dockerfile
@@ -7,7 +7,8 @@ FROM openstack-venv-builder AS build
 ARG PLACEMENT_GIT_REF=7ebf35f049a3ab5bd7be5a2e4ffbd0d82ed4f00f
 ADD --keep-git-dir=true https://github.com/openstack/placement.git#${PLACEMENT_GIT_REF} /src/placement
 RUN git -C /src/placement fetch --unshallow
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/placement

--- a/images/python-openstackclient/Dockerfile
+++ b/images/python-openstackclient/Dockerfile
@@ -3,7 +3,8 @@
 # Atmosphere-Rebuild-Time: 2024-06-25T22:49:25Z
 
 FROM openstack-venv-builder AS build
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         osc-placement \

--- a/images/staffeln/Dockerfile
+++ b/images/staffeln/Dockerfile
@@ -6,7 +6,8 @@ FROM openstack-venv-builder AS build
 ARG STAFFELN_GIT_REF=v2.2.3
 ADD --keep-git-dir=true https://github.com/vexxhost/staffeln.git#${STAFFELN_GIT_REF} /src/staffeln
 RUN git -C /src/staffeln fetch --unshallow
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/staffeln

--- a/images/tempest/Dockerfile
+++ b/images/tempest/Dockerfile
@@ -44,7 +44,8 @@ RUN git -C /src/neutron-tempest-plugin fetch --unshallow
 ARG OCTAVIA_TEMPEST_PLUGIN_GIT_REF=fd803099c2c602fc5e8df1d4bcf25b1e585e4b51
 ADD --keep-git-dir=true https://github.com/openstack/octavia-tempest-plugin.git#${OCTAVIA_TEMPEST_PLUGIN_GIT_REF} /src/octavia-tempest-plugin
 RUN git -C /src/octavia-tempest-plugin fetch --unshallow
-RUN --mount=type=cache,target=/root/.cache/uv <<EOF bash -xe
+ARG UV_CACHE_ID=uv-default
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv <<EOF bash -xe
 uv pip install \
     --constraint /src/requirements/upper-constraints.txt \
         /src/tempest \


### PR DESCRIPTION
Backport of #3229 to stable/2025.1

This PR implements branch-specific cache IDs for uv to prevent cache conflicts when building images from different branches with different Python versions in parallel.