### PR TITLE
[Backport stable/2023.1] fix: Deploy ORC components in control-plane 

### DIFF
--- a/releasenotes/notes/deploy-orc-components-in-control-plane-7f6e32c0b8c14c67.yaml
+++ b/releasenotes/notes/deploy-orc-components-in-control-plane-7f6e32c0b8c14c67.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Ensures the OpenStack Resource Controller runs only on control-plane nodes.

--- a/roles/magnum/meta/main.yml
+++ b/roles/magnum/meta/main.yml
@@ -45,3 +45,5 @@ dependencies:
       cluster_api_infrastructure_version: 0.12.4
       cluster_api_node_selector:
         openstack-control-plane: enabled
+      openstack_resource_controller_node_selector:
+        openstack-control-plane: enabled


### PR DESCRIPTION
(cherry picked from commit ed718b285552352f044ca47313b84ef91e78189b)