### PR TITLE
[Backport stable/2024.2] [A8E-65] Update manila image to support CephFS (#3298)

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -10,7 +10,7 @@ CAPI
 CAPO
 CRD
 CSI
-Ceph
+Cinder
 DNS
 Glance
 HBA
@@ -42,6 +42,7 @@ VPN
 Valkey
 [Bb]ackports
 [Bb]aremetal
+[Cc]eph
 [Pp]ortworx
 agent
 alert

--- a/images/manila/Dockerfile
+++ b/images/manila/Dockerfile
@@ -18,7 +18,7 @@ FROM openstack-python-runtime
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \
-    iproute2 openvswitch-switch
+    iproute2 openvswitch-switch python3-ceph-argparse python3-rados
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF

--- a/releasenotes/notes/update-manila-image-to-support-cephfs-backend-cf8ce63f750ae279.yaml
+++ b/releasenotes/notes/update-manila-image-to-support-cephfs-backend-cf8ce63f750ae279.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add ``python3-rados`` and ``python3-ceph-argparse`` packages to enable
+    Manila to export shared filesystems backed by Ceph’s File System (CephFS).


### PR DESCRIPTION
(cherry picked from commit 4cfac2c0bceb918f1659f441e33707624f8594ec)