### PR TITLE
fix(ceph_csi_rbd): fix external Ceph keyring variable evaluation

### DIFF
--- a/roles/ceph_csi_rbd/tasks/main.yml
+++ b/roles/ceph_csi_rbd/tasks/main.yml
@@ -69,8 +69,8 @@
 - name: Store keyring inside fact
   run_once: true
   ansible.builtin.set_fact:
-    _ceph_rbd_csi_ceph_keyring:
-      key: "{{ ceph_csi_rbd_keyring | default((_ceph_key.stdout | from_json | first).key) }}"
+    ceph_csi_rbd_keyring: "{{ (_ceph_key.stdout | from_json | first).key }}"
+  when: ceph_csi_rbd_keyring is not defined
 
 - name: Deploy Helm chart
   run_once: true

--- a/roles/ceph_csi_rbd/vars/main.yml
+++ b/roles/ceph_csi_rbd/vars/main.yml
@@ -52,4 +52,4 @@ _ceph_csi_rbd_helm_values:
   secret:
     create: true
     userID: "{{ ceph_csi_rbd_id }}"
-    userKey: "{{ _ceph_rbd_csi_ceph_keyring.key }}"
+    userKey: "{{ ceph_csi_rbd_keyring }}"


### PR DESCRIPTION
## Summary
- Fix undefined variable error when using external Ceph clusters with `ceph_csi_rbd_keyring`
- Simplify keyring handling by removing intermediate variable

## Problem
When using an external Ceph cluster with `ceph_csi_rbd_keyring` defined, the playbook failed with:
```
Unable to look up a name or access an attribute in template string 
({{ ceph_csi_rbd_keyring | default((_ceph_key.stdout | from_json | first).key) }}).
the JSON object must be str, bytes or bytearray, not AnsibleUndefined
```

This happened because Jinja2's `default()` filter evaluates both sides of the expression before choosing which to use, causing `_ceph_key.stdout` to be evaluated even when `ceph_csi_rbd_keyring` was defined.

## Solution
1. Set `ceph_csi_rbd_keyring` directly from the Ceph query result only when it's not already defined
2. Remove the intermediate `_ceph_rbd_csi_ceph_keyring` variable
3. Use `ceph_csi_rbd_keyring` directly in the Helm values

## Test plan
- [ ] Deploy with internal Ceph (existing behavior unchanged)
- [ ] Deploy with external Ceph cluster using `ceph_csi_rbd_keyring`

🤖 Generated with [Claude Code](https://claude.com/claude-code)