### PR TITLE
fix(placement): increase default uwsgi processes from 1 to 4

### DIFF
--- a/releasenotes/notes/placement-uwsgi-processes-cf26dad88a45a152.yaml
+++ b/releasenotes/notes/placement-uwsgi-processes-cf26dad88a45a152.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The Placement API now uses 4 uWSGI processes by default instead of 1,
+    improving request handling capacity and aligning with other OpenStack
+    services like Octavia.

--- a/roles/placement/vars/main.yml
+++ b/roles/placement/vars/main.yml
@@ -42,6 +42,9 @@ _placement_helm_values:
           priority: 0
           apply-to: all
           pattern: '^(?!(amq\.|reply_)).*'
+    placement_api_uwsgi:
+      uwsgi:
+        processes: 4
   manifests:
     ingress: false
     service_ingress: false


### PR DESCRIPTION
## Summary
- Increase Placement API default uWSGI process count from 1 to 4
- Aligns with other OpenStack services like Octavia for better request handling

## Test plan
- [ ] Deploy placement and verify uWSGI runs with 4 processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)