### PR TITLE
[stable/2023.2] fix(placement): increase default uwsgi processes from 1 to 4

### DIFF
--- a/releasenotes/notes/placement-uwsgi-processes-cf26dad88a45a152.yaml
+++ b/releasenotes/notes/placement-uwsgi-processes-cf26dad88a45a152.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The Placement API now uses 4 uWSGI processes by default instead of 1,
+    improving request handling capacity and aligning with other OpenStack
+    services like Octavia.

--- a/roles/placement/vars/main.yml
+++ b/roles/placement/vars/main.yml
@@ -33,6 +33,9 @@ _placement_helm_values:
         pool_timeout: 30
       oslo_messaging_notifications:
         driver: noop
+    placement_api_uwsgi:
+      uwsgi:
+        processes: 4
   manifests:
     ingress: false
     service_ingress: false


### PR DESCRIPTION
## Summary
Backport of #3356 to stable/2023.2

- Increase Placement API default uWSGI process count from 1 to 4
- Aligns with other OpenStack services like Octavia for better request handling

Closes #3361

🤖 Generated with [Claude Code](https://claude.com/claude-code)