### PR TITLE
fix: improve ironic and fix flat network

### DIFF
--- a/releasenotes/notes/ironic-defaults-and-kernel-params-f8a49b20d482d571.yaml
+++ b/releasenotes/notes/ironic-defaults-and-kernel-params-f8a49b20d482d571.yaml
@@ -1,28 +1,29 @@
 ---
 upgrade:
   - |
-    The default Ironic ``default_network_interface`` is now ``neutron`` instead
-    of ``flat``. The ``flat`` interface remains enabled via
+    The default Ironic ``default_network_interface`` is now ``neutron``
+    instead of ``flat``. The ``flat`` interface remains enabled via
     ``enabled_network_interfaces``, so existing nodes that explicitly use
-    ``--network-interface flat`` continue to work. Operators who relied on the
-    implicit ``flat`` default for newly enrolled bare metal nodes should set
-    ``--network-interface flat`` on enrollment, or override
-    ``ironic_helm_values.conf.ironic.DEFAULT.default_network_interface`` back
-    to ``flat`` in their inventory.
+    ``--network-interface flat`` continue to work. Operators who relied on
+    the implicit ``flat`` default for newly enrolled bare metal nodes
+    should set ``--network-interface flat`` on enrollment, or override the
+    ``default_network_interface`` option under
+    ``ironic_helm_values.conf.ironic`` back to ``flat`` in their inventory.
   - |
-    The default ``kernel_append_params`` for the Ironic Python Agent (IPA)
-    ramdisk is now set explicitly for both the PXE and Redfish boot drivers
-    to ``nofb vga=normal ipa-insecure=true console=ttyS0,115200
-    systemd.journald.forward_to_console=yes``. Previously only the
-    ``[pxe]/kernel_append_params`` value was overridden by Atmosphere; the
-    Redfish virtual-media boot path fell through to the upstream Ironic
-    default (``nofb vga=normal``) because ``[redfish]/kernel_append_params``
-    is an independent option that does not inherit from ``[pxe]``. As a
-    result, IPA boot output for Redfish-driven deploys now lands on the
-    serial console, matching the PXE behaviour. Operators with custom
+    The default ``kernel_append_params`` for the Ironic Python agent
+    ramdisk is now set explicitly for both the ``pxe`` and ``redfish`` boot
+    drivers to ``nofb vga=normal ipa-insecure=true console=ttyS0,115200
+    systemd.journald.forward_to_console=yes``. Previously Atmosphere only
+    overrode the ``[pxe]/kernel_append_params`` value; the redfish
+    virtual-media boot path fell through to the upstream Ironic default
+    (``nofb vga=normal``) because ``[redfish]/kernel_append_params`` is an
+    independent option that doesn't inherit from ``[pxe]``. As a result,
+    agent boot output for redfish-driven deploys now lands on the serial
+    console, matching the ``pxe`` driver behaviour. Custom
     ``ironic_helm_values.conf.ironic.pxe.kernel_append_params`` overrides
-    are unaffected; operators relying on Atmosphere's previous defaults for
-    Redfish nodes will see different kernel cmdlines on the next deploy.
+    keep working unchanged; operators relying on Atmosphere's previous
+    defaults for redfish nodes will see different kernel cmdlines on the
+    next deploy.
 features:
   - |
     The ``neutron`` network interface is now the default for new Ironic
@@ -31,9 +32,10 @@ features:
     enrollment.
 fixes:
   - |
-    Ironic Python Agent boot output is now visible on the serial console
-    (``console=ttyS0,115200``) for both PXE-booted and Redfish-virtual-media
-    booted nodes, allowing operators to debug deploy failures over IPMI or
-    Redfish Serial-over-LAN. The ``nofb vga=normal`` parameters suppress
-    framebuffer console initialisation that can hang or scribble on serial
-    output on common BMC graphics controllers (Aspeed, Matrox).
+    Ironic Python agent boot output is now visible on the serial console
+    (``console=ttyS0,115200``) for both ``pxe``-booted and
+    ``redfish``-virtual-media-booted nodes, letting operators debug deploy
+    failures over the management controller's serial console. The
+    ``nofb vga=normal`` parameters suppress framebuffer console
+    initialisation that can hang or scribble on serial output on common
+    server graphics controllers (Aspeed, Matrox).

--- a/releasenotes/notes/ironic-defaults-and-kernel-params-f8a49b20d482d571.yaml
+++ b/releasenotes/notes/ironic-defaults-and-kernel-params-f8a49b20d482d571.yaml
@@ -1,0 +1,39 @@
+---
+upgrade:
+  - |
+    The default Ironic ``default_network_interface`` is now ``neutron`` instead
+    of ``flat``. The ``flat`` interface remains enabled via
+    ``enabled_network_interfaces``, so existing nodes that explicitly use
+    ``--network-interface flat`` continue to work. Operators who relied on the
+    implicit ``flat`` default for newly enrolled bare metal nodes should set
+    ``--network-interface flat`` on enrollment, or override
+    ``ironic_helm_values.conf.ironic.DEFAULT.default_network_interface`` back
+    to ``flat`` in their inventory.
+  - |
+    The default ``kernel_append_params`` for the Ironic Python Agent (IPA)
+    ramdisk is now set explicitly for both the PXE and Redfish boot drivers
+    to ``nofb vga=normal ipa-insecure=true console=ttyS0,115200
+    systemd.journald.forward_to_console=yes``. Previously only the
+    ``[pxe]/kernel_append_params`` value was overridden by Atmosphere; the
+    Redfish virtual-media boot path fell through to the upstream Ironic
+    default (``nofb vga=normal``) because ``[redfish]/kernel_append_params``
+    is an independent option that does not inherit from ``[pxe]``. As a
+    result, IPA boot output for Redfish-driven deploys now lands on the
+    serial console, matching the PXE behaviour. Operators with custom
+    ``ironic_helm_values.conf.ironic.pxe.kernel_append_params`` overrides
+    are unaffected; operators relying on Atmosphere's previous defaults for
+    Redfish nodes will see different kernel cmdlines on the next deploy.
+features:
+  - |
+    The ``neutron`` network interface is now the default for new Ironic
+    nodes, enabling tenant-network attachment and OVN integration without
+    requiring an explicit ``--network-interface neutron`` on every node
+    enrollment.
+fixes:
+  - |
+    Ironic Python Agent boot output is now visible on the serial console
+    (``console=ttyS0,115200``) for both PXE-booted and Redfish-virtual-media
+    booted nodes, allowing operators to debug deploy failures over IPMI or
+    Redfish Serial-over-LAN. The ``nofb vga=normal`` parameters suppress
+    framebuffer console initialisation that can hang or scribble on serial
+    output on common BMC graphics controllers (Aspeed, Matrox).

--- a/releasenotes/notes/ironic-improve-flat-396db22bb9ecca15.yaml
+++ b/releasenotes/notes/ironic-improve-flat-396db22bb9ecca15.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix the bare metal service when using flat networks by preventing requests for a segment ID on flat network types.
+other:
+  - |
+    Add support for system scope in the OpenStack command-line client and SDKs to improve the bare metal management experience.
+    Users can enable system scope authentication by setting ``OS_CLOUD=system``.

--- a/releasenotes/notes/ironic-ipa-image-public-option-3a8c28d54979f318.yaml
+++ b/releasenotes/notes/ironic-ipa-image-public-option-3a8c28d54979f318.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Added ``ironic_python_agent_image_is_public`` to control whether the
+    Ironic role creates the Ironic Python agent deploy kernel and
+    ramdisk as public Glance images. The default is ``false`` so deploy
+    images remain private to the configured owner project unless
+    operators explicitly opt in to public visibility.

--- a/releasenotes/notes/ironic-ipa-images-service-project-9f91d3e9a8720c41.yaml
+++ b/releasenotes/notes/ironic-ipa-images-service-project-9f91d3e9a8720c41.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    The Ironic role now creates the Ironic Python agent deploy kernel
+    and ramdisk with the Glance owner set to the ``service`` project by
+    default. This matches the project used by Ironic service credentials
+    when conductor fetches ``deploy_kernel`` and ``deploy_ramdisk`` for
+    deploy, cleaning, inspection, rescue, and clean-step reboot flows.

--- a/roles/ironic/defaults/main.yml
+++ b/roles/ironic/defaults/main.yml
@@ -36,6 +36,9 @@ ironic_bare_metal_subnet_name: baremetal
 ironic_bare_metal_subnet_cidr: 172.24.6.0/24
 
 # Ironic Python Agent images
+ironic_python_agent_image_cloud: atmosphere
+ironic_python_agent_image_owner: service
+ironic_python_agent_image_owner_domain: service
 ironic_python_agent_deploy_kernel_name: ipa-centos9-zed.kernel
 ironic_python_agent_deploy_kernel_url: https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-zed.kernel
 ironic_python_agent_deploy_ramdisk_name: ipa-centos9-zed.initramfs

--- a/roles/ironic/defaults/main.yml
+++ b/roles/ironic/defaults/main.yml
@@ -39,6 +39,7 @@ ironic_bare_metal_subnet_cidr: 172.24.6.0/24
 ironic_python_agent_image_cloud: atmosphere
 ironic_python_agent_image_owner: service
 ironic_python_agent_image_owner_domain: service
+ironic_python_agent_image_is_public: false
 ironic_python_agent_deploy_kernel_name: ipa-centos9-zed.kernel
 ironic_python_agent_deploy_kernel_url: https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-zed.kernel
 ironic_python_agent_deploy_ramdisk_name: ipa-centos9-zed.initramfs

--- a/roles/ironic/tasks/main.yml
+++ b/roles/ironic/tasks/main.yml
@@ -64,6 +64,7 @@
     glance_image_disk_format: "{{ item.format }}"
     glance_image_owner: "{{ ironic_python_agent_image_owner }}"
     glance_image_owner_domain: "{{ ironic_python_agent_image_owner_domain }}"
+    glance_image_is_public: "{{ ironic_python_agent_image_is_public }}"
 
 - name: Get details on the kernel image
   run_once: true

--- a/roles/ironic/tasks/main.yml
+++ b/roles/ironic/tasks/main.yml
@@ -57,22 +57,25 @@
       url: "{{ ironic_python_agent_deploy_ramdisk_url }}"
       format: ari
   vars:
+    glance_image_cloud: "{{ ironic_python_agent_image_cloud }}"
     glance_image_name: "{{ item.name }}"
     glance_image_url: "{{ item.url }}"
     glance_image_container_format: "{{ item.format }}"
     glance_image_disk_format: "{{ item.format }}"
+    glance_image_owner: "{{ ironic_python_agent_image_owner }}"
+    glance_image_owner_domain: "{{ ironic_python_agent_image_owner_domain }}"
 
 - name: Get details on the kernel image
   run_once: true
   openstack.cloud.image_info:
-    cloud: atmosphere
+    cloud: "{{ ironic_python_agent_image_cloud }}"
     image: "{{ ironic_python_agent_deploy_kernel_name }}"
   register: ironic_python_agent_deploy_kernel
 
 - name: Get details on the ramdisk image
   run_once: true
   openstack.cloud.image_info:
-    cloud: atmosphere
+    cloud: "{{ ironic_python_agent_image_cloud }}"
     image: "{{ ironic_python_agent_deploy_ramdisk_name }}"
   register: ironic_python_agent_deploy_ramdisk
 

--- a/roles/ironic/tasks/network/create.yml
+++ b/roles/ironic/tasks/network/create.yml
@@ -20,7 +20,9 @@
     name: "{{ ironic_bare_metal_network_name }}"
     provider_physical_network: "{{ ironic_bare_metal_network_provider_physical_network }}"
     provider_network_type: "{{ ironic_bare_metal_network_provider_network_type }}"
-    provider_segmentation_id: "{{ ironic_bare_metal_network_provider_segmentation_id }}"
+    provider_segmentation_id: >-
+      {{ (ironic_bare_metal_network_provider_network_type == 'flat')
+         | ternary(omit, ironic_bare_metal_network_provider_segmentation_id) }}
   register: ironic_bare_metal_network
 
 - name: Create bare metal network subnet

--- a/roles/ironic/tasks/network/create.yml
+++ b/roles/ironic/tasks/network/create.yml
@@ -21,8 +21,9 @@
     provider_physical_network: "{{ ironic_bare_metal_network_provider_physical_network }}"
     provider_network_type: "{{ ironic_bare_metal_network_provider_network_type }}"
     provider_segmentation_id: >-
-      {{ (ironic_bare_metal_network_provider_network_type == 'flat')
-         | ternary(omit, ironic_bare_metal_network_provider_segmentation_id) }}
+      {{ omit
+         if ironic_bare_metal_network_provider_network_type == 'flat'
+         else ironic_bare_metal_network_provider_segmentation_id }}
   register: ironic_bare_metal_network
 
 - name: Create bare metal network subnet

--- a/roles/ironic/vars/main.yml
+++ b/roles/ironic/vars/main.yml
@@ -46,7 +46,7 @@ _ironic_helm_values:
       DEFAULT:
         log_config_append: null
         enabled_network_interfaces: flat,neutron
-        default_network_interface: flat
+        default_network_interface: neutron
         rbac_service_role_elevated_access: true
       conductor:
         clean_step_priority_override: deploy.erase_devices_express:5

--- a/roles/ironic/vars/main.yml
+++ b/roles/ironic/vars/main.yml
@@ -66,7 +66,9 @@ _ironic_helm_values:
         provisioning_network: "{{ ironic_bare_metal_network_name }}"
         rescuing_network: "{{ ironic_bare_metal_network_name }}"
       pxe:
-        kernel_append_params: "ipa-insecure=true systemd.journald.forward_to_console=yes"
+        kernel_append_params: "nofb ipa-insecure=true console=ttyS0,115200 systemd.journald.forward_to_console=yes"
+      redfish:
+        kernel_append_params: "nofb ipa-insecure=true console=ttyS0,115200 systemd.journald.forward_to_console=yes"
       service_catalog:
         valid_interfaces: public
     rabbitmq:

--- a/roles/ironic/vars/main.yml
+++ b/roles/ironic/vars/main.yml
@@ -66,9 +66,9 @@ _ironic_helm_values:
         provisioning_network: "{{ ironic_bare_metal_network_name }}"
         rescuing_network: "{{ ironic_bare_metal_network_name }}"
       pxe:
-        kernel_append_params: "nofb ipa-insecure=true console=ttyS0,115200 systemd.journald.forward_to_console=yes"
+        kernel_append_params: "nofb vga=normal ipa-insecure=true console=ttyS0,115200 systemd.journald.forward_to_console=yes"
       redfish:
-        kernel_append_params: "nofb ipa-insecure=true console=ttyS0,115200 systemd.journald.forward_to_console=yes"
+        kernel_append_params: "nofb vga=normal ipa-insecure=true console=ttyS0,115200 systemd.journald.forward_to_console=yes"
       service_catalog:
         valid_interfaces: public
     rabbitmq:

--- a/roles/openstacksdk/templates/clouds.yaml.j2
+++ b/roles/openstacksdk/templates/clouds.yaml.j2
@@ -17,3 +17,20 @@ clouds:
 {% elif cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
     cacert: "/etc/ssl/certs/ca-certificates.crt"
 {% endif %}
+  system:
+    auth:
+      auth_url: "https://{{ openstack_helm_endpoints_keystone_api_host }}"
+      username: "admin-{{ openstack_helm_endpoints_region_name }}"
+      password: "{{ openstack_helm_endpoints_keystone_admin_password }}"
+      system_scope: all
+      user_domain_name: Default
+    region_name: "{{ openstack_helm_endpoints_keystone_region_name }}"
+{% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca', 'venafi') %}
+{% if ansible_os_family == 'Debian' %}
+    cacert: "/usr/local/share/ca-certificates/atmosphere.crt"
+{% elif ansible_os_family == 'RedHat' %}
+    cacert: "/etc/pki/ca-trust/source/anchors/atmosphere.crt"
+{% endif %}
+{% elif cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
+    cacert: "/etc/ssl/certs/ca-certificates.crt"
+{% endif %}


### PR DESCRIPTION
This PR introduce: 
- Add common kernal params: Add nofb, console=ttyS0,115200 to ironic kernel_append_params
- Fix flat ironic network config for multi-tenant network
- Allow using system scope authentication from OS-CLOUD