### PR TITLE
feat(barbican): add policy options for vTPM secret access

### DIFF
--- a/releasenotes/notes/vtpm-barbican-access-39f2ba5b63d54d90.yaml
+++ b/releasenotes/notes/vtpm-barbican-access-39f2ba5b63d54d90.yaml
@@ -1,0 +1,17 @@
+---
+features:
+  - |
+    Add options to configure Barbican policy for vTPM support. When a compute
+    node reboots, Nova needs to access Barbican secrets to start vTPM-enabled
+    virtual machines automatically. Two new variables control this behavior:
+    ``barbican_policy_nova_secret_access`` enables the Nova service account to
+    read secrets, and ``barbican_policy_admin_secret_access`` enables admin
+    users to access all secrets. Both default to false.
+security:
+  - |
+    When ``barbican_policy_nova_secret_access`` or
+    ``barbican_policy_admin_secret_access`` is set to true, secret isolation
+    between projects is reduced. The Nova service account or admin users
+    can access any secret in Barbican, not just vTPM-related secrets.
+    Enable these options only if you require automatic vTPM virtual machine
+    restart after compute node reboots.

--- a/roles/barbican/defaults/main.yml
+++ b/roles/barbican/defaults/main.yml
@@ -28,3 +28,28 @@ barbican_ingress_annotations: {}
 
 # Barbican key encryption key
 barbican_kek: "{{ undef(hint='You must specify a Barbican key encryption key') }}"
+
+# Allow admin role to access all Barbican secrets.
+#
+# Enabling this allows users with the admin role to access any secret in
+# Barbican, regardless of ownership. This is useful for administrative tasks
+# and troubleshooting but has security implications.
+#
+# WARNING: This setting reduces secret isolation between projects.
+#
+# barbican_policy_admin_secret_access: true
+barbican_policy_admin_secret_access: false
+
+# Allow Nova service user to access Barbican secrets for vTPM operations.
+#
+# When enabled, the Nova service account can retrieve Barbican secrets from
+# any project. This is required for Nova to automatically start vTPM-enabled
+# VMs after a physical server reboot, as Nova needs to decrypt the vTPM data
+# stored in Barbican.
+#
+# WARNING: This setting allows the Nova service account to read any secret
+# in Barbican. Only enable this if you use vTPM and require automatic VM
+# restart after compute node reboots.
+#
+# barbican_policy_nova_secret_access: true
+barbican_policy_nova_secret_access: false

--- a/roles/barbican/tasks/main.yml
+++ b/roles/barbican/tasks/main.yml
@@ -12,6 +12,31 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Generate Helm values
+  ansible.builtin.set_fact:
+    __barbican_helm_values: "{{ _barbican_helm_values }}"
+
+- name: Append Helm values (admin secret access)
+  when:
+    - barbican_policy_admin_secret_access | bool
+    - not (barbican_policy_nova_secret_access | bool)
+  ansible.builtin.set_fact:
+    __barbican_helm_values: "{{ __barbican_helm_values | combine(__barbican_admin_secret_access_helm_values, recursive=True) }}"
+
+- name: Append Helm values (Nova secret access)
+  when:
+    - barbican_policy_nova_secret_access | bool
+    - not (barbican_policy_admin_secret_access | bool)
+  ansible.builtin.set_fact:
+    __barbican_helm_values: "{{ __barbican_helm_values | combine(__barbican_nova_secret_access_helm_values, recursive=True) }}"
+
+- name: Append Helm values (admin and Nova secret access)
+  when:
+    - barbican_policy_admin_secret_access | bool
+    - barbican_policy_nova_secret_access | bool
+  ansible.builtin.set_fact:
+    __barbican_helm_values: "{{ __barbican_helm_values | combine(__barbican_admin_and_nova_secret_access_helm_values, recursive=True) }}"
+
 - name: Deploy Helm chart
   run_once: true
   kubernetes.core.helm:
@@ -20,7 +45,7 @@
     release_namespace: "{{ barbican_helm_release_namespace }}"
     create_namespace: true
     kubeconfig: "{{ barbican_helm_kubeconfig }}"
-    values: "{{ _barbican_helm_values | combine(barbican_helm_values, recursive=True) }}"
+    values: "{{ __barbican_helm_values | combine(barbican_helm_values, recursive=True) }}"
 
 - name: Create Ingress
   ansible.builtin.include_role:

--- a/roles/barbican/vars/main.yml
+++ b/roles/barbican/vars/main.yml
@@ -49,3 +49,26 @@ _barbican_helm_values:
   manifests:
     ingress_api: false
     service_ingress_api: false
+
+# Policy rules to allow admin role to access all secrets
+__barbican_admin_secret_access_helm_values:
+  conf:
+    policy:
+      secret:get: "rule:all_but_audit and (rule:secret_project_match or rule:secret_acl_read or rule:secret_project_admin)"
+      secret:decrypt: "rule:all_users and (rule:secret_project_match or rule:secret_acl_read or rule:secret_project_admin)"
+
+# Policy rules to allow Nova service user to access secrets for vTPM
+__barbican_nova_secret_access_helm_values:
+  conf:
+    policy:
+      secret_project_nova: "user_id:%(target.secret.creator_id)s or project_id:%(target.secret.project_id)s or role:service"
+      secret:get: "rule:all_but_audit and (rule:secret_project_match or rule:secret_acl_read or rule:secret_project_nova)"
+      secret:decrypt: "rule:all_users and (rule:secret_project_match or rule:secret_acl_read or rule:secret_project_nova)"
+
+# Combined policy rules when both admin and Nova access are enabled
+__barbican_admin_and_nova_secret_access_helm_values:
+  conf:
+    policy:
+      secret_project_nova: "user_id:%(target.secret.creator_id)s or project_id:%(target.secret.project_id)s or role:service"
+      secret:get: "rule:all_but_audit and (rule:secret_project_match or rule:secret_acl_read or rule:secret_project_admin or rule:secret_project_nova)"
+      secret:decrypt: "rule:all_users and (rule:secret_project_match or rule:secret_acl_read or rule:secret_project_admin or rule:secret_project_nova)"


### PR DESCRIPTION
## Summary

- Add `barbican_policy_nova_secret_access` option to allow Nova service account to access Barbican secrets for vTPM operations
- Add `barbican_policy_admin_secret_access` option to allow admin users to access all Barbican secrets
- Both options are disabled by default for security
- Add documentation with security warnings to the emulated-tpm admin guide
- Add release note documenting the feature and security implications

**Depends on:** #3438

Resolves: [A8E-82](https://vexxhost.atlassian.net/browse/A8E-82)

## Test plan

- [ ] Deploy Atmosphere with `barbican_policy_nova_secret_access: false` (default) and verify vTPM VMs cannot auto-restart after compute node reboot
- [ ] Deploy with `barbican_policy_nova_secret_access: true` and verify vTPM VMs auto-restart successfully after compute node reboot
- [ ] Verify documentation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[A8E-82]: https://vexxhost.atlassian.net/browse/A8E-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ