### PR TITLE
fix(ci): remove unused import in ovsinit

### DIFF
--- a/crates/ovsinit/src/config.rs
+++ b/crates/ovsinit/src/config.rs
@@ -1,4 +1,4 @@
-use log::{error, info};
+use log::info;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::{fs::File, path::PathBuf};

--- a/crates/ovsinit/src/routes.rs
+++ b/crates/ovsinit/src/routes.rs
@@ -1,5 +1,4 @@
 use ipnet::IpNet;
-use log::error;
 use netlink_packet_route::{
     AddressFamily,
     route::{RouteAddress, RouteAttribute, RouteMessage, RouteProtocol},


### PR DESCRIPTION
## Summary
- Remove unused `log::error` import in `crates/ovsinit/src/routes.rs`
- Fixes compilation warning with `-D warnings` flag

## Test plan
- [ ] CI passes with no unused import warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)