### PR TITLE
feat(magnum): add Cilium as allowed network driver

### DIFF
--- a/releasenotes/notes/magnum-cilium-network-driver-ef2b79135f772d67.yaml
+++ b/releasenotes/notes/magnum-cilium-network-driver-ef2b79135f772d67.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Cilium is now available as a network driver option for Magnum cluster
+    templates. Users can specify ``--network-driver cilium`` when creating
+    cluster templates.

--- a/roles/magnum/vars/main.yml
+++ b/roles/magnum/vars/main.yml
@@ -32,7 +32,7 @@ _magnum_helm_values:
         endpoint_type: internalURL
         region_name: "{{ openstack_helm_endpoints_cinder_region_name }}"
       cluster_template:
-        kubernetes_allowed_network_drivers: calico
+        kubernetes_allowed_network_drivers: calico, cilium
         kubernetes_default_network_driver: calico
       conductor:
         workers: 4


### PR DESCRIPTION
## Summary
- Add Cilium to the `kubernetes_allowed_network_drivers` configuration for Magnum
- Users can now create Magnum cluster templates with `--network-driver cilium`
- Default network driver remains Calico

## Test plan
- [ ] Verify Magnum accepts `cilium` as a valid network driver when creating cluster templates
- [ ] Confirm existing Calico-based templates continue to work

🤖 Generated with [Claude Code](https://claude.ai/code)