### PR TITLE
fix: Ironic image should be public

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -5,6 +5,7 @@ ACME
 ALLOCATED
 AMD
 AVX
+Agent
 Ansible
 BGP
 Bitnami

--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -5,7 +5,6 @@ ACME
 ALLOCATED
 AMD
 AVX
-Agent
 Ansible
 BGP
 Bitnami

--- a/releasenotes/notes/ironic-image-public-ed34dd3dd076df33.yaml
+++ b/releasenotes/notes/ironic-image-public-ed34dd3dd076df33.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The Ironic Python Agent deploy images are now set to public visibility,
+    allowing users to provision bare metal instances.

--- a/releasenotes/notes/ironic-image-public-ed34dd3dd076df33.yaml
+++ b/releasenotes/notes/ironic-image-public-ed34dd3dd076df33.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    The Ironic Python Agent deploy images are now set to public visibility,
+    The Ironic Python agent deploy images are now set to public visibility,
     allowing users to provision bare metal instances.

--- a/roles/ironic/tasks/main.yml
+++ b/roles/ironic/tasks/main.yml
@@ -57,6 +57,7 @@
       url: "{{ ironic_python_agent_deploy_ramdisk_url }}"
       format: ari
   vars:
+    glance_image_is_public: true
     glance_image_name: "{{ item.name }}"
     glance_image_url: "{{ item.url }}"
     glance_image_container_format: "{{ item.format }}"


### PR DESCRIPTION
This change sets public visibility only for the Ironic Python Agent deploy images uploaded by the `roles/ironic` role.

Affected deploy images from config:

- `ironic_python_agent_deploy_kernel_name`
- `ironic_python_agent_deploy_ramdisk_name`

This does not make tenant instance images public. It only makes the operator-owned IPA deploy kernel and ramdisk visible so Ironic can boot the agent during deploy, cleaning, inspection, rescue, and clean-step reboot flows.

Change-Id: I852d4a75fe289efdc3f7d6e4f1f237c8292ed3a2