### PR TITLE
feat(ipmi_exporter): add SEL events monitoring and alerts

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -18,6 +18,7 @@ FQDN
 FQDNs
 Glance
 HBA
+IPMI
 JWT
 Keycloak
 Kubernetes

--- a/releasenotes/notes/ipmi-sel-events-monitoring-1bba79a87918fe3d.yaml
+++ b/releasenotes/notes/ipmi-sel-events-monitoring-1bba79a87918fe3d.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    The IPMI exporter now collects System Event Log (SEL) events and exposes
+    them as Prometheus metrics. New Prometheus alerts notify operators of
+    critical hardware events such as memory errors, CPU failures, temperature
+    thresholds, power supply issues, and storage failures.

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -207,7 +207,7 @@ _atmosphere_images:
   placement: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/placement:main@sha256:ae9d401c35c837d9c7dc3b0dbbe1b183545949eefb9c3b594ba08084c2cf85ca"
   pod_tls_sidecar: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/pod-tls-sidecar:v1.0.0"
   prometheus_config_reloader: "{{ atmosphere_image_prefix }}quay.io/prometheus-operator/prometheus-config-reloader:v0.73.0"
-  prometheus_ipmi_exporter: "{{ atmosphere_image_prefix }}us-docker.pkg.dev/vexxhost-infra/openstack/ipmi-exporter:1.4.0"
+  prometheus_ipmi_exporter: "{{ atmosphere_image_prefix }}registry.hub.docker.com/prometheuscommunity/ipmi-exporter:v1.10.1"
   prometheus_memcached_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/memcached-exporter:v0.14.3"
   prometheus_mysqld_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/mysqld-exporter:v0.17.0"
   prometheus_node_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/node-exporter:v1.8.1"

--- a/roles/ipmi_exporter/defaults/main.yml
+++ b/roles/ipmi_exporter/defaults/main.yml
@@ -17,7 +17,7 @@
 ipmi_exporter_config:
   modules:
     default:
-      collectors: ["bmc", "ipmi", "chassis", "sel"]
+      collectors: ["bmc", "ipmi", "dcmi", "chassis", "sel", "sel-events"]
       exclude_sensor_ids:
         - 42
         - 45 # Entity Presence (Dell PowerEdge servers)
@@ -42,5 +42,75 @@ ipmi_exporter_config:
         - 180 # TPM Presence (Dell PowerEdge servers)
         - 182 # Entity Presence (Dell PowerEdge servers)
         - 185 # Entity Presence (Dell PowerEdge servers)
+      # SEL Events Configuration - regex patterns to match critical hardware events
+      sel_events:
+        # Memory errors
+        - name: memory_ecc_correctable
+          regex: "Memory.*Correctable"
+        - name: memory_ecc_uncorrectable
+          regex: "Memory.*Uncorrectable"
+        - name: memory_dimm_failure
+          regex: "Memory.*Failure|DIMM.*Fail"
+        - name: memory_configuration_error
+          regex: "Memory.*Configuration"
+        # CPU/Processor events
+        - name: processor_thermal_trip
+          regex: "Processor.*Thermal|CPU.*Thermal"
+        - name: processor_ierr
+          regex: "Processor.*IERR|CPU.*IERR"
+        - name: processor_failure
+          regex: "Processor.*Fail|CPU.*Fail"
+        - name: machine_check_exception
+          regex: "Machine Check|MCE"
+        # Temperature events
+        - name: temperature_critical
+          regex: "Temperature.*Critical|Upper Critical"
+        - name: temperature_warning
+          regex: "Temperature.*Warning|Upper Non-critical"
+        - name: temperature_non_recoverable
+          regex: "Temperature.*Non-recoverable"
+        # Fan/Cooling events
+        - name: fan_failure
+          regex: "Fan.*Fail|Fan.*Lower Critical"
+        - name: fan_warning
+          regex: "Fan.*Warning|Fan.*Lower Non-critical"
+        - name: fan_redundancy_lost
+          regex: "Fan.*Redundancy.*Lost"
+        # Power supply events
+        - name: psu_failure
+          regex: "Power Supply.*Fail|PSU.*Fail"
+        - name: psu_redundancy_lost
+          regex: "Power Supply.*Redundancy|PSU.*Redundancy.*Lost"
+        - name: psu_ac_lost
+          regex: "Power Supply.*AC Lost|AC.*Lost"
+        - name: power_unit_failure
+          regex: "Power Unit.*Fail"
+        # Disk/Storage events
+        - name: drive_failure
+          regex: "Drive.*Fail|Disk.*Fail|HDD.*Fail|SSD.*Fail"
+        - name: drive_predictive_failure
+          regex: "Drive.*Predictive|Predictive Failure"
+        - name: nvme_temperature_critical
+          regex: "NVMe.*Critical|NVMe.*Temperature"
+        # Voltage events
+        - name: voltage_critical
+          regex: "Voltage.*Critical"
+        - name: voltage_warning
+          regex: "Voltage.*Warning|Voltage.*Non-critical"
+        # Chassis/Physical security
+        - name: chassis_intrusion
+          regex: "Chassis Intrusion|Physical Security"
+        # System events
+        - name: system_boot_failure
+          regex: "Boot.*Fail|POST.*Error"
+        - name: watchdog_reset
+          regex: "Watchdog.*Reset|Watchdog.*Timer"
+        - name: os_critical_stop
+          regex: "OS Critical Stop|OS.*Fail"
+        - name: system_firmware_error
+          regex: "Firmware.*Error|BIOS.*Error"
+        # SEL management
+        - name: sel_full
+          regex: "SEL.*Full|Event Log.*Full"
 
                                                                    # ]]]

--- a/roles/ipmi_exporter/tasks/main.yml
+++ b/roles/ipmi_exporter/tasks/main.yml
@@ -53,6 +53,7 @@
                       containerPort: 9290
                   securityContext:
                     privileged: true
+                    runAsUser: 0
                   volumeMounts:
                     - name: dev-ipmi0
                       mountPath: /dev/ipmi0

--- a/roles/kube_prometheus_stack/files/jsonnet/legacy.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/legacy.libsonnet
@@ -109,6 +109,350 @@
             },
           ],
         },
+        {
+          name: 'sel-events-critical',
+          rules: [
+            // Memory errors - Critical
+            {
+              alert: 'IpmiSelMemoryUncorrectableError',
+              expr: 'increase(ipmi_sel_events_count{name="memory_ecc_uncorrectable"}[1h]) > 0',
+              labels: {
+                severity: 'critical',
+              },
+              annotations: {
+                summary: 'Uncorrectable memory error detected on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged uncorrectable memory errors which may indicate imminent memory failure.',
+              },
+            },
+            {
+              alert: 'IpmiSelMemoryFailure',
+              expr: 'increase(ipmi_sel_events_count{name="memory_dimm_failure"}[1h]) > 0',
+              labels: {
+                severity: 'critical',
+              },
+              annotations: {
+                summary: 'Memory DIMM failure detected on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a memory DIMM failure event.',
+              },
+            },
+            // CPU/Processor events - Critical
+            {
+              alert: 'IpmiSelProcessorThermalTrip',
+              expr: 'increase(ipmi_sel_events_count{name="processor_thermal_trip"}[1h]) > 0',
+              labels: {
+                severity: 'critical',
+              },
+              annotations: {
+                summary: 'Processor thermal trip detected on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a processor thermal trip event indicating CPU overheating.',
+              },
+            },
+            {
+              alert: 'IpmiSelProcessorIerr',
+              expr: 'increase(ipmi_sel_events_count{name="processor_ierr"}[1h]) > 0',
+              labels: {
+                severity: 'critical',
+              },
+              annotations: {
+                summary: 'Processor IERR detected on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a processor internal error (IERR).',
+              },
+            },
+            {
+              alert: 'IpmiSelProcessorFailure',
+              expr: 'increase(ipmi_sel_events_count{name="processor_failure"}[1h]) > 0',
+              labels: {
+                severity: 'critical',
+              },
+              annotations: {
+                summary: 'Processor failure detected on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a processor failure event.',
+              },
+            },
+            {
+              alert: 'IpmiSelMachineCheckException',
+              expr: 'increase(ipmi_sel_events_count{name="machine_check_exception"}[1h]) > 0',
+              labels: {
+                severity: 'critical',
+              },
+              annotations: {
+                summary: 'Machine check exception detected on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a machine check exception (MCE) indicating a hardware error.',
+              },
+            },
+            // Temperature events - Critical
+            {
+              alert: 'IpmiSelTemperatureCritical',
+              expr: 'increase(ipmi_sel_events_count{name="temperature_critical"}[1h]) > 0',
+              labels: {
+                severity: 'critical',
+              },
+              annotations: {
+                summary: 'Critical temperature event on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a critical temperature threshold event.',
+              },
+            },
+            {
+              alert: 'IpmiSelTemperatureNonRecoverable',
+              expr: 'increase(ipmi_sel_events_count{name="temperature_non_recoverable"}[1h]) > 0',
+              labels: {
+                severity: 'critical',
+              },
+              annotations: {
+                summary: 'Non-recoverable temperature event on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a non-recoverable temperature event.',
+              },
+            },
+            // Power supply events - Critical
+            {
+              alert: 'IpmiSelPsuFailure',
+              expr: 'increase(ipmi_sel_events_count{name="psu_failure"}[1h]) > 0',
+              labels: {
+                severity: 'critical',
+              },
+              annotations: {
+                summary: 'Power supply failure detected on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a power supply failure event.',
+              },
+            },
+            {
+              alert: 'IpmiSelPsuRedundancyLost',
+              expr: 'increase(ipmi_sel_events_count{name="psu_redundancy_lost"}[1h]) > 0',
+              labels: {
+                severity: 'critical',
+              },
+              annotations: {
+                summary: 'Power supply redundancy lost on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a power supply redundancy lost event.',
+              },
+            },
+            {
+              alert: 'IpmiSelPowerUnitFailure',
+              expr: 'increase(ipmi_sel_events_count{name="power_unit_failure"}[1h]) > 0',
+              labels: {
+                severity: 'critical',
+              },
+              annotations: {
+                summary: 'Power unit failure detected on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a power unit failure event.',
+              },
+            },
+            // Voltage events - Critical
+            {
+              alert: 'IpmiSelVoltageCritical',
+              expr: 'increase(ipmi_sel_events_count{name="voltage_critical"}[1h]) > 0',
+              labels: {
+                severity: 'critical',
+              },
+              annotations: {
+                summary: 'Critical voltage event on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a critical voltage threshold event.',
+              },
+            },
+            // System events - Critical
+            {
+              alert: 'IpmiSelOsCriticalStop',
+              expr: 'increase(ipmi_sel_events_count{name="os_critical_stop"}[1h]) > 0',
+              labels: {
+                severity: 'critical',
+              },
+              annotations: {
+                summary: 'OS critical stop detected on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged an operating system critical stop event.',
+              },
+            },
+          ],
+        },
+        {
+          name: 'sel-events-warning',
+          rules: [
+            // Memory errors - Warning
+            {
+              alert: 'IpmiSelMemoryCorrectableError',
+              expr: 'increase(ipmi_sel_events_count{name="memory_ecc_correctable"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'Correctable memory error detected on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged correctable memory errors. Monitor for increasing frequency.',
+              },
+            },
+            {
+              alert: 'IpmiSelMemoryConfigurationError',
+              expr: 'increase(ipmi_sel_events_count{name="memory_configuration_error"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'Memory configuration error on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a memory configuration error event.',
+              },
+            },
+            // Temperature events - Warning
+            {
+              alert: 'IpmiSelTemperatureWarning',
+              expr: 'increase(ipmi_sel_events_count{name="temperature_warning"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'Temperature warning event on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a temperature warning threshold event.',
+              },
+            },
+            // Fan events - Warning
+            {
+              alert: 'IpmiSelFanFailure',
+              expr: 'increase(ipmi_sel_events_count{name="fan_failure"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'Fan failure detected on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a fan failure event.',
+              },
+            },
+            {
+              alert: 'IpmiSelFanWarning',
+              expr: 'increase(ipmi_sel_events_count{name="fan_warning"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'Fan warning event on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a fan speed warning event.',
+              },
+            },
+            {
+              alert: 'IpmiSelFanRedundancyLost',
+              expr: 'increase(ipmi_sel_events_count{name="fan_redundancy_lost"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'Fan redundancy lost on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a fan redundancy lost event.',
+              },
+            },
+            // Power supply events - Warning
+            {
+              alert: 'IpmiSelPsuAcLost',
+              expr: 'increase(ipmi_sel_events_count{name="psu_ac_lost"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'Power supply AC lost on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a power supply AC lost event.',
+              },
+            },
+            // Disk/Storage events - Warning
+            {
+              alert: 'IpmiSelDriveFailure',
+              expr: 'increase(ipmi_sel_events_count{name="drive_failure"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'Drive failure detected on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a drive failure event.',
+              },
+            },
+            {
+              alert: 'IpmiSelDrivePredictiveFailure',
+              expr: 'increase(ipmi_sel_events_count{name="drive_predictive_failure"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'Drive predictive failure on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a drive predictive failure event. Replace drive soon.',
+              },
+            },
+            {
+              alert: 'IpmiSelNvmeTemperatureCritical',
+              expr: 'increase(ipmi_sel_events_count{name="nvme_temperature_critical"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'NVMe critical temperature on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged an NVMe critical temperature event.',
+              },
+            },
+            // Voltage events - Warning
+            {
+              alert: 'IpmiSelVoltageWarning',
+              expr: 'increase(ipmi_sel_events_count{name="voltage_warning"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'Voltage warning event on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a voltage warning threshold event.',
+              },
+            },
+            // Chassis events - Warning
+            {
+              alert: 'IpmiSelChassisIntrusion',
+              expr: 'increase(ipmi_sel_events_count{name="chassis_intrusion"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'Chassis intrusion detected on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a chassis intrusion event.',
+              },
+            },
+            // System events - Warning
+            {
+              alert: 'IpmiSelSystemBootFailure',
+              expr: 'increase(ipmi_sel_events_count{name="system_boot_failure"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'System boot failure on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a system boot failure or POST error event.',
+              },
+            },
+            {
+              alert: 'IpmiSelWatchdogReset',
+              expr: 'increase(ipmi_sel_events_count{name="watchdog_reset"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'Watchdog reset on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a watchdog timer reset event.',
+              },
+            },
+            {
+              alert: 'IpmiSelFirmwareError',
+              expr: 'increase(ipmi_sel_events_count{name="system_firmware_error"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'System firmware error on {{ $labels.instance }}',
+                description: 'IPMI SEL has logged a firmware or BIOS error event.',
+              },
+            },
+            // SEL management - Warning
+            {
+              alert: 'IpmiSelFull',
+              expr: 'increase(ipmi_sel_events_count{name="sel_full"}[1h]) > 0',
+              labels: {
+                severity: 'warning',
+              },
+              annotations: {
+                summary: 'SEL is full on {{ $labels.instance }}',
+                description: 'IPMI SEL is full and needs to be cleared to capture new events.',
+              },
+            },
+          ],
+        },
       ],
     },
   },

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -270,3 +270,247 @@ tests:
       - eval_time: 1h
         alertname: OctaviaAmphoraNotOperational
         exp_alerts: []
+
+  # IPMI SEL Events - Critical alerts
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="memory_ecc_uncorrectable"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelMemoryUncorrectableError
+        exp_alerts:
+          - exp_labels:
+              severity: P1
+              instance: node1
+              name: memory_ecc_uncorrectable
+            exp_annotations:
+              summary: "Uncorrectable memory error detected on node1"
+              description: "IPMI SEL has logged uncorrectable memory errors which may indicate imminent memory failure."
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="memory_ecc_uncorrectable"}'
+        values: '5x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelMemoryUncorrectableError
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="memory_dimm_failure"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelMemoryFailure
+        exp_alerts:
+          - exp_labels:
+              severity: P1
+              instance: node1
+              name: memory_dimm_failure
+            exp_annotations:
+              summary: "Memory DIMM failure detected on node1"
+              description: "IPMI SEL has logged a memory DIMM failure event."
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="processor_thermal_trip"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelProcessorThermalTrip
+        exp_alerts:
+          - exp_labels:
+              severity: P1
+              instance: node1
+              name: processor_thermal_trip
+            exp_annotations:
+              summary: "Processor thermal trip detected on node1"
+              description: "IPMI SEL has logged a processor thermal trip event indicating CPU overheating."
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="machine_check_exception"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelMachineCheckException
+        exp_alerts:
+          - exp_labels:
+              severity: P1
+              instance: node1
+              name: machine_check_exception
+            exp_annotations:
+              summary: "Machine check exception detected on node1"
+              description: "IPMI SEL has logged a machine check exception (MCE) indicating a hardware error."
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="temperature_critical"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelTemperatureCritical
+        exp_alerts:
+          - exp_labels:
+              severity: P1
+              instance: node1
+              name: temperature_critical
+            exp_annotations:
+              summary: "Critical temperature event on node1"
+              description: "IPMI SEL has logged a critical temperature threshold event."
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="psu_failure"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelPsuFailure
+        exp_alerts:
+          - exp_labels:
+              severity: P1
+              instance: node1
+              name: psu_failure
+            exp_annotations:
+              summary: "Power supply failure detected on node1"
+              description: "IPMI SEL has logged a power supply failure event."
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="psu_redundancy_lost"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelPsuRedundancyLost
+        exp_alerts:
+          - exp_labels:
+              severity: P1
+              instance: node1
+              name: psu_redundancy_lost
+            exp_annotations:
+              summary: "Power supply redundancy lost on node1"
+              description: "IPMI SEL has logged a power supply redundancy lost event."
+
+  # IPMI SEL Events - Warning alerts
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="memory_ecc_correctable"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelMemoryCorrectableError
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+              instance: node1
+              name: memory_ecc_correctable
+            exp_annotations:
+              summary: "Correctable memory error detected on node1"
+              description: "IPMI SEL has logged correctable memory errors. Monitor for increasing frequency."
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="memory_ecc_correctable"}'
+        values: '10x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelMemoryCorrectableError
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="fan_failure"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelFanFailure
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+              instance: node1
+              name: fan_failure
+            exp_annotations:
+              summary: "Fan failure detected on node1"
+              description: "IPMI SEL has logged a fan failure event."
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="drive_failure"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelDriveFailure
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+              instance: node1
+              name: drive_failure
+            exp_annotations:
+              summary: "Drive failure detected on node1"
+              description: "IPMI SEL has logged a drive failure event."
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="drive_predictive_failure"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelDrivePredictiveFailure
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+              instance: node1
+              name: drive_predictive_failure
+            exp_annotations:
+              summary: "Drive predictive failure on node1"
+              description: "IPMI SEL has logged a drive predictive failure event. Replace drive soon."
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="sel_full"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelFull
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+              instance: node1
+              name: sel_full
+            exp_annotations:
+              summary: "SEL is full on node1"
+              description: "IPMI SEL is full and needs to be cleared to capture new events."
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="chassis_intrusion"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelChassisIntrusion
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+              instance: node1
+              name: chassis_intrusion
+            exp_annotations:
+              summary: "Chassis intrusion detected on node1"
+              description: "IPMI SEL has logged a chassis intrusion event."
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_count{instance="node1", name="watchdog_reset"}'
+        values: '0+1x60'
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: IpmiSelWatchdogReset
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+              instance: node1
+              name: watchdog_reset
+            exp_annotations:
+              summary: "Watchdog reset on node1"
+              description: "IPMI SEL has logged a watchdog timer reset event."


### PR DESCRIPTION
## Summary
- Update ipmi-exporter to v1.10.1 from Docker Hub
- Enable SEL events collection with regex patterns for critical hardware events
- Add Prometheus alert rules for SEL events (critical and warning severity)
- Add unit tests for the new alert rules

## Test plan
- [ ] Verify ipmi-exporter image pulls successfully
- [ ] Confirm SEL events are collected on nodes with IPMI support
- [ ] Validate Prometheus alerts fire correctly when SEL events occur
- [ ] Run alert rule unit tests

Closes: A8E-89
Fixes: #2973

🤖 Generated with [Claude Code](https://claude.com/claude-code)