### PR TITLE
fix(kube_prometheus_stack): set AppArmor to unconfined for node-exporter

### DIFF
--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -606,6 +606,11 @@ _kube_prometheus_stack_helm_values:
         repository: "{{ atmosphere_images['prometheus_config_reloader'] | vexxhost.kubernetes.docker_image('path') }}"
         tag: "{{ atmosphere_images['prometheus_config_reloader'] | vexxhost.kubernetes.docker_image('tag') }}"
   prometheus-node-exporter:
+    podAnnotations:
+      container.apparmor.security.beta.kubernetes.io/node-exporter: unconfined
+    securityContext:
+      appArmorProfile:
+        type: Unconfined
     image:
       registry: "{{ atmosphere_images['prometheus_node_exporter'] | vexxhost.kubernetes.docker_image('domain') }}"
       repository: "{{ atmosphere_images['prometheus_node_exporter'] | vexxhost.kubernetes.docker_image('path') }}"


### PR DESCRIPTION
## Summary

The node-exporter requires ptrace capabilities to collect process metrics, which is denied by the `cri-containerd.apparmor.d` AppArmor profile. This causes audit logs like:

```
audit: type=1400 audit(1769757582.095:122939): apparmor="DENIED" operation="ptrace" class="ptrace" profile="cri-containerd.apparmor.d" pid=3673482 comm="node_exporter" requested_mask="read" denied_mask="read" peer="unconfined"
```

This PR adds a pod annotation to set the AppArmor profile to `unconfined` for the node-exporter container, allowing the necessary ptrace operations.

## Changes

- Added `podAnnotations` with `container.apparmor.security.beta.kubernetes.io/node-exporter: unconfined` to the prometheus-node-exporter Helm values