### PR TITLE
fix(nova): use WSGI module instead of removed wsgi-file

### DIFF
--- a/charts/nova/values.yaml
+++ b/charts/nova/values.yaml
@@ -1584,7 +1584,7 @@ conf:
       route-user-agent: '^kube-probe.* donotlog:'
       thunder-lock: true
       worker-reload-mercy: 80
-      wsgi-file: /var/lib/openstack/bin/nova-api-wsgi
+      module: "nova.wsgi.osapi_compute:application"
   nova_metadata_uwsgi:
     uwsgi:
       add-header: "Connection: close"
@@ -1600,7 +1600,7 @@ conf:
       route-user-agent: '^kube-probe.* donotlog:'
       thunder-lock: true
       worker-reload-mercy: 80
-      wsgi-file: /var/lib/openstack/bin/nova-metadata-wsgi
+      module: "nova.wsgi.metadata:application"
 
 # Names of secrets used by bootstrap and environmental checks
 secrets:

--- a/charts/patches/nova/0003-use-wsgi-module-instead-of-script.patch
+++ b/charts/patches/nova/0003-use-wsgi-module-instead-of-script.patch
@@ -1,0 +1,21 @@
+diff --git a/nova/values.yaml b/nova/values.yaml
+--- a/nova/values.yaml
++++ b/nova/values.yaml
+@@ -1583,7 +1583,7 @@
+       route-user-agent: '^kube-probe.* donotlog:'
+       thunder-lock: true
+       worker-reload-mercy: 80
+-      wsgi-file: /var/lib/openstack/bin/nova-api-wsgi
++      module: "nova.wsgi.osapi_compute:application"
+   nova_metadata_uwsgi:
+     uwsgi:
+       add-header: "Connection: close"
+@@ -1599,7 +1599,7 @@
+       route-user-agent: '^kube-probe.* donotlog:'
+       thunder-lock: true
+       worker-reload-mercy: 80
+-      wsgi-file: /var/lib/openstack/bin/nova-metadata-wsgi
++      module: "nova.wsgi.metadata:application"
+
+ # Names of secrets used by bootstrap and environmental checks
+ secrets:

--- a/releasenotes/notes/fix-nova-wsgi-module-39c2db1fa58648db.yaml
+++ b/releasenotes/notes/fix-nova-wsgi-module-39c2db1fa58648db.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The Nova API and metadata services now use Python module entry points
+    instead of the removed WSGI script files, fixing startup failures with
+    newer images.


### PR DESCRIPTION
## Summary

The newer Nova images built with uv no longer include the WSGI script files at `/var/lib/openstack/bin/`. This PR switches to using the WSGI module entry points instead:

- `nova-api`: `nova.wsgi.osapi_compute:application`
- `nova-metadata`: `nova.wsgi.metadata:application`

This is consistent with the fix applied to Cinder in #3494.

Related: #3494

🤖 Generated with [Claude Code](https://claude.ai/code)