### PR TITLE
[Backport stable/2025.2] feat: add per-service RabbitMQ spec overrides

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -51,6 +51,7 @@ VPN
 Valkey
 [Bb]ackports
 [Bb]aremetal
+[Nn]amespace
 [Pp]ortworx
 agent
 alert

--- a/doc/source/config/index.rst
+++ b/doc/source/config/index.rst
@@ -7,3 +7,4 @@ Configuration Guide
 
    ingress
    horizon
+   rabbitmq

--- a/doc/source/config/rabbitmq.rst
+++ b/doc/source/config/rabbitmq.rst
@@ -1,0 +1,91 @@
+########
+RabbitMQ
+########
+
+Atmosphere deploys a dedicated RabbitMQ cluster for each OpenStack service that
+requires message queuing. This provides isolation between services and enables
+per-service resource tuning.
+
+***********************
+Per-service overrides
+***********************
+
+To customize the RabbitMQ cluster for a specific service, define a variable
+named ``<chart>_rabbitmq_spec`` in your inventory, where ``<chart>`` matches the
+chart name under ``charts/`` (for example: ``nova``, ``neutron``, ``glance``,
+``keystone``).
+
+Example (increase Nova RabbitMQ resources):
+
+.. code-block:: yaml
+
+   nova_rabbitmq_spec:
+     resources:
+       requests:
+         cpu: 500m
+         memory: 4Gi
+       limits:
+         cpu: "1"
+         memory: 4Gi
+
+*********************
+Common tuning options
+*********************
+
+Atmosphere merges overrides into the default ``RabbitmqCluster`` spec recursively.
+You can set any valid ``RabbitmqCluster.spec`` field. Common options include
+resources, replicas, persistence, and additional configuration.
+
+.. code-block:: yaml
+
+   nova_rabbitmq_spec:
+     # Resource requests and limits
+     resources:
+       requests:
+         cpu: 500m
+         memory: 4Gi
+       limits:
+         cpu: "1"
+         memory: 4Gi
+
+     # Number of RabbitMQ replicas (optional)
+     replicas: 3
+
+     # Persistent volume storage size (optional)
+     persistence:
+       storage: 20Gi
+
+     # Additional RabbitMQ configuration (optional)
+     rabbitmq:
+       additionalConfig: |
+         deprecated_features.permit.management_metrics_collection = true
+         vm_memory_high_watermark.relative = 0.9
+
+.. note::
+
+   Setting ``rabbitmq.additionalConfig`` replaces the default value (it's not
+   appended). If you override it, include any defaults you still want applied.
+
+*****************************
+Skipping spec diff approval
+*****************************
+
+By default, Atmosphere will prompt for approval when the RabbitMQ cluster
+specification changes. To skip this approval step when using per-service
+overrides, set:
+
+.. code-block:: yaml
+
+   rabbitmq_skip_spec_diff: true
+
+******************
+Verifying changes
+******************
+
+Atmosphere deploys RabbitMQ clusters as ``RabbitmqCluster`` resources in the
+``openstack`` namespace with names following the pattern ``rabbitmq-<chart>``.
+
+.. code-block:: console
+
+   kubectl -n openstack get rabbitmqclusters
+   kubectl -n openstack get rabbitmqcluster rabbitmq-nova -o yaml

--- a/releasenotes/notes/per-service-rabbitmq-spec-overrides-c37608d25d757201.yaml
+++ b/releasenotes/notes/per-service-rabbitmq-spec-overrides-c37608d25d757201.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Per-service RabbitMQ specification overrides are now supported, allowing
+    operators to customize RabbitMQ resources for individual OpenStack services.

--- a/roles/openstack_helm_endpoints/tasks/main.yml
+++ b/roles/openstack_helm_endpoints/tasks/main.yml
@@ -31,6 +31,7 @@
         name: rabbitmq
       vars:
         rabbitmq_cluster_name: "{{ openstack_helm_endpoints_chart }}"
+        rabbitmq_spec: "{{ lookup('vars', openstack_helm_endpoints_chart ~ '_rabbitmq_spec', default={}) }}"
 
     - name: Grab RabbitMQ cluster secret
       kubernetes.core.k8s_info:


### PR DESCRIPTION
# Description
Backport of #3462 to `stable/2025.2`.