### PR TITLE
refactor(kube_prometheus_stack): address review feedback on nginx SLO alerts

### DIFF
--- a/roles/kube_prometheus_stack/files/jsonnet/nginx.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/nginx.libsonnet
@@ -1,3 +1,33 @@
+// SLO: 99.9% availability → error budget = 0.001
+// Thresholds = error_budget × burn_rate_multiplier
+local burnRateTiers = {
+  critical: { multiplier: 14.4, threshold: '0.0144', longWindow: '1h', shortWindow: '5m' },
+  high: { multiplier: 6, threshold: '0.006', longWindow: '6h', shortWindow: '30m' },
+  moderate: { multiplier: 3, threshold: '0.003', longWindow: '1d', shortWindow: '2h' },
+  low: { multiplier: 1, threshold: '0.001', longWindow: '3d', shortWindow: '6h' },
+};
+
+local errorRatio(window) = |||
+  sum by (service) (rate(nginx_ingress_controller_requests{status=~"5[0-9]{2}"}[%(window)s]))
+  /
+  sum by (service) (rate(nginx_ingress_controller_requests[%(window)s]))
+||| % { window: window };
+
+local burnRateExpr(tier) = |||
+  (
+  %(longRatio)s) > %(threshold)s
+  and
+  (
+  %(shortRatio)s) > %(threshold)s
+  and
+  sum by (service) (rate(nginx_ingress_controller_requests[%(shortWindow)s])) > 1
+||| % {
+  longRatio: errorRatio(tier.longWindow),
+  shortRatio: errorRatio(tier.shortWindow),
+  threshold: tier.threshold,
+  shortWindow: tier.shortWindow,
+};
+
 {
   prometheusAlerts+: {
     groups+: [
@@ -6,108 +36,52 @@
         rules: [
           {
             alert: 'NginxIngressCriticalErrorBudgetBurn',
-            expr: |||
-              (
-                sum by (service) (rate(nginx_ingress_controller_requests{status=~"5[0-9]{2}"}[1h]))
-                /
-                sum by (service) (rate(nginx_ingress_controller_requests[1h]))
-              ) > 0.0144
-              and
-              (
-                sum by (service) (rate(nginx_ingress_controller_requests{status=~"5[0-9]{2}"}[5m]))
-                /
-                sum by (service) (rate(nginx_ingress_controller_requests[5m]))
-              ) > 0.0144
-              and
-              sum by (service) (rate(nginx_ingress_controller_requests[5m])) > 1
-            |||,
+            expr: burnRateExpr(burnRateTiers.critical),
             'for': '2m',
             labels: {
               severity: 'P2',
             },
             annotations: {
-              summary: 'NGINX Ingress: critical error budget burn rate',
+              summary: 'NGINX Ingress: elevated 5xx errors rapidly consuming error budget',
               description: 'The service {{ $labels.service }} error rate is {{ $value | humanizePercentage }} over the last hour, which exceeds the 1.44% burn-rate threshold (14.4x against 99.9% SLO). At this rate, the 30-day error budget exhausts in under 2.1 days.',
               runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#nginxingresscriticalerrorbudgetburn',
             },
           },
           {
             alert: 'NginxIngressHighErrorBudgetBurn',
-            expr: |||
-              (
-                sum by (service) (rate(nginx_ingress_controller_requests{status=~"5[0-9]{2}"}[6h]))
-                /
-                sum by (service) (rate(nginx_ingress_controller_requests[6h]))
-              ) > 0.006
-              and
-              (
-                sum by (service) (rate(nginx_ingress_controller_requests{status=~"5[0-9]{2}"}[30m]))
-                /
-                sum by (service) (rate(nginx_ingress_controller_requests[30m]))
-              ) > 0.006
-              and
-              sum by (service) (rate(nginx_ingress_controller_requests[30m])) > 1
-            |||,
+            expr: burnRateExpr(burnRateTiers.high),
             'for': '5m',
             labels: {
               severity: 'P2',
             },
             annotations: {
-              summary: 'NGINX Ingress: high error budget burn rate',
+              summary: 'NGINX Ingress: sustained 5xx errors depleting error budget',
               description: 'The service {{ $labels.service }} error rate is {{ $value | humanizePercentage }} over the last 6 hours, which exceeds the 0.6% burn-rate threshold (6x against 99.9% SLO). At this rate, the 30-day error budget exhausts in under 5 days.',
               runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#nginxingresshigherrorbudgetburn',
             },
           },
           {
             alert: 'NginxIngressModerateErrorBudgetBurn',
-            expr: |||
-              (
-                sum by (service) (rate(nginx_ingress_controller_requests{status=~"5[0-9]{2}"}[1d]))
-                /
-                sum by (service) (rate(nginx_ingress_controller_requests[1d]))
-              ) > 0.003
-              and
-              (
-                sum by (service) (rate(nginx_ingress_controller_requests{status=~"5[0-9]{2}"}[2h]))
-                /
-                sum by (service) (rate(nginx_ingress_controller_requests[2h]))
-              ) > 0.003
-              and
-              sum by (service) (rate(nginx_ingress_controller_requests[2h])) > 1
-            |||,
+            expr: burnRateExpr(burnRateTiers.moderate),
             'for': '15m',
             labels: {
               severity: 'P3',
             },
             annotations: {
-              summary: 'NGINX Ingress: moderate error budget burn rate',
+              summary: 'NGINX Ingress: ongoing 5xx errors steadily consuming error budget',
               description: 'The service {{ $labels.service }} error rate is {{ $value | humanizePercentage }} over the last day, which exceeds the 0.3% burn-rate threshold (3x against 99.9% SLO). At this rate, the 30-day error budget exhausts in under 10 days.',
               runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#nginxingressmoderateerrorbudgetburn',
             },
           },
           {
             alert: 'NginxIngressLowErrorBudgetBurn',
-            expr: |||
-              (
-                sum by (service) (rate(nginx_ingress_controller_requests{status=~"5[0-9]{2}"}[3d]))
-                /
-                sum by (service) (rate(nginx_ingress_controller_requests[3d]))
-              ) > 0.001
-              and
-              (
-                sum by (service) (rate(nginx_ingress_controller_requests{status=~"5[0-9]{2}"}[6h]))
-                /
-                sum by (service) (rate(nginx_ingress_controller_requests[6h]))
-              ) > 0.001
-              and
-              sum by (service) (rate(nginx_ingress_controller_requests[6h])) > 1
-            |||,
+            expr: burnRateExpr(burnRateTiers.low),
             'for': '1h',
             labels: {
               severity: 'P4',
             },
             annotations: {
-              summary: 'NGINX Ingress: low error budget burn rate',
+              summary: 'NGINX Ingress: low-level 5xx errors eroding error budget',
               description: 'The service {{ $labels.service }} error rate is {{ $value | humanizePercentage }} over the last 3 days, which exceeds the 0.1% burn-rate threshold (1x against 99.9% SLO). At this rate, the 30-day error budget exhausts before the window resets.',
               runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#nginxingresslowerrorbudgetburn',
             },

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -555,9 +555,22 @@ tests:
               severity: P2
               service: nova-api
             exp_annotations:
-              summary: "NGINX Ingress: critical error budget burn rate"
+              summary: "NGINX Ingress: elevated 5xx errors rapidly consuming error budget"
               description: "The service nova-api error rate is 2% over the last hour, which exceeds the 1.44% burn-rate threshold (14.4x against 99.9% SLO). At this rate, the 30-day error budget exhausts in under 2.1 days."
               runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#nginxingresscriticalerrorbudgetburn"
+
+  # NginxIngressCriticalErrorBudgetBurn - should NOT fire when long window above threshold but short window below
+  - interval: 1m
+    input_series:
+      # High error rate for the first 60 min (long window), then drop to zero errors (short window recovers)
+      - series: 'nginx_ingress_controller_requests{service="barbican-api",status="200"}'
+        values: '0+196x60 0+200x20'
+      - series: 'nginx_ingress_controller_requests{service="barbican-api",status="500"}'
+        values: '0+4x60 0+0x20'
+    alert_rule_test:
+      - eval_time: 70m
+        alertname: NginxIngressCriticalErrorBudgetBurn
+        exp_alerts: []
 
   # NginxIngressCriticalErrorBudgetBurn - should NOT fire when traffic is too low
   - interval: 1m
@@ -601,9 +614,22 @@ tests:
               severity: P2
               service: cinder-api
             exp_annotations:
-              summary: "NGINX Ingress: high error budget burn rate"
+              summary: "NGINX Ingress: sustained 5xx errors depleting error budget"
               description: "The service cinder-api error rate is 1% over the last 6 hours, which exceeds the 0.6% burn-rate threshold (6x against 99.9% SLO). At this rate, the 30-day error budget exhausts in under 5 days."
               runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#nginxingresshigherrorbudgetburn"
+
+  # NginxIngressHighErrorBudgetBurn - should NOT fire when long window above threshold but short window below
+  - interval: 1m
+    input_series:
+      # High error rate for the first 360 min (long window), then drop to zero errors (short window recovers)
+      - series: 'nginx_ingress_controller_requests{service="magnum-api",status="200"}'
+        values: '0+198x360 0+200x40'
+      - series: 'nginx_ingress_controller_requests{service="magnum-api",status="502"}'
+        values: '0+2x360 0+0x40'
+    alert_rule_test:
+      - eval_time: 390m
+        alertname: NginxIngressHighErrorBudgetBurn
+        exp_alerts: []
 
   # NginxIngressHighErrorBudgetBurn - should NOT fire when traffic is too low
   - interval: 1m
@@ -647,7 +673,7 @@ tests:
               severity: P3
               service: designate-api
             exp_annotations:
-              summary: "NGINX Ingress: moderate error budget burn rate"
+              summary: "NGINX Ingress: ongoing 5xx errors steadily consuming error budget"
               description: "The service designate-api error rate is 0.5% over the last day, which exceeds the 0.3% burn-rate threshold (3x against 99.9% SLO). At this rate, the 30-day error budget exhausts in under 10 days."
               runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#nginxingressmoderateerrorbudgetburn"
 
@@ -680,6 +706,6 @@ tests:
               severity: P4
               service: placement-api
             exp_annotations:
-              summary: "NGINX Ingress: low error budget burn rate"
+              summary: "NGINX Ingress: low-level 5xx errors eroding error budget"
               description: "The service placement-api error rate is 0.2% over the last 3 days, which exceeds the 0.1% burn-rate threshold (1x against 99.9% SLO). At this rate, the 30-day error budget exhausts before the window resets."
               runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#nginxingresslowerrorbudgetburn"


### PR DESCRIPTION
Addresses review feedback from #3564.

## Changes

### Extract burn-rate thresholds into locals
The magic numbers (0.0144, 0.006, 0.003, 0.001) are now defined as named thresholds in a `burnRateTiers` struct alongside their corresponding windows and multipliers. This makes the SLO policy easier to update and review.

### Update alert summaries to describe impact
Per the project's alerting conventions (`<Component>: <Impact statement>`), summaries now describe user-visible impact:
- `elevated 5xx errors rapidly consuming error budget`
- `sustained 5xx errors depleting error budget`
- `ongoing 5xx errors steadily consuming error budget`
- `low-level 5xx errors eroding error budget`

### Add multi-window negative tests
Added 2 test cases that validate the core multi-window gating behavior — the alert should NOT fire when the long window exceeds the threshold but the short window has recovered (errors stopped recently). This was the main gap in test coverage.

### Not addressed
The review suggested changing bold heading capitalization in `monitoring.rst` from Title Case to sentence case. This was **not** applied because all existing alert entries in the file consistently use Title Case (`**Likely Root Causes**`, `**Diagnostic and Remediation Steps**`), so the current headings are already consistent with the established pattern.