### PR TITLE
fix(magnum): use WSGI module instead of removed wsgi-file

### DIFF
--- a/charts/magnum/values.yaml
+++ b/charts/magnum/values.yaml
@@ -177,7 +177,7 @@ conf:
       socket-timeout: 10
       thunder-lock: true
       worker-reload-mercy: 80
-      wsgi-file: /var/lib/openstack/bin/magnum-api-wsgi
+      module: "magnum.api.app:build_wsgi_app"
 
 network:
   api:

--- a/charts/patches/magnum/0001-tune-uwsgi-config.patch
+++ b/charts/patches/magnum/0001-tune-uwsgi-config.patch
@@ -1,8 +1,8 @@
-diff --git b/magnum/values.yaml a/charts/magnum/values.yaml
-index 56232eb8..88b4203e 100644
---- b/magnum/values.yaml
-+++ a/magnum/values.yaml
-@@ -161,15 +161,20 @@ conf:
+diff --git a/magnum/values.yaml b/magnum/values.yaml
+--- a/magnum/values.yaml
++++ b/magnum/values.yaml
+@@ -171,18 +171,23 @@
+   magnum_api_uwsgi:
      uwsgi:
        add-header: "Connection: close"
        buffer-size: 65535
@@ -22,4 +22,8 @@ index 56232eb8..88b4203e 100644
 +      socket-timeout: 10
        thunder-lock: true
        worker-reload-mercy: 80
-       wsgi-file: /var/lib/openstack/bin/magnum-api-wsgi
+-      wsgi-file: /var/lib/openstack/bin/magnum-api-wsgi
++      module: "magnum.api.app:build_wsgi_app"
+
+ network:
+   api:

--- a/releasenotes/notes/fix-magnum-wsgi-module-1a9a76652e72621d.yaml
+++ b/releasenotes/notes/fix-magnum-wsgi-module-1a9a76652e72621d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The Magnum API now uses a Python module entry point instead of the removed
+    WSGI script file, fixing startup failures with newer images.


### PR DESCRIPTION
## Summary
- Use Python module entry point `magnum.api.app:build_wsgi_app` instead of removed `wsgi-file`
- Similar to #3494 (cinder) and #3495 (nova)

## Related
- #3494 
- #3495

🤖 Generated with [Claude Code](https://claude.com/claude-code)