### PR TITLE
feat(monitoring): replace CoreDNS mixin with burn-rate SLO alerts

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -14,6 +14,7 @@ CAPO
 CRD
 CSI
 Cinder
+CoreDNS
 DNS
 FQDN
 FQDNs

--- a/releasenotes/notes/coredns-alert-inhibition-rules-7de3cf552716bef5.yaml
+++ b/releasenotes/notes/coredns-alert-inhibition-rules-7de3cf552716bef5.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Replaced the upstream CoreDNS alerts with custom burn-rate SLO alerts.
+    The new alerts use multi-window burn-rate detection to track error budget
+    consumption, reducing alert noise from cascading cause-based alerts.

--- a/roles/kube_prometheus_stack/files/jsonnet/burnrate.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/burnrate.libsonnet
@@ -1,0 +1,8 @@
+// SLO: 99.9% availability → error budget = 0.001
+// Thresholds = error_budget × burn_rate_multiplier
+{
+  critical: { multiplier: 14.4, threshold: '0.0144', longWindow: '1h', shortWindow: '5m' },
+  high: { multiplier: 6, threshold: '0.006', longWindow: '6h', shortWindow: '30m' },
+  moderate: { multiplier: 3, threshold: '0.003', longWindow: '1d', shortWindow: '2h' },
+  low: { multiplier: 1, threshold: '0.001', longWindow: '3d', shortWindow: '6h' },
+}

--- a/roles/kube_prometheus_stack/files/jsonnet/coredns.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/coredns.libsonnet
@@ -1,0 +1,99 @@
+local burnRateTiers = import 'burnrate.libsonnet';
+
+local errorRatio(window) = |||
+  sum(rate(coredns_dns_responses_total{job="coredns",rcode="SERVFAIL"}[%(window)s]))
+  /
+  sum(rate(coredns_dns_responses_total{job="coredns"}[%(window)s]))
+||| % { window: window };
+
+local burnRateExpr(tier) = |||
+  (
+  %(longRatio)s) > %(threshold)s
+  and
+  (
+  %(shortRatio)s) > %(threshold)s
+  and
+  sum(rate(coredns_dns_responses_total{job="coredns"}[%(shortWindow)s])) > 1
+||| % {
+  longRatio: errorRatio(tier.longWindow),
+  shortRatio: errorRatio(tier.shortWindow),
+  threshold: tier.threshold,
+  shortWindow: tier.shortWindow,
+};
+
+{
+  prometheusAlerts+: {
+    groups+: [
+      {
+        name: 'coredns',
+        rules: [
+          {
+            alert: 'CoreDNSCriticalErrorBudgetBurn',
+            expr: burnRateExpr(burnRateTiers.critical),
+            'for': '2m',
+            labels: {
+              severity: 'P1',
+            },
+            annotations: {
+              summary: 'CoreDNS: SERVFAIL rate rapidly consuming error budget',
+              description: 'The CoreDNS SERVFAIL rate is {{ $value | humanizePercentage }} over the last hour, which exceeds the 1.44% burn-rate threshold (14.4x against 99.9% SLO). At this rate, the 30-day error budget exhausts in under 2.1 days.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#corednscriticalerrorbudgetburn',
+            },
+          },
+          {
+            alert: 'CoreDNSHighErrorBudgetBurn',
+            expr: burnRateExpr(burnRateTiers.high),
+            'for': '5m',
+            labels: {
+              severity: 'P2',
+            },
+            annotations: {
+              summary: 'CoreDNS: sustained SERVFAIL rate depleting error budget',
+              description: 'The CoreDNS SERVFAIL rate is {{ $value | humanizePercentage }} over the last 6 hours, which exceeds the 0.6% burn-rate threshold (6x against 99.9% SLO). At this rate, the 30-day error budget exhausts in under 5 days.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#corednshigherrorbudgetburn',
+            },
+          },
+          {
+            alert: 'CoreDNSModerateErrorBudgetBurn',
+            expr: burnRateExpr(burnRateTiers.moderate),
+            'for': '15m',
+            labels: {
+              severity: 'P3',
+            },
+            annotations: {
+              summary: 'CoreDNS: ongoing SERVFAIL rate steadily consuming error budget',
+              description: 'The CoreDNS SERVFAIL rate is {{ $value | humanizePercentage }} over the last day, which exceeds the 0.3% burn-rate threshold (3x against 99.9% SLO). At this rate, the 30-day error budget exhausts in under 10 days.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#corednsmoderateerrorbudgetburn',
+            },
+          },
+          {
+            alert: 'CoreDNSLowErrorBudgetBurn',
+            expr: burnRateExpr(burnRateTiers.low),
+            'for': '1h',
+            labels: {
+              severity: 'P4',
+            },
+            annotations: {
+              summary: 'CoreDNS: low-level SERVFAIL rate eroding error budget',
+              description: 'The CoreDNS SERVFAIL rate is {{ $value | humanizePercentage }} over the last 3 days, which exceeds the 0.1% burn-rate threshold (1x against 99.9% SLO). At this rate, the 30-day error budget exhausts before the window resets.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#corednslowerrorbudgetburn',
+            },
+          },
+          {
+            alert: 'CoreDNSDown',
+            expr: 'absent(up{job="coredns"} == 1)',
+            'for': '15m',
+            labels: {
+              severity: 'P3',
+            },
+            annotations: {
+              summary: 'CoreDNS: instance has disappeared from Prometheus target discovery',
+              description: 'CoreDNS has disappeared from Prometheus target discovery for more than 15 minutes. This could indicate a crashed CoreDNS pod or a misconfigured scrape target.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#corednsdown',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
@@ -98,11 +98,7 @@ local mixins = {
       ],
     },
   },
-  coredns: (import 'vendor/github.com/povilasv/coredns-mixin/mixin.libsonnet') + {
-    _config+:: {
-      corednsSelector: 'job="coredns"',
-    },
-  },
+  coredns: (import 'coredns.libsonnet'),
   kube: (import 'vendor/github.com/kubernetes-monitoring/kubernetes-mixin/mixin.libsonnet') + {
     _config+:: {
       kubeApiserverSelector: 'job="apiserver"',

--- a/roles/kube_prometheus_stack/files/jsonnet/nginx.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/nginx.libsonnet
@@ -1,11 +1,4 @@
-// SLO: 99.9% availability → error budget = 0.001
-// Thresholds = error_budget × burn_rate_multiplier
-local burnRateTiers = {
-  critical: { multiplier: 14.4, threshold: '0.0144', longWindow: '1h', shortWindow: '5m' },
-  high: { multiplier: 6, threshold: '0.006', longWindow: '6h', shortWindow: '30m' },
-  moderate: { multiplier: 3, threshold: '0.003', longWindow: '1d', shortWindow: '2h' },
-  low: { multiplier: 1, threshold: '0.001', longWindow: '3d', shortWindow: '6h' },
-};
+local burnRateTiers = import 'burnrate.libsonnet';
 
 local errorRatio(window) = |||
   sum by (service) (rate(nginx_ingress_controller_requests{status=~"5[0-9]{2}"}[%(window)s]))

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -765,3 +765,157 @@ tests:
               summary: "Percona XtraDB Cluster: Galera node not in sync with cluster"
               description: "The Galera node percona-xtradb-pxc-1 has wsrep_local_state=1 which is not the expected value of 4 (Synced).  The node is not in Donor state (2) and wsrep_desync is not enabled, indicating an unexpected loss of cluster sync.  Normal behavior is wsrep_local_state=4 for all nodes not actively serving as SST donors."
               runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#mysqlgaleraoutofsync"
+
+  # CoreDNSCriticalErrorBudgetBurn - should NOT fire when error rate is below burn-rate threshold
+  - interval: 1m
+    input_series:
+      # Low error rate: 1 SERVFAIL out of 200 total per minute = 0.5% (below 1.44% threshold)
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="SERVFAIL",instance="192.0.2.1:9153"}'
+        values: '0+1x80'
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="NOERROR",instance="192.0.2.1:9153"}'
+        values: '0+199x80'
+    alert_rule_test:
+      - eval_time: 70m
+        alertname: CoreDNSCriticalErrorBudgetBurn
+        exp_alerts: []
+
+  # CoreDNSCriticalErrorBudgetBurn - should fire when error rate exceeds 14.4x burn-rate threshold
+  - interval: 1m
+    input_series:
+      # Error rate: 4 SERVFAIL out of 200 total per minute = 2% (above 1.44% threshold)
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="SERVFAIL",instance="192.0.2.1:9153"}'
+        values: '0+4x80'
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="NOERROR",instance="192.0.2.1:9153"}'
+        values: '0+196x80'
+    alert_rule_test:
+      - eval_time: 70m
+        alertname: CoreDNSCriticalErrorBudgetBurn
+        exp_alerts:
+          - exp_labels:
+              severity: P1
+            exp_annotations:
+              summary: "CoreDNS: SERVFAIL rate rapidly consuming error budget"
+              description: "The CoreDNS SERVFAIL rate is 2% over the last hour, which exceeds the 1.44% burn-rate threshold (14.4x against 99.9% SLO). At this rate, the 30-day error budget exhausts in under 2.1 days."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#corednscriticalerrorbudgetburn"
+
+  # CoreDNSHighErrorBudgetBurn - should NOT fire when error rate is below burn-rate threshold
+  - interval: 1m
+    input_series:
+      # Low error rate: 1 SERVFAIL out of 500 total per minute = 0.2% (below 0.6% threshold)
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="SERVFAIL",instance="198.51.100.1:9153"}'
+        values: '0+1x400'
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="NOERROR",instance="198.51.100.1:9153"}'
+        values: '0+499x400'
+    alert_rule_test:
+      - eval_time: 390m
+        alertname: CoreDNSHighErrorBudgetBurn
+        exp_alerts: []
+
+  # CoreDNSHighErrorBudgetBurn - should fire when error rate exceeds 6x burn-rate threshold
+  - interval: 1m
+    input_series:
+      # Error rate: 2 SERVFAIL out of 200 total per minute = 1% (above 0.6% threshold)
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="SERVFAIL",instance="198.51.100.1:9153"}'
+        values: '0+2x400'
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="NOERROR",instance="198.51.100.1:9153"}'
+        values: '0+198x400'
+    alert_rule_test:
+      - eval_time: 390m
+        alertname: CoreDNSHighErrorBudgetBurn
+        exp_alerts:
+          - exp_labels:
+              severity: P2
+            exp_annotations:
+              summary: "CoreDNS: sustained SERVFAIL rate depleting error budget"
+              description: "The CoreDNS SERVFAIL rate is 1% over the last 6 hours, which exceeds the 0.6% burn-rate threshold (6x against 99.9% SLO). At this rate, the 30-day error budget exhausts in under 5 days."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#corednshigherrorbudgetburn"
+
+  # CoreDNSModerateErrorBudgetBurn - should NOT fire when error rate is below burn-rate threshold
+  - interval: 1m
+    input_series:
+      # Low error rate: 1 SERVFAIL out of 1000 total per minute = 0.1% (below 0.3% threshold)
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="SERVFAIL",instance="203.0.113.1:9153"}'
+        values: '0+1x1500'
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="NOERROR",instance="203.0.113.1:9153"}'
+        values: '0+999x1500'
+    alert_rule_test:
+      - eval_time: 1455m
+        alertname: CoreDNSModerateErrorBudgetBurn
+        exp_alerts: []
+
+  # CoreDNSModerateErrorBudgetBurn - should fire when error rate exceeds 3x burn-rate threshold
+  - interval: 1m
+    input_series:
+      # Error rate: 1 SERVFAIL out of 200 total per minute = 0.5% (above 0.3% threshold)
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="SERVFAIL",instance="203.0.113.1:9153"}'
+        values: '0+1x1500'
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="NOERROR",instance="203.0.113.1:9153"}'
+        values: '0+199x1500'
+    alert_rule_test:
+      - eval_time: 1455m
+        alertname: CoreDNSModerateErrorBudgetBurn
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+            exp_annotations:
+              summary: "CoreDNS: ongoing SERVFAIL rate steadily consuming error budget"
+              description: "The CoreDNS SERVFAIL rate is 0.5% over the last day, which exceeds the 0.3% burn-rate threshold (3x against 99.9% SLO). At this rate, the 30-day error budget exhausts in under 10 days."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#corednsmoderateerrorbudgetburn"
+
+  # CoreDNSLowErrorBudgetBurn - should NOT fire when error rate is below burn-rate threshold
+  - interval: 1m
+    input_series:
+      # Low error rate: 1 SERVFAIL out of 5000 total per minute = 0.02% (below 0.1% threshold)
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="SERVFAIL",instance="192.0.2.10:9153"}'
+        values: '0+1x4400'
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="NOERROR",instance="192.0.2.10:9153"}'
+        values: '0+4999x4400'
+    alert_rule_test:
+      - eval_time: 4380m
+        alertname: CoreDNSLowErrorBudgetBurn
+        exp_alerts: []
+
+  # CoreDNSLowErrorBudgetBurn - should fire when error rate exceeds 1x burn-rate threshold
+  - interval: 1m
+    input_series:
+      # Error rate: 1 SERVFAIL out of 500 total per minute = 0.2% (above 0.1% threshold)
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="SERVFAIL",instance="192.0.2.10:9153"}'
+        values: '0+1x4400'
+      - series: 'coredns_dns_responses_total{job="coredns",rcode="NOERROR",instance="192.0.2.10:9153"}'
+        values: '0+499x4400'
+    alert_rule_test:
+      - eval_time: 4380m
+        alertname: CoreDNSLowErrorBudgetBurn
+        exp_alerts:
+          - exp_labels:
+              severity: P4
+            exp_annotations:
+              summary: "CoreDNS: low-level SERVFAIL rate eroding error budget"
+              description: "The CoreDNS SERVFAIL rate is 0.2% over the last 3 days, which exceeds the 0.1% burn-rate threshold (1x against 99.9% SLO). At this rate, the 30-day error budget exhausts before the window resets."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#corednslowerrorbudgetburn"
+
+  # CoreDNSDown - should NOT fire when CoreDNS is up
+  - interval: 1m
+    input_series:
+      - series: 'up{job="coredns",instance="192.0.2.1:9153"}'
+        values: '1x20'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: CoreDNSDown
+        exp_alerts: []
+
+  # CoreDNSDown - should fire when CoreDNS disappears
+  - interval: 1m
+    input_series:
+      - series: 'up{job="coredns",instance="192.0.2.1:9153"}'
+        values: '0x20'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: CoreDNSDown
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+            exp_annotations:
+              summary: "CoreDNS: instance has disappeared from Prometheus target discovery"
+              description: "CoreDNS has disappeared from Prometheus target discovery for more than 15 minutes. This could indicate a crashed CoreDNS pod or a misconfigured scrape target."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#corednsdown"

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -57,6 +57,18 @@ _kube_prometheus_stack_helm_values:
           equal:
             - service
             - namespace
+        - source_matchers:
+            - alertname = "CoreDNSCriticalErrorBudgetBurn"
+          target_matchers:
+            - alertname =~ "CoreDNSHighErrorBudgetBurn|CoreDNSModerateErrorBudgetBurn|CoreDNSLowErrorBudgetBurn"
+        - source_matchers:
+            - alertname = "CoreDNSHighErrorBudgetBurn"
+          target_matchers:
+            - alertname =~ "CoreDNSModerateErrorBudgetBurn|CoreDNSLowErrorBudgetBurn"
+        - source_matchers:
+            - alertname = "CoreDNSModerateErrorBudgetBurn"
+          target_matchers:
+            - alertname = "CoreDNSLowErrorBudgetBurn"
       route:
         group_by:
           - alertname


### PR DESCRIPTION
## Summary

Replaces the upstream CoreDNS mixin alerts with custom burn-rate SLO alerts following the project's alerting philosophy.

### Problem

The upstream CoreDNS mixin produced **cascading alert storms** during upstream DNS blips. A single upstream DNS hiccup triggered up to 5 alerts simultaneously (`CoreDNSForwardHealthcheckFailureCount`, `CoreDNSForwardHealthcheckBrokenCount`, `CoreDNSForwardErrorsHigh`, `CoreDNSErrorsHigh`, `CoreDNSLatencyHigh`) — all with 100% flap rates in production (ext-nurucloud). The alerts were:

- **Cause-based** (healthcheck counters) instead of symptom-based
- Using **static thresholds** instead of burn-rate/SLO detection
- Missing **documentation**, **tests**, and **runbook URLs**
- Mapped to incorrect severities (e.g., forward errors to one upstream as P1)

### Solution

New custom `coredns.libsonnet` with burn-rate SLO alerts matching the NGINX Ingress pattern:

| Alert | Severity | Burn Rate | Long Window | Short Window |
|-------|----------|-----------|-------------|--------------|
| `CoreDNSCriticalErrorBudgetBurn` | P1 | 14.4x | 1h | 5m |
| `CoreDNSHighErrorBudgetBurn` | P2 | 6x | 6h | 30m |
| `CoreDNSModerateErrorBudgetBurn` | P3 | 3x | 1d | 2h |
| `CoreDNSLowErrorBudgetBurn` | P4 | 1x | 3d | 6h |
| `CoreDNSDown` | P3 | N/A | N/A | N/A |

Alertmanager inhibition rules ensure higher-tier burn-rate alerts suppress lower tiers.

### Checklist

- [x] All alerts have documentation entries in `monitoring.rst`
- [x] All entries include description, root causes, and remediation steps
- [x] P1-P3 alerts have `runbook_url` annotations
- [x] Summary and description annotations follow the format guidelines
- [x] All alerts have negative and positive test cases
- [x] Test expectations include all annotations
- [x] Vale linting passes with no new errors
- [x] All CoreDNS tests pass