### PR TITLE
ci: use harbor mirror for zuul jobs to avoid rate limits

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -24,6 +24,7 @@
     roles:
       - zuul: opendev.org/openstack/openstack-helm
     vars:
+      atmosphere_image_prefix: "harbor.atmosphere.dev/"
       ceph_fsid: 4837cbf8-4f90-4300-b3f6-726c9b9f89b4
       ceph_conf_overrides:
         - section: global


### PR DESCRIPTION
Set `atmosphere_image_prefix` to `harbor.atmosphere.dev/` in the base `atmosphere-molecule` Zuul job vars so all image pulls go through Harbor's proxy cache, avoiding upstream registry rate limits.