### PR TITLE
Add IPMI SEL alerts for memory and CPU errors

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -15,8 +15,10 @@ CRD
 CSI
 Cinder
 CoreDNS
+DIMM
 DNS
 Dell
+ECC
 FQDN
 FQDNs
 Galera
@@ -56,6 +58,7 @@ READY
 RGW
 RPC
 RabbitMQ
+SEL
 SLOs?
 SMART
 SQLAlchemy

--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -908,6 +908,82 @@ experiencing network issues.
      kubectl debug node/<affected-node> -it --image=busybox -- \
        cat /host/var/log/syslog | tail -100
 
+``IpmiUncorrectableMemoryError``
+================================
+
+This alert fires when the Intelligent Platform Management Interface (IPMI)
+exporter reports a recent ``uncorrectable_memory_error`` System Event Log
+(SEL) event. These events
+indicate a non-recoverable memory error on the host and often require
+hardware intervention.
+
+**Likely root causes**
+
+- Failing dual in-line memory module (DIMM) or memory controller
+- Unstable firmware or Basic Input/Output System (BIOS) configuration
+- Recent hardware changes or maintenance introducing faulty memory
+
+**Diagnostic and remediation steps**
+
+1. Identify the affected host from the alert ``instance`` label.
+
+2. Check the SEL (System Event Log) on the host for uncorrectable memory errors:
+
+   .. code-block:: console
+
+     ipmitool sel list | grep -i "uncorrectable"
+
+3. Review system logs for error-correcting code (ECC) or memory errors:
+
+   .. code-block:: console
+
+     journalctl -k | grep -i -e ecc -e memory -e edac
+
+4. If the error recurs, replace the failing DIMM (dual in-line memory module)
+   and run a memory test
+   (for example, ``memtest86``) before returning the host to service.
+
+``IpmiUnrecoverableCpuError``
+=============================
+
+This alert fires when the IPMI (Intelligent Platform Management Interface)
+exporter reports a recent ``unrecoverable_cpu_error`` SEL (System Event Log)
+event. These events
+indicate a fatal CPU error that typically requires hardware
+intervention and may precede a crash.
+
+**Likely root causes**
+
+- Failing CPU or socket
+- Hardware instability due to power or thermal issues
+- Firmware or microcode issues
+
+**Diagnostic and remediation steps**
+
+1. Identify the affected host from the alert ``instance`` label.
+
+2. Check the SEL (System Event Log) on the host for CPU errors:
+
+   .. code-block:: console
+
+     ipmitool sel list | grep -i -e "processor" -e "err"
+
+3. Review system logs for machine check or CPU errors:
+
+   .. code-block:: console
+
+     journalctl -k | grep -i -e mce -e machine -e cpu
+
+4. Check CPU temperatures and system health:
+
+   .. code-block:: console
+
+     ipmitool sdr type temperature
+     ipmitool sdr type processor
+
+5. If the error recurs, schedule hardware maintenance and replace the
+   affected CPU or motherboard as needed.
+
 ``MySQLGaleraOutOfSync``
 ========================
 

--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -559,14 +559,14 @@ for a 99.9% SLO. At this rate, the 30-day error budget exhausts in under
 5 days. It uses multi-window burn-rate detection with 6-hour and 30-minute
 windows.
 
-**Likely Root Causes**
+**Likely root causes**
 
 - Intermittent upstream DNS server issues
 - Partial network connectivity problems
 - DNS zone transfer failures
 - Upstream rate limiting
 
-**Diagnostic and Remediation Steps**
+**Diagnostic and remediation steps**
 
 1. Check CoreDNS logs for recurring errors:
 
@@ -602,14 +602,14 @@ for a 99.9% SLO. At this rate, the error budget exhausts before the 30-day
 window resets. It uses multi-window burn-rate detection with 3-day and 6-hour
 windows.
 
-**Likely Root Causes**
+**Likely root causes**
 
 - Chronic low-level DNS resolution failures
 - Specific zones or domains consistently failing
 - Degraded upstream DNS server performance
 - Incorrectly configured DNS records causing intermittent failures
 
-**Diagnostic and Remediation Steps**
+**Diagnostic and remediation steps**
 
 1. Identify which DNS queries are failing:
 
@@ -917,13 +917,13 @@ exporter reports a recent ``uncorrectable_memory_error`` System Event Log
 indicate a non-recoverable memory error on the host and often require
 hardware intervention.
 
-**Likely root causes**
+**Likely Root Causes**
 
 - Failing dual in-line memory module (DIMM) or memory controller
 - Unstable firmware or Basic Input/Output System (BIOS) configuration
 - Recent hardware changes or maintenance introducing faulty memory
 
-**Diagnostic and remediation steps**
+**Diagnostic and Remediation Steps**
 
 1. Identify the affected host from the alert ``instance`` label.
 
@@ -952,13 +952,13 @@ event. These events
 indicate a fatal CPU error that typically requires hardware
 intervention and may precede a crash.
 
-**Likely root causes**
+**Likely Root Causes**
 
 - Failing CPU or socket
 - Hardware instability due to power or thermal issues
 - Firmware or microcode issues
 
-**Diagnostic and remediation steps**
+**Diagnostic and Remediation Steps**
 
 1. Identify the affected host from the alert ``instance`` label.
 

--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -559,14 +559,14 @@ for a 99.9% SLO. At this rate, the 30-day error budget exhausts in under
 5 days. It uses multi-window burn-rate detection with 6-hour and 30-minute
 windows.
 
-**Likely root causes**
+**Likely Root Causes**
 
 - Intermittent upstream DNS server issues
 - Partial network connectivity problems
 - DNS zone transfer failures
 - Upstream rate limiting
 
-**Diagnostic and remediation steps**
+**Diagnostic and Remediation Steps**
 
 1. Check CoreDNS logs for recurring errors:
 
@@ -602,14 +602,14 @@ for a 99.9% SLO. At this rate, the error budget exhausts before the 30-day
 window resets. It uses multi-window burn-rate detection with 3-day and 6-hour
 windows.
 
-**Likely root causes**
+**Likely Root Causes**
 
 - Chronic low-level DNS resolution failures
 - Specific zones or domains consistently failing
 - Degraded upstream DNS server performance
 - Incorrectly configured DNS records causing intermittent failures
 
-**Diagnostic and remediation steps**
+**Diagnostic and Remediation Steps**
 
 1. Identify which DNS queries are failing:
 

--- a/releasenotes/notes/ipmi-sel-alerts-2026022757713d47.yaml
+++ b/releasenotes/notes/ipmi-sel-alerts-2026022757713d47.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add IPMI SEL-based P1 alerts for uncorrectable memory and unrecoverable CPU
+    errors using the latest SEL event timestamp, and update the monitoring
+    documentation and tests accordingly.

--- a/roles/ipmi_exporter/defaults/main.yml
+++ b/roles/ipmi_exporter/defaults/main.yml
@@ -17,7 +17,7 @@
 ipmi_exporter_config:
   modules:
     default:
-      collectors: ["bmc", "ipmi", "chassis", "sel"]
+      collectors: ["bmc", "ipmi", "chassis", "sel", "sel-events"]
       exclude_sensor_ids:
         - 42
         - 45 # Entity Presence (Dell PowerEdge servers)
@@ -45,5 +45,10 @@ ipmi_exporter_config:
       custom_args:
         ipmi:
           - "--entity-sensor-names"
+      sel_events:
+        - name: uncorrectable_memory_error
+          regex: Uncorrectable memory error
+        - name: unrecoverable_cpu_error
+          regex: IERR
 
                                                                    # ]]]

--- a/roles/kube_prometheus_stack/files/jsonnet/legacy.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/legacy.libsonnet
@@ -109,6 +109,37 @@
             },
           ],
         },
+        {
+          name: 'ipmi-exporter-sel',
+          rules: [
+            {
+              alert: 'IpmiUncorrectableMemoryError',
+              expr: 'time() - max by (instance) (ipmi_sel_events_latest_timestamp{name="uncorrectable_memory_error"}) < 86400',
+              'for': '2m',
+              labels: {
+                severity: 'P1',
+              },
+              annotations: {
+                summary: 'IPMI: uncorrectable memory error on {{ $labels.instance }}',
+                description: 'The latest IPMI SEL event ipmi_sel_events_latest_timestamp{name="uncorrectable_memory_error"} on {{ $labels.instance }} is {{ $value | humanizeDuration }} old (threshold: 24h).',
+                runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#ipmiuncorrectablememoryerror',
+              },
+            },
+            {
+              alert: 'IpmiUnrecoverableCpuError',
+              expr: 'time() - max by (instance) (ipmi_sel_events_latest_timestamp{name="unrecoverable_cpu_error"}) < 86400',
+              'for': '2m',
+              labels: {
+                severity: 'P1',
+              },
+              annotations: {
+                summary: 'IPMI: unrecoverable CPU error on {{ $labels.instance }}',
+                description: 'The latest IPMI SEL event ipmi_sel_events_latest_timestamp{name="unrecoverable_cpu_error"} on {{ $labels.instance }} is {{ $value | humanizeDuration }} old (threshold: 24h).',
+                runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#ipmiunrecoverablecpuerror',
+              },
+            },
+          ],
+        },
       ],
     },
   },

--- a/roles/kube_prometheus_stack/files/jsonnet/legacy.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/legacy.libsonnet
@@ -120,8 +120,8 @@
                 severity: 'P1',
               },
               annotations: {
-                summary: 'IPMI: uncorrectable memory error on {{ $labels.instance }}',
-                description: 'The latest IPMI SEL event ipmi_sel_events_latest_timestamp{name="uncorrectable_memory_error"} on {{ $labels.instance }} is {{ $value | humanizeDuration }} old (threshold: 24h).',
+                summary: 'IPMI: recent uncorrectable memory error may affect host stability on {{ $labels.instance }}',
+                description: 'The metric ipmi_sel_events_latest_timestamp{name="uncorrectable_memory_error"} for {{ $labels.instance }} indicates the most recent uncorrectable memory SEL event is {{ $value | humanizeDuration }} old, which is within the alert window of 24 hours. Normal behavior is that no uncorrectable memory SEL events occur, or the latest such event is older than 24 hours.',
                 runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#ipmiuncorrectablememoryerror',
               },
             },
@@ -133,8 +133,8 @@
                 severity: 'P1',
               },
               annotations: {
-                summary: 'IPMI: unrecoverable CPU error on {{ $labels.instance }}',
-                description: 'The latest IPMI SEL event ipmi_sel_events_latest_timestamp{name="unrecoverable_cpu_error"} on {{ $labels.instance }} is {{ $value | humanizeDuration }} old (threshold: 24h).',
+                summary: 'IPMI: recent unrecoverable CPU error may affect host stability on {{ $labels.instance }}',
+                description: 'The metric ipmi_sel_events_latest_timestamp{name="unrecoverable_cpu_error"} for {{ $labels.instance }} indicates the most recent unrecoverable CPU SEL event is {{ $value | humanizeDuration }} old, which is within the alert window of 24 hours. Normal behavior is that no unrecoverable CPU SEL events occur, or the latest such event is older than 24 hours.',
                 runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#ipmiunrecoverablecpuerror',
               },
             },

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -251,8 +251,8 @@ tests:
               instance: 192.0.2.10
               severity: P1
             exp_annotations:
-              summary: "IPMI: uncorrectable memory error on 192.0.2.10"
-              description: "The latest IPMI SEL event ipmi_sel_events_latest_timestamp{name=\"uncorrectable_memory_error\"} on 192.0.2.10 is 1m 0s old (threshold: 24h)."
+              summary: "IPMI: recent uncorrectable memory error may affect host stability on 192.0.2.10"
+              description: "The metric ipmi_sel_events_latest_timestamp{name=\"uncorrectable_memory_error\"} for 192.0.2.10 indicates the most recent uncorrectable memory SEL event is 1m 0s old, which is within the alert window of 24 hours. Normal behavior is that no uncorrectable memory SEL events occur, or the latest such event is older than 24 hours."
               runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#ipmiuncorrectablememoryerror"
 
   - interval: 1m
@@ -276,8 +276,8 @@ tests:
               instance: 192.0.2.11
               severity: P1
             exp_annotations:
-              summary: "IPMI: unrecoverable CPU error on 192.0.2.11"
-              description: "The latest IPMI SEL event ipmi_sel_events_latest_timestamp{name=\"unrecoverable_cpu_error\"} on 192.0.2.11 is 1m 0s old (threshold: 24h)."
+              summary: "IPMI: recent unrecoverable CPU error may affect host stability on 192.0.2.11"
+              description: "The metric ipmi_sel_events_latest_timestamp{name=\"unrecoverable_cpu_error\"} for 192.0.2.11 indicates the most recent unrecoverable CPU SEL event is 1m 0s old, which is within the alert window of 24 hours. Normal behavior is that no unrecoverable CPU SEL events occur, or the latest such event is older than 24 hours."
               runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#ipmiunrecoverablecpuerror"
 
   - interval: 1m

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -232,6 +232,56 @@ tests:
 
   - interval: 1m
     input_series:
+      - series: 'ipmi_sel_events_latest_timestamp{instance="192.0.2.10",name="uncorrectable_memory_error"}'
+        values: '0x2880'
+    alert_rule_test:
+      - eval_time: 2d
+        alertname: IpmiUncorrectableMemoryError
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_latest_timestamp{instance="192.0.2.10",name="uncorrectable_memory_error"}'
+        values: '172740x2880'
+    alert_rule_test:
+      - eval_time: 2d
+        alertname: IpmiUncorrectableMemoryError
+        exp_alerts:
+          - exp_labels:
+              instance: 192.0.2.10
+              severity: P1
+            exp_annotations:
+              summary: "IPMI: uncorrectable memory error on 192.0.2.10"
+              description: "The latest IPMI SEL event ipmi_sel_events_latest_timestamp{name=\"uncorrectable_memory_error\"} on 192.0.2.10 is 1m 0s old (threshold: 24h)."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#ipmiuncorrectablememoryerror"
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_latest_timestamp{instance="192.0.2.11",name="unrecoverable_cpu_error"}'
+        values: '0x2880'
+    alert_rule_test:
+      - eval_time: 2d
+        alertname: IpmiUnrecoverableCpuError
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_latest_timestamp{instance="192.0.2.11",name="unrecoverable_cpu_error"}'
+        values: '172740x2880'
+    alert_rule_test:
+      - eval_time: 2d
+        alertname: IpmiUnrecoverableCpuError
+        exp_alerts:
+          - exp_labels:
+              instance: 192.0.2.11
+              severity: P1
+            exp_annotations:
+              summary: "IPMI: unrecoverable CPU error on 192.0.2.11"
+              description: "The latest IPMI SEL event ipmi_sel_events_latest_timestamp{name=\"unrecoverable_cpu_error\"} on 192.0.2.11 is 1m 0s old (threshold: 24h)."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#ipmiunrecoverablecpuerror"
+
+  - interval: 1m
+    input_series:
       - series: 'openstack_loadbalancer_loadbalancer_status{id="d4e449ad-fad5-4d9e-a039-f71c773ec999", job="openstack-exporter", name="test-lb", operating_status="ONLINE", provisioning_status="PENDING_UPDATE"}'
         values: '0x15'
       - series: 'openstack_loadbalancer_loadbalancer_status{id="25dcf79f-b09d-4d0c-9e29-b69ded2ec734", job="openstack-exporter", name="test-lb-2", operating_status="ONLINE", provisioning_status="ACTIVE"}'


### PR DESCRIPTION
**Add IPMI SEL alerts for memory and CPU errors**

- Add SEL event matchers for uncorrectable memory and CPU errors.
- Create P1 alerts for those SEL conditions.
- Add alert tests and documentation entries.