### PR TITLE
fix(glance): update paste config to deploy healthcheck as app

### DIFF
--- a/charts/glance/values.yaml
+++ b/charts/glance/values.yaml
@@ -128,35 +128,48 @@ conf:
     override:
     append:
   paste:
-    pipeline:glance-api:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context rootapp
-    pipeline:glance-api-caching:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context cache rootapp
-    pipeline:glance-api-cachemanagement:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context cache cachemanage rootapp
-    pipeline:glance-api-keystone:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context  rootapp
-    pipeline:glance-api-keystone+caching:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context cache rootapp
-    pipeline:glance-api-keystone+cachemanagement:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context cache cachemanage rootapp
-    pipeline:glance-api-trusted-auth:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler context rootapp
-    pipeline:glance-api-trusted-auth+cachemanagement:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler context cache cachemanage rootapp
+    composite:glance-api:
+      paste.composite_factory: glance.api:root_app_factory
+      /: api
+      /healthcheck: healthcheck
+    composite:glance-api-caching:
+      paste.composite_factory: glance.api:root_app_factory
+      /: api
+      /healthcheck: healthcheck
+    composite:glance-api-cachemanagement:
+      paste.composite_factory: glance.api:root_app_factory
+      /: api
+      /healthcheck: healthcheck
+    composite:glance-api-keystone:
+      paste.composite_factory: glance.api:root_app_factory
+      /: api
+      /healthcheck: healthcheck
+    composite:glance-api-keystone+caching:
+      paste.composite_factory: glance.api:root_app_factory
+      /: api
+      /healthcheck: healthcheck
+    composite:glance-api-keystone+cachemanagement:
+      paste.composite_factory: glance.api:root_app_factory
+      /: api
+      /healthcheck: healthcheck
+    composite:api:
+      paste.composite_factory: glance.api:pipeline_factory
+      default: cors http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context rootapp
+      caching: cors http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context cache rootapp
+      cachemanagement: cors http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context cache cachemanage rootapp
+      keystone: cors http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context rootapp
+      keystone+caching: cors http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context cache rootapp
+      keystone+cachemanagement: cors http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context cache cachemanage rootapp
     composite:rootapp:
       paste.composite_factory: glance.api:root_app_factory
       /: apiversions
-      /v1: apiv1app
       /v2: apiv2app
     app:apiversions:
       paste.app_factory: glance.api.versions:create_resource
-    app:apiv1app:
-      paste.app_factory: glance.api.v1.router:API.factory
     app:apiv2app:
       paste.app_factory: glance.api.v2.router:API.factory
-    filter:healthcheck:
-      paste.filter_factory: oslo_middleware:Healthcheck.factory
+    app:healthcheck:
+      paste.app_factory: oslo_middleware:Healthcheck.app_factory
       backends: disable_by_file
       disable_by_file_path: /etc/glance/healthcheck_disable
     filter:versionnegotiation:

--- a/charts/patches/glance/0003-update-paste-config-healthcheck-as-app.patch
+++ b/charts/patches/glance/0003-update-paste-config-healthcheck-as-app.patch
@@ -1,0 +1,74 @@
+diff --git a/glance/values.yaml b/glance/values.yaml
+index af3d7cd8..1f477af1 100644
+--- a/glance/values.yaml
++++ b/glance/values.yaml
+@@ -128,35 +128,48 @@ conf:
+     override:
+     append:
+   paste:
+-    pipeline:glance-api:
+-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context rootapp
+-    pipeline:glance-api-caching:
+-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context cache rootapp
+-    pipeline:glance-api-cachemanagement:
+-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context cache cachemanage rootapp
+-    pipeline:glance-api-keystone:
+-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context  rootapp
+-    pipeline:glance-api-keystone+caching:
+-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context cache rootapp
+-    pipeline:glance-api-keystone+cachemanagement:
+-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context cache cachemanage rootapp
+-    pipeline:glance-api-trusted-auth:
+-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler context rootapp
+-    pipeline:glance-api-trusted-auth+cachemanagement:
+-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler context cache cachemanage rootapp
++    composite:glance-api:
++      paste.composite_factory: glance.api:root_app_factory
++      /: api
++      /healthcheck: healthcheck
++    composite:glance-api-caching:
++      paste.composite_factory: glance.api:root_app_factory
++      /: api
++      /healthcheck: healthcheck
++    composite:glance-api-cachemanagement:
++      paste.composite_factory: glance.api:root_app_factory
++      /: api
++      /healthcheck: healthcheck
++    composite:glance-api-keystone:
++      paste.composite_factory: glance.api:root_app_factory
++      /: api
++      /healthcheck: healthcheck
++    composite:glance-api-keystone+caching:
++      paste.composite_factory: glance.api:root_app_factory
++      /: api
++      /healthcheck: healthcheck
++    composite:glance-api-keystone+cachemanagement:
++      paste.composite_factory: glance.api:root_app_factory
++      /: api
++      /healthcheck: healthcheck
++    composite:api:
++      paste.composite_factory: glance.api:pipeline_factory
++      default: cors http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context rootapp
++      caching: cors http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context cache rootapp
++      cachemanagement: cors http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context cache cachemanage rootapp
++      keystone: cors http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context rootapp
++      keystone+caching: cors http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context cache rootapp
++      keystone+cachemanagement: cors http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context cache cachemanage rootapp
+     composite:rootapp:
+       paste.composite_factory: glance.api:root_app_factory
+       /: apiversions
+-      /v1: apiv1app
+       /v2: apiv2app
+     app:apiversions:
+       paste.app_factory: glance.api.versions:create_resource
+-    app:apiv1app:
+-      paste.app_factory: glance.api.v1.router:API.factory
+     app:apiv2app:
+       paste.app_factory: glance.api.v2.router:API.factory
+-    filter:healthcheck:
+-      paste.filter_factory: oslo_middleware:Healthcheck.factory
++    app:healthcheck:
++      paste.app_factory: oslo_middleware:Healthcheck.app_factory
+       backends: disable_by_file
+       disable_by_file_path: /etc/glance/healthcheck_disable
+     filter:versionnegotiation:

--- a/releasenotes/notes/fix-glance-healthcheck-paste-config-4e545b5bcc9a12c9.yaml
+++ b/releasenotes/notes/fix-glance-healthcheck-paste-config-4e545b5bcc9a12c9.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    The Glance API paste configuration now deploys the health check
+    as a standalone app with path-based routing instead of an inline
+    pipeline filter. This fixes a boot failure caused by newer versions
+    of ``oslo.middleware`` that require ``HealthcheckMiddleware`` to run
+    as an app.


### PR DESCRIPTION
## Problem

Newer versions of `oslo.middleware` require `HealthcheckMiddleware` to be deployed as an app, not a filter. This causes Glance API to crash on boot with:

```
NotImplementedError: HealthcheckMiddleware should be deployed as an app, not a filter
```

See: https://logs.oss.vexxhost.dev/825/oss/825e2361415e4e3a97869a0b0850c72a/instance/pod-logs/openstack/glance-api-6f8bb4f4d7-7s4tb/glance-api.txt

## Fix

Updates the Glance API paste configuration to match the [upstream glance-api-paste.ini](https://github.com/openstack/glance/blob/master/etc/glance-api-paste.ini):

- Convert `pipeline:glance-api-*` sections to `composite:glance-api-*` with route-based dispatch to `/healthcheck`
- Add `composite:api` section with the actual pipeline definitions
- Change `filter:healthcheck` to `app:healthcheck` using `paste.app_factory`
- Remove `healthcheck` from pipeline filter chains
- Remove deprecated v1 API references