### PR TITLE
docs: add no-animal-violence Vale package for inclusive language checking

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,7 +1,7 @@
 StylesPath = .github/styles
 MinAlertLevel = suggestion
-Packages = Microsoft
+Packages = Microsoft, https://github.com/Open-Paws/vale-no-animal-violence/releases/latest/download/NoAnimalViolence.zip
 Vocab = Base
 
 [*.{rst,yaml}]
-BasedOnStyles = Vale, Microsoft
+BasedOnStyles = Vale, Microsoft, NoAnimalViolence


### PR DESCRIPTION
Adds the [no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) Vale package to the existing Vale configuration.

Atmosphere already uses the `Microsoft` Vale package. The `NoAnimalViolence` package extends this by flagging phrases that normalize violence toward animals and suggesting clearer technical alternatives:

- "cattle vs. pets" → "ephemeral vs. persistent"
- "canary deployment" → "progressive rollout"
- "kill two birds with one stone" → "accomplish two things at once"
- "guinea pig" → "test subject"

Particularly relevant for infrastructure documentation where cattle/pets, canary, and similar idioms are common.

**Package source**: https://github.com/Open-Paws/vale-no-animal-violence

**Change**: `.vale.ini` — add `NoAnimalViolence` to `Packages` and `BasedOnStyles`