### PR TITLE
feat(monitoring): replace NodeDiskIOSaturation with NodeDiskHighLatency

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -24,6 +24,7 @@ Glance
 Goldpinger
 Grafana
 HBA
+HDD
 ICMP
 JWT
 Keycloak
@@ -47,6 +48,7 @@ Percona
 PowerStore
 Pure
 QEMU
+RAID
 RBAC
 RBD
 READY
@@ -54,7 +56,9 @@ RGW
 RPC
 RabbitMQ
 SLOs?
+SMART
 SQLAlchemy
+SSD
 SST
 Staffeln
 StorPool

--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -968,6 +968,61 @@ the risk of a full outage if another node fails.
 
      kubectl -n openstack get pxc-backup
 
+``NodeDiskHighLatency``
+=======================
+
+This alert fires when the average IO latency on a disk device exceeds 20ms for
+at least 1 hour. It measures the time the kernel spends servicing reads and
+writes divided by the number of completed operations, which represents the
+true per-operation latency at the block device layer.
+
+**Likely root causes:**
+
+- Failing or degraded SSD or HDD (wear-out, bad sectors, firmware issues)
+- RAID array running in degraded mode after a disk failure
+- Storage controller problems
+- Severely overloaded storage subsystem (too many concurrent IO operations)
+- Incorrect IO scheduler for the workload type
+
+**Diagnostic and remediation steps:**
+
+1. Identify the affected host and device from the alert labels (``instance``
+   and ``device``).
+
+2. Check the current IO latency and throughput on the affected device:
+
+   .. code-block:: console
+
+      iostat -xz 1 5
+
+3. Check for disk errors in the kernel log:
+
+   .. code-block:: console
+
+      dmesg | grep -i -E "error|fault|reset|i/o" | tail -30
+
+4. If the device is part of a RAID array, check the array status:
+
+   .. code-block:: console
+
+      cat /proc/mdstat
+
+5. Check the SMART health status of the underlying drives:
+
+   .. code-block:: console
+
+      smartctl -a /dev/<device>
+
+6. Review whether the host is under unusual IO load:
+
+   .. code-block:: console
+
+      iotop -aoP
+
+7. If the disk shows degradation or failure, plan a replacement. For RAID arrays,
+   replace the failed member. For standalone disks, migrate workloads before
+   the disk fails completely.
+
 ``NginxIngressCriticalErrorBudgetBurn``
 =======================================
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
 [tools]
 "pipx:reno" = "latest"
+promtool = "latest"
 "uv" = "latest"
 "vale" = "latest"

--- a/releasenotes/notes/replace-nodediskiosaturation-with-latency-alert-6ee75c5fd4c20087.yaml
+++ b/releasenotes/notes/replace-nodediskiosaturation-with-latency-alert-6ee75c5fd4c20087.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    The ``NodeDiskHighLatency`` alert replaces ``NodeDiskIOSaturation``.
+    The old alert measured disk queue depth, which produces false positives
+    on SSD and RAID devices. The new alert measures actual per-operation IO
+    latency with a threshold of 20ms sustained for 1 hour, catching genuinely
+    degraded storage without alert noise.

--- a/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
@@ -20,6 +20,10 @@ local disabledAlerts = [
   // * Dropped `MySQLDown` due to noisy alerts even
   //   the replication still more than minimum
   'MySQLDown',
+
+  // Superseded by NodeDiskHighLatency which measures actual IO latency
+  // instead of queue depth, which is misleading on SSDs and RAID arrays.
+  'NodeDiskIOSaturation',
 ];
 
 // NOTE(mnaser): This is the default mapping for severities:
@@ -202,6 +206,7 @@ local mixins = {
     (import 'vendor/github.com/prometheus/node_exporter/docs/node-mixin/mixin.libsonnet') {
       _config+:: {
         nodeExporterSelector: 'job="node-exporter"',
+        diskDeviceSelector: 'device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"',
       },
       prometheusAlerts+:: {
         groups+: [
@@ -220,6 +225,39 @@ local mixins = {
                 annotations: {
                   summary: 'Node {{ $labels.instance }} has a time difference.',
                   description: 'Node {{ $labels.instance }} has a time difference {{ $value }}.',
+                },
+              },
+              {
+                alert: 'NodeDiskHighLatency',
+                expr: |||
+                  (
+                    (
+                      rate(node_disk_read_time_seconds_total{%(nodeExporterSelector)s, %(diskDeviceSelector)s}[5m])
+                      +
+                      rate(node_disk_write_time_seconds_total{%(nodeExporterSelector)s, %(diskDeviceSelector)s}[5m])
+                    )
+                    /
+                    (
+                      rate(node_disk_reads_completed_total{%(nodeExporterSelector)s, %(diskDeviceSelector)s}[5m])
+                      +
+                      rate(node_disk_writes_completed_total{%(nodeExporterSelector)s, %(diskDeviceSelector)s}[5m])
+                    )
+                  ) > 0.02
+                  and
+                  (
+                    rate(node_disk_reads_completed_total{%(nodeExporterSelector)s, %(diskDeviceSelector)s}[5m])
+                    +
+                    rate(node_disk_writes_completed_total{%(nodeExporterSelector)s, %(diskDeviceSelector)s}[5m])
+                  ) > 0
+                ||| % mixins.node._config,
+                'for': '1h',
+                labels: {
+                  severity: 'P4',
+                },
+                annotations: {
+                  summary: 'Node disk: high IO latency affecting workloads',
+                  description: 'Average IO latency on {{ $labels.device }} at {{ $labels.instance }} is {{ $value | humanizeDuration }} over the last 5 minutes, which exceeds the threshold of 20ms. Normal SSD latency is below 1ms and normal HDD latency is below 15ms.',
+                  runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodediskhighlatency',
                 },
               },
             ],

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -106,6 +106,47 @@ tests:
         alertname: NodeTimeSkewDetected
         exp_alerts: []
 
+  # NodeDiskHighLatency - negative test (normal latency, no alert)
+  - interval: 1m
+    input_series:
+      - series: 'node_disk_read_time_seconds_total{instance="192.0.2.1:9100", job="node-exporter", device="sda"}'
+        values: '0+0.001x70'
+      - series: 'node_disk_write_time_seconds_total{instance="192.0.2.1:9100", job="node-exporter", device="sda"}'
+        values: '0+0.001x70'
+      - series: 'node_disk_reads_completed_total{instance="192.0.2.1:9100", job="node-exporter", device="sda"}'
+        values: '0+100x70'
+      - series: 'node_disk_writes_completed_total{instance="192.0.2.1:9100", job="node-exporter", device="sda"}'
+        values: '0+100x70'
+    alert_rule_test:
+      - eval_time: 65m
+        alertname: NodeDiskHighLatency
+        exp_alerts: []
+
+  # NodeDiskHighLatency - positive test (high latency, alert fires)
+  - interval: 1m
+    input_series:
+      - series: 'node_disk_read_time_seconds_total{instance="192.0.2.2:9100", job="node-exporter", device="nvme0n1"}'
+        values: '0+5x70'
+      - series: 'node_disk_write_time_seconds_total{instance="192.0.2.2:9100", job="node-exporter", device="nvme0n1"}'
+        values: '0+5x70'
+      - series: 'node_disk_reads_completed_total{instance="192.0.2.2:9100", job="node-exporter", device="nvme0n1"}'
+        values: '0+100x70'
+      - series: 'node_disk_writes_completed_total{instance="192.0.2.2:9100", job="node-exporter", device="nvme0n1"}'
+        values: '0+100x70'
+    alert_rule_test:
+      - eval_time: 65m
+        alertname: NodeDiskHighLatency
+        exp_alerts:
+          - exp_labels:
+              severity: P4
+              instance: "192.0.2.2:9100"
+              job: node-exporter
+              device: nvme0n1
+            exp_annotations:
+              summary: "Node disk: high IO latency affecting workloads"
+              description: "Average IO latency on nvme0n1 at 192.0.2.2:9100 is 50ms over the last 5 minutes, which exceeds the threshold of 20ms. Normal SSD latency is below 1ms and normal HDD latency is below 15ms."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodediskhighlatency"
+
   - interval: 1m
     input_series:
       - series: 'mysql_up{instance="percona-xtradb-pxc-0", job="pxc"}'


### PR DESCRIPTION
## Summary

Replace the noisy `NodeDiskIOSaturation` alert with `NodeDiskHighLatency`.

### Problem

`NodeDiskIOSaturation` measures disk queue depth (`avgqu-sz > 10`), a threshold designed for single spinning HDDs. On modern SSDs and RAID arrays, queue depths of 10-20 are completely normal. This caused **41 false alerts in 7 days**, all auto-resolving with no action taken — textbook alert fatigue.

### Solution

`NodeDiskHighLatency` measures actual per-operation IO latency:
- **Metric**: `(read_time + write_time) / (reads_completed + writes_completed)`
- **Threshold**: 20ms sustained for 1 hour (P4)
- **Device filter**: Uses the same specific device regex as the upstream chart

### Validation

- Tested against live Prometheus on customer env: the worst offender (kvm12/md1) had 94 separate latency spikes >20ms over 7 days, but the longest sustained run was only 20 minutes — the `for: 1h` correctly filters all transient bursts
- Would have produced **zero** false alerts vs the old alert's **41**
- Both positive and negative promtool tests pass

### Changes

- Disable `NodeDiskIOSaturation` in the mixin `disabledAlerts` list
- Add `NodeDiskHighLatency` alert in `node-exporter-extras` group
- Override `diskDeviceSelector` to match the upstream chart's device regex
- Add negative and positive test cases in `tests.yml`
- Add runbook entry in `monitoring.rst`
- Add HDD, RAID, SMART, SSD to Vale vocabulary
- Add release note