### PR TITLE
feat(ipmi_exporter): upgrade to v1.10.1 with entity sensor names

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -26,6 +26,7 @@ Grafana
 HBA
 HDD
 ICMP
+IPMI
 JWT
 Keycloak
 Kubernetes

--- a/releasenotes/notes/ipmi-exporter-entity-sensor-names-392f30b9d191b70a.yaml
+++ b/releasenotes/notes/ipmi-exporter-entity-sensor-names-392f30b9d191b70a.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    Bump the IPMI exporter from v1.4.0 to v1.10.1 and enable the
+    ``--entity-sensor-names`` flag. IPMI sensor metrics now include
+    descriptive entity names (for example, ``Add-in Card 3 Presence``
+    instead of ``Presence``), making alerts easier to diagnose.
+upgrade:
+  - |
+    IPMI sensor ``name`` labels in Prometheus now include entity prefixes
+    (for example, ``Add-in Card 3 Presence`` instead of ``Presence``).
+    Any custom alert rules or dashboards that match on the old ``name``
+    values need updating.

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -207,7 +207,7 @@ _atmosphere_images:
   placement: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/placement:main@sha256:ae9d401c35c837d9c7dc3b0dbbe1b183545949eefb9c3b594ba08084c2cf85ca"
   pod_tls_sidecar: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/pod-tls-sidecar:v1.0.0"
   prometheus_config_reloader: "{{ atmosphere_image_prefix }}quay.io/prometheus-operator/prometheus-config-reloader:v0.73.0"
-  prometheus_ipmi_exporter: "{{ atmosphere_image_prefix }}us-docker.pkg.dev/vexxhost-infra/openstack/ipmi-exporter:1.4.0"
+  prometheus_ipmi_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheuscommunity/ipmi-exporter:v1.10.1@sha256:0662cadaf268b6718f0f66429047cb23566ab3e4c175f25eaf588416a7b035e8"
   prometheus_memcached_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/memcached-exporter:v0.14.3"
   prometheus_mysqld_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/mysqld-exporter:v0.17.0"
   prometheus_node_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/node-exporter:v1.8.1"

--- a/roles/ipmi_exporter/defaults/main.yml
+++ b/roles/ipmi_exporter/defaults/main.yml
@@ -42,5 +42,8 @@ ipmi_exporter_config:
         - 180 # TPM Presence (Dell PowerEdge servers)
         - 182 # Entity Presence (Dell PowerEdge servers)
         - 185 # Entity Presence (Dell PowerEdge servers)
+      custom_args:
+        ipmi:
+          - "--entity-sensor-names"
 
                                                                    # ]]]

--- a/roles/ipmi_exporter/tasks/main.yml
+++ b/roles/ipmi_exporter/tasks/main.yml
@@ -24,7 +24,7 @@
           labels:
             application: ipmi-exporter
         data:
-          config.yml: "{{ ipmi_exporter_config | to_yaml }}"
+          config.yml: "{{ ipmi_exporter_config | to_nice_yaml(indent=2) }}"
 
       - apiVersion: apps/v1
         kind: DaemonSet
@@ -40,19 +40,23 @@
           template:
             metadata:
               annotations:
-                config-hash: "{{ ipmi_exporter_config | to_yaml | hash('md5') }}"
+                config-hash: "{{ ipmi_exporter_config | to_nice_yaml(indent=2) | hash('md5') }}"
               labels:
                 application: ipmi-exporter
                 job: ipmi
             spec:
               containers:
                 - name: exporter
+                  args:
+                    - --config.file=/config.yml
                   image: "{{ atmosphere_images['prometheus_ipmi_exporter'] | vexxhost.kubernetes.docker_image('ref') }}"
                   ports:
                     - name: metrics
                       containerPort: 9290
                   securityContext:
                     privileged: true
+                    runAsUser: 0
+                    runAsGroup: 0
                   volumeMounts:
                     - name: dev-ipmi0
                       mountPath: /dev/ipmi0


### PR DESCRIPTION
Upgrades the IPMI exporter from v1.4.0 to v1.10.1 using the upstream `quay.io/prometheuscommunity/ipmi-exporter` image and enables `--entity-sensor-names` so IPMI sensor metrics include descriptive entity names (e.g. `Add-in Card 3 Presence` instead of `Presence`), making alerts significantly easier to diagnose.

## Changes

- Bump image to `quay.io/prometheuscommunity/ipmi-exporter:v1.10.1`
- Add `--entity-sensor-names` to `custom_args` for the ipmi collector
- Add explicit `--config.file=/config.yml` arg (required by new image)
- Add `runAsUser: 0` / `runAsGroup: 0` (new image defaults to non-root)
- Use `to_nice_yaml(indent=2)` for cleaner ConfigMap output
- Add `IPMI` to vale vocabulary

## Testing

Tested live on customer cluster:
- All 25 IPMI exporter pods running with v1.10.1
- Sensor names now include entity prefixes in Prometheus metrics
- New alerts firing with descriptive labels

## Related

- #3697 (SEL-based alerts, same image bump)