### PR TITLE
fix(ipmi): exclude Entity Presence sensors from IpmiSensor alerts

### DIFF
--- a/releasenotes/notes/fix-ipmi-exclude-presence-alerts-b3722aff036b365d.yaml
+++ b/releasenotes/notes/fix-ipmi-exclude-presence-alerts-b3722aff036b365d.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Exclude all Entity Presence sensors (for example, ``Add-in Card X Presence``,
+    ``BP0 Presence``) from ``IpmiSensor`` alert rules. These sensors report
+    ``Entity Absent`` on intentionally empty expansion slots and other
+    unpopulated hardware positions, causing false positive alerts across
+    the fleet.

--- a/roles/kube_prometheus_stack/files/jsonnet/legacy.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/legacy.libsonnet
@@ -41,7 +41,7 @@
             },
             {
               alert: 'IpmiSensor',
-              expr: 'ipmi_sensor_state == 1',
+              expr: 'ipmi_sensor_state{name!~".*Presence.*"} == 1',
               labels: {
                 severity: 'warning',
               },
@@ -88,7 +88,7 @@
             },
             {
               alert: 'IpmiSensor',
-              expr: 'ipmi_sensor_state{name!="TPM Presence"} == 2',
+              expr: 'ipmi_sensor_state{name!~".*Presence.*"} == 2',
               labels: {
                 severity: 'critical',
               },


### PR DESCRIPTION
## Problem

The `IpmiSensor` alert fires false positives for Entity Presence sensors (e.g. `Add-in Card 4 Presence`) on servers with intentionally empty PCIe slots. These sensors report `Entity Absent` which is expected behavior, not a hardware issue.

The previous approach had two issues:
- The **warning** rule had **no filtering at all** (`ipmi_sensor_state == 1`)
- The **critical** rule only excluded `TPM Presence` by exact name match (`name!="TPM Presence"`)

This meant every server with an empty PCIe slot, missing backplane, or other unpopulated hardware position would generate a false alert.

## Fix

Exclude **all** sensors with `Presence` in their name from both warning and critical `IpmiSensor` alert rules using a regex match:

```
```

This is a fleet-wide fix that works across different server models (Dell, Supermicro, etc.) without needing to maintain per-host sensor ID exclusion lists.

## Affected sensors (examples)
- `Add-in Card X Presence` — empty PCIe slots
- `BP0 Presence` / `BP1 Presence` — backplane presence
- `TPM Presence` — TPM module (previously excluded only on critical)
- `Dedicated NIC` / other Entity Presence sensors