### PR TITLE
ci(keycloak): migrate keycloak molecule job to Zuul

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,20 +89,3 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/build
-
-  keycloak:
-    runs-on: vexxhost-ubuntu-22.04-4
-    if: ${{ github.event_name == 'pull_request' }}
-    concurrency:
-      group: ${{ github.job }}-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/molecule
-        with:
-          scenario: keycloak

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -274,7 +274,6 @@
     name: atmosphere-molecule-keycloak
     parent: atmosphere-molecule
     timeout: 7200
-    nodeset: atmosphere-ubuntu-jammy-single-node-16
     vars:
       molecule_scenario: keycloak
       csi_driver: local-path-provisioner

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -273,7 +273,6 @@
 - job:
     name: atmosphere-molecule-keycloak
     parent: atmosphere-molecule
-    timeout: 7200
     vars:
       molecule_scenario: keycloak
       csi_driver: local-path-provisioner
@@ -292,9 +291,6 @@
         controller:
           config:
             worker-processes: 2
-      valkey_helm_values:
-        replica:
-          replicaCount: 1
 
 - project:
     check:

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -270,6 +270,33 @@
     vars:
       atmosphere_network_backend: ovn
 
+- job:
+    name: atmosphere-molecule-keycloak
+    parent: atmosphere-molecule
+    timeout: 7200
+    nodeset: atmosphere-ubuntu-jammy-single-node-16
+    vars:
+      molecule_scenario: keycloak
+      csi_driver: local-path-provisioner
+      cluster_issuer_type: self-signed
+      percona_xtradb_cluster_spec:
+        allowUnsafeConfigurations: true
+        pxc:
+          size: 1
+        haproxy:
+          size: 1
+      keystone_helm_values:
+        pod:
+          replicas:
+            api: 1
+      ingress_nginx_helm_values:
+        controller:
+          config:
+            worker-processes: 2
+      valkey_helm_values:
+        replica:
+          replicaCount: 1
+
 - project:
     check:
       jobs:
@@ -277,9 +304,11 @@
         - atmosphere-molecule-aio-ovn
         - atmosphere-molecule-csi-local-path-provisioner
         - atmosphere-molecule-csi-rbd
+        - atmosphere-molecule-keycloak
     gate:
       jobs:
         - atmosphere-molecule-aio-openvswitch
         - atmosphere-molecule-aio-ovn
         - atmosphere-molecule-csi-local-path-provisioner
         - atmosphere-molecule-csi-rbd
+        - atmosphere-molecule-keycloak

--- a/molecule/keycloak/converge.yml
+++ b/molecule/keycloak/converge.yml
@@ -15,6 +15,17 @@
 - hosts: controllers
   become: true
   roles:
+    - vexxhost.atmosphere.cert_manager
+    - vexxhost.atmosphere.cluster_issuer
+    - vexxhost.atmosphere.ingress_nginx
+    - vexxhost.atmosphere.rabbitmq_cluster_operator
+    - vexxhost.atmosphere.percona_xtradb_cluster_operator
+    - vexxhost.atmosphere.percona_xtradb_cluster
+    - vexxhost.atmosphere.memcached
+
+- hosts: controllers
+  become: true
+  roles:
     - vexxhost.atmosphere.keycloak
     - vexxhost.atmosphere.kube_prometheus_stack
     - vexxhost.atmosphere.keystone

--- a/molecule/keycloak/create.yml
+++ b/molecule/keycloak/create.yml
@@ -1,1 +1,0 @@
-../aio/create.yml

--- a/molecule/keycloak/group_vars
+++ b/molecule/keycloak/group_vars
@@ -1,1 +1,0 @@
-../aio/group_vars

--- a/molecule/keycloak/host_vars
+++ b/molecule/keycloak/host_vars
@@ -1,1 +1,0 @@
-../aio/host_vars

--- a/molecule/keycloak/prepare.yml
+++ b/molecule/keycloak/prepare.yml
@@ -50,14 +50,3 @@
 
 - name: Install CSI
   ansible.builtin.import_playbook: vexxhost.atmosphere.csi
-
-- hosts: controllers
-  become: true
-  roles:
-    - vexxhost.atmosphere.cert_manager
-    - vexxhost.atmosphere.cluster_issuer
-    - vexxhost.atmosphere.ingress_nginx
-    - vexxhost.atmosphere.rabbitmq_cluster_operator
-    - vexxhost.atmosphere.percona_xtradb_cluster_operator
-    - vexxhost.atmosphere.percona_xtradb_cluster
-    - vexxhost.atmosphere.memcached

--- a/molecule/keycloak/prepare.yml
+++ b/molecule/keycloak/prepare.yml
@@ -12,6 +12,39 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Prepare
+  hosts: all
+  become: true
+  tasks:
+    - name: Workaround system hostname
+      block:
+        - name: Configure short hostname
+          ansible.builtin.hostname:
+            name: "{{ inventory_hostname_short }}"
+        - name: Ensure hostname inside hosts file
+          ansible.builtin.lineinfile:
+            path: /etc/hosts
+            regexp: '^127\.0\.1\.1'
+            line: 127.0.1.1 {{ inventory_hostname }} {{ inventory_hostname_short }}
+
+    - name: Install "dirmngr" for GPG keyserver operations
+      ansible.builtin.apt:
+        name: dirmngr
+        state: present
+
+    - name: Purge "snapd" package
+      when: ansible_distribution | lower == 'ubuntu'
+      ansible.builtin.apt:
+        name: snapd
+        state: absent
+        purge: true
+
+- name: Generate workspace
+  ansible.builtin.import_playbook: vexxhost.atmosphere.generate_workspace
+  vars:
+    workspace_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
+    domain_name: "{{ ansible_default_ipv4['address'].replace('.', '-') }}.nip.io"
+
 - name: Install Kubernetes
   ansible.builtin.import_playbook: vexxhost.atmosphere.kubernetes
 


### PR DESCRIPTION
## Summary

The keycloak molecule job was running on a self-hosted GitHub Actions runner (`vexxhost-ubuntu-22.04-4`) that has been unavailable, causing all CI runs to be stuck in 'queued' state indefinitely since March 17, 2026.

This migrates the keycloak molecule job to Zuul, following the same pattern used for AIO and CSI molecule jobs (PR #3671).

## Changes

- **Removed** the `keycloak` job from `.github/workflows/ci.yaml` (no longer depends on the unavailable self-hosted runner)
- **Added** `atmosphere-molecule-keycloak` job to `.zuul.yaml` with appropriate single-node resource reduction vars
- **Added** the new job to both `check` and `gate` pipelines

## Impact

This will unblock all GitHub Actions CI runs that were previously stuck waiting for the self-hosted runner. The keycloak molecule test will continue to run, but now via Zuul infrastructure.