### PR TITLE
[backport stable/2025.2] fix(magnum): remove extra trailing newline from release note

### DIFF
--- a/releasenotes/notes/bump-magnum-cluster-api-0365-3f05b4b4d2220b6c.yaml
+++ b/releasenotes/notes/bump-magnum-cluster-api-0365-3f05b4b4d2220b6c.yaml
@@ -3,4 +3,3 @@ fixes:
   - |
     The Magnum container image now includes the Cluster API driver for
     Magnum version 0.36.5.
-


### PR DESCRIPTION
Fix trailing newline in the magnum-cluster-api 0.36.5 release note that was causing pre-commit `end-of-file-fixer` failures.