### PR TITLE
[Backport stable/zed] feat: switch to OpenStack CLI wrapper

### DIFF
--- a/playbooks/suspend_project.yml
+++ b/playbooks/suspend_project.yml
@@ -32,16 +32,13 @@
     - name: Get list of regions with compute service
       changed_when: false
       run_once: true
-      ansible.builtin.shell: |
-        set -o posix
-        source /etc/profile.d/atmosphere.sh
-        openstack endpoint list \
-          --service compute \
-          --interface public \
-          --column Region \
+      ansible.builtin.command:
+        cmd: >-
+          openstack endpoint list
+          --service compute
+          --interface public
+          --column Region
           --format value
-      args:
-        executable: /bin/bash
       environment:
         OS_CLOUD: atmosphere
       register: _regions
@@ -49,17 +46,14 @@
     - name: Get list of VMs in the project in each region
       changed_when: false
       run_once: true
-      ansible.builtin.shell: |
-        set -o posix
-        source /etc/profile.d/atmosphere.sh
-        openstack server list \
-          --no-name-lookup \
-          --project "{{ project_name }}" \
-          --status ACTIVE \
-          --column ID \
+      ansible.builtin.command:
+        cmd: >-
+          openstack server list
+          --no-name-lookup
+          --project "{{ project_name }}"
+          --status ACTIVE
+          --column ID
           --format value
-      args:
-        executable: /bin/bash
       environment:
         OS_AUTH_URL: "https://{{ openstack_helm_endpoints_keystone_api_host }}"
         OS_USERNAME: "admin-{{ openstack_helm_endpoints_region_name }}"
@@ -73,12 +67,8 @@
 
     - name: Suspend VMs in each region
       run_once: true
-      ansible.builtin.shell: |
-        set -o posix
-        source /etc/profile.d/atmosphere.sh
-        openstack server suspend {{ item.1 }}
-      args:
-        executable: /bin/bash
+      ansible.builtin.command:
+        cmd: openstack server suspend {{ item.1 }}
       environment:
         OS_AUTH_URL: "https://{{ openstack_helm_endpoints_keystone_api_host }}"
         OS_USERNAME: "admin-{{ openstack_helm_endpoints_region_name }}"

--- a/playbooks/terminate_project.yml
+++ b/playbooks/terminate_project.yml
@@ -31,16 +31,13 @@
     - name: Get list of regions with compute service
       changed_when: false
       run_once: true
-      ansible.builtin.shell: |
-        set -o posix
-        source /etc/profile.d/atmosphere.sh
-        openstack endpoint list \
-          --service compute \
-          --interface public \
-          --column Region \
+      ansible.builtin.command:
+        cmd: >-
+          openstack endpoint list
+          --service compute
+          --interface public
+          --column Region
           --format value
-      args:
-        executable: /bin/bash
       environment:
         OS_CLOUD: atmosphere
       register: _regions

--- a/releasenotes/notes/openstack-cli-wrapper-scripts-5dd0e97ac0384dd0.yaml
+++ b/releasenotes/notes/openstack-cli-wrapper-scripts-5dd0e97ac0384dd0.yaml
@@ -1,0 +1,16 @@
+---
+features:
+  - |
+    The ``openstack_cli`` role now installs executable wrapper scripts
+    for ``osc`` and the OpenStack CLI at ``/usr/local/bin`` to replace
+    shell aliases. This makes the OpenStack CLI available in
+    non-interactive contexts such as ``sudo bash -c``, SSH commands,
+    and Ansible tasks without requiring ``set -o posix`` or sourcing
+    ``/etc/profile.d/atmosphere.sh``.
+upgrade:
+  - |
+    Ansible tasks that previously used the shell module with
+    ``source /etc/profile.d/atmosphere.sh`` now use the command module
+    directly. The ``/etc/profile.d/atmosphere.sh`` file no longer
+    defines the ``osc`` or OpenStack CLI aliases and doesn't export
+    any environment variables automatically.

--- a/roles/barbican/tasks/main.yml
+++ b/roles/barbican/tasks/main.yml
@@ -63,14 +63,11 @@
 
 - name: Add implied roles
   run_once: true
-  ansible.builtin.shell: |
-    set -o posix
-    source /etc/profile.d/atmosphere.sh
-    openstack implied role create \
-      --implied-role {{ item.implies }} \
+  ansible.builtin.command:
+    cmd: >-
+      openstack implied role create
+      --implied-role {{ item.implies }}
       {{ item.role }}
-  args:
-    executable: /bin/bash
   loop:
     - role: member
       implies: creator

--- a/roles/octavia/tasks/generate_resources.yml
+++ b/roles/octavia/tasks/generate_resources.yml
@@ -84,14 +84,11 @@
 
 - name: Set binding for ports
   changed_when: false
-  ansible.builtin.shell: |
-    set -o posix
-    source /etc/profile.d/atmosphere.sh
-    openstack port set \
-      --host {{ hostvars[item]['ansible_fqdn'] }} \
+  ansible.builtin.command:
+    cmd: >-
+      openstack port set
+      --host {{ hostvars[item]['ansible_fqdn'] }}
       octavia-health-manager-port-{{ hostvars[item]['inventory_hostname_short'] }}
-  args:
-    executable: /bin/bash
   environment:
     OS_CLOUD: atmosphere
   loop: "{{ groups['controllers'] }}"

--- a/roles/octavia/tasks/main.yml
+++ b/roles/octavia/tasks/main.yml
@@ -132,14 +132,11 @@
 
 - name: Add implied roles
   run_once: true
-  ansible.builtin.shell: |
-    set -o posix
-    source /etc/profile.d/atmosphere.sh
-    openstack implied role create \
-      --implied-role {{ item.implies }} \
+  ansible.builtin.command:
+    cmd: >-
+      openstack implied role create
+      --implied-role {{ item.implies }}
       {{ item.role }}
-  args:
-    executable: /bin/bash
   loop:
     - role: member
       implies: load-balancer_member

--- a/roles/openstack_cli/tasks/main.yml
+++ b/roles/openstack_cli/tasks/main.yml
@@ -46,6 +46,24 @@
     group: root
     mode: "0600"
 
+- name: Install osc wrapper script
+  become: true
+  ansible.builtin.template:
+    src: osc.sh.j2
+    dest: /usr/local/bin/osc
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Install openstack wrapper script
+  become: true
+  ansible.builtin.template:
+    src: openstack.sh.j2
+    dest: /usr/local/bin/openstack
+    owner: root
+    group: root
+    mode: "0755"
+
 - name: Generate openstack aliases
   become: true
   ansible.builtin.template:

--- a/roles/openstack_cli/templates/atmosphere.sh.j2
+++ b/roles/openstack_cli/templates/atmosphere.sh.j2
@@ -1,20 +1,3 @@
-alias osc='nerdctl run --rm --network host \
-      --volume $PWD:/opt --volume /tmp:/tmp \
-      --volume /etc/openstack:/etc/openstack:ro \
-{% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca', 'venafi') %}
-      --volume {{ '/usr/local/share/ca-certificates/atmosphere.crt:/usr/local/share/ca-certificates/atmosphere.crt:ro' if ansible_facts['os_family']
-      in ['Debian'] else '/etc/pki/ca-trust/source/anchors/atmosphere.crt:/usr/local/share/ca-certificates/atmosphere.crt:ro' }} \
-{% elif cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
-      --volume {{ '/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro' if ansible_facts['os_family']
-      in ['Debian'] else '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/ssl/certs/ca-certificates.crt:ro' }} \
-{% endif %}
-{% if ansible_facts['distribution_version'] is ansible.builtin.version('20.04', '<=') %}
-      --env OS_CLOUD=atmosphere \
-{% else %}
-      --env-file <(env | grep OS_) \
-{% endif %}
-      {{ atmosphere_images['openstack_cli'] }}'
-alias openstack='osc openstack'
 alias nova='osc nova'
 alias neutron='osc neutron'
 alias cinder='osc cinder'

--- a/roles/openstack_cli/templates/openstack.sh.j2
+++ b/roles/openstack_cli/templates/openstack.sh.j2
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec /usr/local/bin/osc openstack "$@"

--- a/roles/openstack_cli/templates/osc.sh.j2
+++ b/roles/openstack_cli/templates/osc.sh.j2
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+exec nerdctl run --rm --network host \
+    --volume "$PWD":/opt --volume /tmp:/tmp \
+    --volume /etc/openstack:/etc/openstack:ro \
+{% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca', 'venafi') %}
+    --volume {{ '/usr/local/share/ca-certificates/atmosphere.crt:/usr/local/share/ca-certificates/atmosphere.crt:ro' if ansible_facts['os_family']
+    in ['Debian'] else '/etc/pki/ca-trust/source/anchors/atmosphere.crt:/usr/local/share/ca-certificates/atmosphere.crt:ro' }} \
+{% elif cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
+    --volume {{ '/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro' if ansible_facts['os_family']
+    in ['Debian'] else '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/ssl/certs/ca-certificates.crt:ro' }} \
+{% endif %}
+{% if ansible_facts['distribution_version'] is ansible.builtin.version('20.04', '<=') %}
+    --env OS_CLOUD=atmosphere \
+{% else %}
+    --env-file <(env | grep OS_) \
+{% endif %}
+    {{ atmosphere_images['openstack_cli'] }} "$@"


### PR DESCRIPTION
Backport of #3733 to `stable/zed`.

Cherry-pick of dcffb31c with conflict resolution:
- `roles/openstack_cli/templates/atmosphere.sh.j2`: Removed osc/openstack aliases (replaced by wrapper scripts)
- `roles/rook_ceph_cluster/tasks/main.yml`: Kept native `openstack.cloud.role_assignment` module (already better than CLI approach)
- `roles/openstack_cli/templates/osc.sh.j2`: Preserved Ubuntu 20.04 compatibility (`--env` vs `--env-file`)