### PR TITLE
fix(monitoring): deduplicate active neutron l3 agents

### DIFF
--- a/roles/kube_prometheus_stack/files/jsonnet/openstack.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/openstack.libsonnet
@@ -126,7 +126,7 @@
                 summary: 'Neutron HA router has multiple active L3 agents',
                 description: 'The router with ID {{ $labels.router_id }} has {{ $value }} L3 agents in active state which can cause network resets and traffic drops.',
               },
-              expr: 'sum by (router_id) (openstack_neutron_l3_agent_of_router{ha_state="active"}) > 1',
+              expr: 'sum by (router_id) (max by (router_id, l3_agent_id) (openstack_neutron_l3_agent_of_router{ha_state="active"})) > 1',
               'for': '5m',
               labels: {
                 severity: 'P3',

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -232,6 +232,34 @@ tests:
 
   - interval: 1m
     input_series:
+      - series: 'openstack_neutron_l3_agent_of_router{ha_state="active",l3_agent_id="agent-1",router_id="router-1"}'
+        values: '1x10'
+      - series: 'openstack_neutron_l3_agent_of_router{ha_state="active",l3_agent_id="agent-1",router_id="router-1",service="neutron-metadata"}'
+        values: '1x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: NeutronRouterMultipleActiveL3Agents
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'openstack_neutron_l3_agent_of_router{ha_state="active",l3_agent_id="agent-1",router_id="router-1"}'
+        values: '1x10'
+      - series: 'openstack_neutron_l3_agent_of_router{ha_state="active",l3_agent_id="agent-2",router_id="router-1"}'
+        values: '1x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: NeutronRouterMultipleActiveL3Agents
+        exp_alerts:
+          - exp_labels:
+              router_id: router-1
+              severity: P3
+            exp_annotations:
+              summary: "Neutron HA router has multiple active L3 agents"
+              description: "The router with ID router-1 has 2 L3 agents in active state which can cause network resets and traffic drops."
+
+  - interval: 1m
+    input_series:
       - series: 'openstack_loadbalancer_loadbalancer_status{id="d4e449ad-fad5-4d9e-a039-f71c773ec999", job="openstack-exporter", name="test-lb", operating_status="ONLINE", provisioning_status="PENDING_UPDATE"}'
         values: '0x15'
       - series: 'openstack_loadbalancer_loadbalancer_status{id="25dcf79f-b09d-4d0c-9e29-b69ded2ec734", job="openstack-exporter", name="test-lb-2", operating_status="ONLINE", provisioning_status="ACTIVE"}'


### PR DESCRIPTION
We are getting a false alert NeutronRouterMultipleActiveL3Agents, and upon discovery, it appears we are getting metrics from two sources, `openstack-exporter` and `monitoring/openstack-database-exporter`:
```
openstack_neutron_l3_agent_of_router{agent_admin_up="true", agent_alive="true", agent_host="use1-prod1-os-comp-b-4", container="openstack-exporter", endpoint="metrics", ha_state="active", instance="default", job="openstack-exporter", l3_agent_id="ad147141-bfc7-4ac6-999d-d34c0fbf4425", namespace="openstack", pod="openstack-exporter-789fdfc64c-vgdk8", router_id="18df5243-397c-426d-a11a-64eafe960575", service="openstack-exporter"}
```
```
openstack_neutron_l3_agent_of_router{agent_admin_up="true", agent_alive="true", agent_host="use1-prod1-os-comp-b-4", ha_state="active", instance="openstack-database-exporter-7b94cc5bd5-hlthk", job="monitoring/openstack-database-exporter", l3_agent_id="ad147141-bfc7-4ac6-999d-d34c0fbf4425", router_id="18df5243-397c-426d-a11a-64eafe960575"}
```

which gives us `2 > 1` and fires the alert.

The previous expression summed all openstack_neutron_l3_agent_of_router{ha_state="active"} series by router_id, which could overcount duplicate samples for the same l3_agent_id and trigger false positives. This change deduplicates per (router_id, l3_agent_id) first, then counts active agents per router.

Example of duplicate:
```
openstack_neutron_l3_agent_of_router{router_id="7ae1ac00-1b57-44d0-9447-eee9004d0673"}
```

```

openstack_neutron_l3_agent_of_router{agent_admin_up="true", agent_alive="true", agent_host="use1-prod1-os-comp-a-1", ha_state="active", instance="openstack-database-exporter-7b94cc5bd5-95gr2", job="monitoring/openstack-database-exporter", l3_agent_id="a3c91e02-e783-4334-a4ee-0feca7b867ae", router_id="7ae1ac00-1b57-44d0-9447-eee9004d0673"} | 1
-- | --
openstack_neutron_l3_agent_of_router{agent_admin_up="true", agent_alive="true", agent_host="use1-prod1-os-comp-b-4", ha_state="standby", instance="openstack-database-exporter-7b94cc5bd5-95gr2", job="monitoring/openstack-database-exporter", l3_agent_id="ad147141-bfc7-4ac6-999d-d34c0fbf4425", router_id="7ae1ac00-1b57-44d0-9447-eee9004d0673"} | 1
openstack_neutron_l3_agent_of_router{agent_admin_up="true", agent_alive="true", agent_host="use1-prod1-os-comp-c-1", ha_state="standby", instance="openstack-database-exporter-7b94cc5bd5-95gr2", job="monitoring/openstack-database-exporter", l3_agent_id="a6d04a9a-ab19-4bca-a69b-ea9f410c8951", router_id="7ae1ac00-1b57-44d0-9447-eee9004d0673"} | 1
openstack_neutron_l3_agent_of_router{agent_admin_up="true", agent_alive="true", agent_host="use1-prod1-os-comp-a-1", container="openstack-exporter", endpoint="metrics", ha_state="active", instance="default", job="openstack-exporter", l3_agent_id="a3c91e02-e783-4334-a4ee-0feca7b867ae", namespace="openstack", pod="openstack-exporter-789fdfc64c-ghss8", router_id="7ae1ac00-1b57-44d0-9447-eee9004d0673", service="openstack-exporter"} | 1
openstack_neutron_l3_agent_of_router{agent_admin_up="true", agent_alive="true", agent_host="use1-prod1-os-comp-b-4", container="openstack-exporter", endpoint="metrics", ha_state="standby", instance="default", job="openstack-exporter", l3_agent_id="ad147141-bfc7-4ac6-999d-d34c0fbf4425", namespace="openstack", pod="openstack-exporter-789fdfc64c-ghss8", router_id="7ae1ac00-1b57-44d0-9447-eee9004d0673", service="openstack-exporter"} | 1
openstack_neutron_l3_agent_of_router{agent_admin_up="true", agent_alive="true", agent_host="use1-prod1-os-comp-c-1", container="openstack-exporter", endpoint="metrics", ha_state="standby", instance="default", job="openstack-exporter", l3_agent_id="a6d04a9a-ab19-4bca-a69b-ea9f410c8951", namespace="openstack", pod="openstack-exporter-789fdfc64c-ghss8", router_id="7ae1ac00-1b57-44d0-9447-eee9004d0673", service="openstack-exporter"}
```