### PR TITLE
feat(cinder): add VAST data volume backend support

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -65,6 +65,7 @@ Staffeln
 StorPool
 TLS
 UUID
+VAST
 VLAN
 VNC
 VPN

--- a/doc/source/deploy/storage.rst
+++ b/doc/source/deploy/storage.rst
@@ -203,6 +203,21 @@ and file system mounts automatically.
     type: storpool
     template: hybrid-2ssd
 
+VAST data (``vast``)
+====================
+
+VAST Data volume backend. Supports authentication via API token or username
+and password. You must provide ``subsystem`` and ``vippool_name``.
+
+.. code-block:: yaml
+
+    type: vast
+    address: <management_ip_or_hostname>
+    api_token: <api_token>          # or use username + password
+    subsystem: <subsystem_name>
+    vippool_name: <vippool_name>
+    tenant_name: <tenant_name>      # optional
+
 Cinder (``cinder``)
 ====================
 

--- a/plugins/filter/storage.py
+++ b/plugins/filter/storage.py
@@ -418,6 +418,62 @@ class VolumeBackendStorpool(_HostAttachedVolumeBackend):
         }
 
 
+class VolumeBackendVast(_HostAttachedVolumeBackend):
+    """VAST Data volume backend."""
+
+    type: Literal["vast"]
+    address: str = Field(description="Management address (IP or hostname).")
+    username: str | None = Field(
+        default=None, description="Username credential for REST API access."
+    )
+    password: str | None = Field(
+        default=None, description="Password credential for REST API access."
+    )
+    api_token: str | None = Field(
+        default=None,
+        description="API token for REST API access. Takes precedence over username/password.",
+    )
+    subsystem: str = Field(description="VAST subsystem name.")
+    vippool_name: str = Field(description="Name of the Virtual IP pool.")
+    tenant_name: str | None = Field(
+        default=None,
+        description="VAST tenant name for filtering when multiple subsystems share the same name.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_credentials(self) -> Self:
+        has_userpass = self.username is not None and self.password is not None
+        has_token = self.api_token is not None
+        if not has_userpass and not has_token:
+            raise ValueError(
+                "Either 'api_token' or both 'username' and 'password' must be provided."
+            )
+        return self
+
+    def cinder_backend_config(self, name: str) -> dict[str, Any]:
+        """Generate Cinder backend config for VAST Data."""
+        config: dict[str, Any] = {
+            "volume_backend_name": name,
+            "volume_driver": "cinder.volume.drivers.vastdata.driver.VASTVolumeDriver",
+            "san_ip": self.address,
+            "vast_subsystem": self.subsystem,
+            "vast_vippool_name": self.vippool_name,
+        }
+        if self.api_token is not None:
+            config["vast_api_token"] = self.api_token
+        else:
+            config["san_login"] = self.username
+            config["san_password"] = self.password
+        if self.tenant_name is not None:
+            config["vast_tenant_name"] = self.tenant_name
+        return config
+
+    def amend_cinder(self, result: HelmValues, name: str) -> None:
+        """Amend Cinder Helm values for a VAST Data volume backend."""
+        super().amend_cinder(result, name)
+        result["conf"]["backends"][name] = self.cinder_backend_config(name)
+
+
 VolumeBackend = Annotated[
     Union[
         VolumeBackendRbd,
@@ -425,6 +481,7 @@ VolumeBackend = Annotated[
         VolumeBackendPowerstore,
         VolumeBackendPure,
         VolumeBackendStorpool,
+        VolumeBackendVast,
     ],
     Field(discriminator="type"),
 ]

--- a/releasenotes/notes/cinder-vast-data-backend-c4aa359f26d6911e.yaml
+++ b/releasenotes/notes/cinder-vast-data-backend-c4aa359f26d6911e.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add support for VAST Data as a Cinder volume backend via
+    ``atmosphere_storage``. Configure the management address, subsystem name,
+    and Virtual IP pool name. Authenticate with an API token or username and
+    password.

--- a/tests/unit/plugins/filter/test_storage.py
+++ b/tests/unit/plugins/filter/test_storage.py
@@ -90,6 +90,23 @@ _STORPOOL_BACKEND = {
     "template": "hybrid-2ssd",
 }
 
+_VAST_BACKEND_WITH_TOKEN = {
+    "type": "vast",
+    "address": "10.0.0.5",
+    "api_token": "vast-api-token",
+    "subsystem": "openstack-subsystem",
+    "vippool_name": "openstack-vips",
+}
+
+_VAST_BACKEND_WITH_USERPASS = {
+    "type": "vast",
+    "address": "10.0.0.5",
+    "username": "admin",
+    "password": "secret",
+    "subsystem": "openstack-subsystem",
+    "vippool_name": "openstack-vips",
+}
+
 
 class TestValidation:
     def test_empty_storage_is_valid(self):
@@ -574,6 +591,80 @@ class TestStorageToCinderHelmValues:
         mounts = result["pod"]["mounts"]["cinder_volume"]
         assert len(mounts["volumeMounts"]) == 2
         assert len(mounts["volumes"]) == 2
+
+    def test_vast_backend_with_api_token(self):
+        storage = {
+            **DEFAULT_STORAGE,
+            "volumes": {
+                "default": "vast",
+                "backends": {"vast": _VAST_BACKEND_WITH_TOKEN},
+            },
+            "backup": {"type": "none"},
+        }
+        result = storage_to_cinder_helm_values(storage)
+
+        backend = result["conf"]["backends"]["vast"]
+        assert (
+            backend["volume_driver"]
+            == "cinder.volume.drivers.vastdata.driver.VASTVolumeDriver"
+        )
+        assert backend["san_ip"] == "10.0.0.5"
+        assert backend["vast_api_token"] == "vast-api-token"
+        assert backend["vast_subsystem"] == "openstack-subsystem"
+        assert backend["vast_vippool_name"] == "openstack-vips"
+        assert "san_login" not in backend
+        assert "san_password" not in backend
+        assert "vast_tenant_name" not in backend
+        assert result["conf"]["enable_iscsi"] is True
+
+    def test_vast_backend_with_username_password(self):
+        storage = {
+            **DEFAULT_STORAGE,
+            "volumes": {
+                "default": "vast",
+                "backends": {"vast": _VAST_BACKEND_WITH_USERPASS},
+            },
+            "backup": {"type": "none"},
+        }
+        result = storage_to_cinder_helm_values(storage)
+
+        backend = result["conf"]["backends"]["vast"]
+        assert backend["san_login"] == "admin"
+        assert backend["san_password"] == "secret"
+        assert "vast_api_token" not in backend
+
+    def test_vast_backend_with_tenant_name(self):
+        storage = {
+            **DEFAULT_STORAGE,
+            "volumes": {
+                "default": "vast",
+                "backends": {
+                    "vast": {**_VAST_BACKEND_WITH_TOKEN, "tenant_name": "my-tenant"}
+                },
+            },
+            "backup": {"type": "none"},
+        }
+        result = storage_to_cinder_helm_values(storage)
+        assert result["conf"]["backends"]["vast"]["vast_tenant_name"] == "my-tenant"
+
+    def test_vast_backend_missing_credentials_raises(self):
+        with pytest.raises(Exception):
+            StorageConfig.model_validate(
+                {
+                    **DEFAULT_STORAGE,
+                    "volumes": {
+                        "default": "vast",
+                        "backends": {
+                            "vast": {
+                                "type": "vast",
+                                "address": "10.0.0.5",
+                                "subsystem": "openstack-subsystem",
+                                "vippool_name": "openstack-vips",
+                            }
+                        },
+                    },
+                }
+            )
 
     def test_no_backup(self):
         storage = {


### PR DESCRIPTION
## Summary

Adds support for the VAST Data volume backend in Cinder, introduced in OpenStack 2026.1.

## Changes

### `plugins/filter/storage.py`
- New `VolumeBackendVast` class with:
  - Required: `address`, `subsystem`, `vippool_name`
  - Auth: `api_token` **or** `username` + `password` (validated at model level)
  - Optional: `tenant_name`
  - Uses `cinder.volume.drivers.vastdata.driver.VASTVolumeDriver`
  - Inherits `_HostAttachedVolumeBackend` (iSCSI enablement, trimmed dependency graph)
- Registered in the `VolumeBackend` discriminated union

### `tests/unit/plugins/filter/test_storage.py`
- Tests for API token auth, username/password auth, optional tenant name, and missing credentials validation

### `doc/source/deploy/storage.rst`
- New VAST data section documenting all configuration fields

## Example configuration

```yaml
atmosphere_storage:
  volumes:
    default: vast
    backends:
      vast:
        type: vast
        address: 10.0.0.5
        api_token: my-api-token
        subsystem: openstack-subsystem
        vippool_name: openstack-vips
  backup:
    type: none
  ephemeral:
    type: local
```