### PR TITLE
fix(openvswitch): add /var/tmp mount to ovs-vswitchd container

### DIFF
--- a/.charts.yml
+++ b/.charts.yml
@@ -187,6 +187,10 @@ charts:
     version: 1.2.0
     repository: *vexxhost_openstack_helm_repository
     dependencies: *vexxhost_openstack_helm_dependencies
+    patches:
+      gerrit:
+        review.opendev.org:
+          - 966771
   - name: ovn
     version: 1.1.0
     repository: *vexxhost_openstack_helm_repository

--- a/charts/openvswitch/templates/daemonset.yaml
+++ b/charts/openvswitch/templates/daemonset.yaml
@@ -230,6 +230,8 @@ It should be handled through lcore and pmd core masks. */}}
               mountPath: /sys/bus/pci/drivers
             - name: cgroup
               mountPath: /sys/fs/cgroup
+            - name: var-tmp
+              mountPath: /var/tmp
 {{- end }}
       volumes:
         - name: pod-tmp
@@ -282,5 +284,9 @@ It should be handled through lcore and pmd core masks. */}}
         - name: cgroup
           hostPath:
             path: /sys/fs/cgroup
+        - name: var-tmp
+          hostPath:
+            path: /var/tmp
+            type: DirectoryOrCreate
 {{- end }}
 {{- end }}

--- a/releasenotes/notes/ovs-var-tmp-mount-67980c1b553984ae.yaml
+++ b/releasenotes/notes/ovs-var-tmp-mount-67980c1b553984ae.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Added ``/var/tmp`` mount to the ``ovs-vswitchd`` container in the
+    Open vSwitch chart. The ``ovs-vswitchd`` container needs this mount
+    for Data Plane Development Kit operation with NVIDIA ConnectX drivers.
+    Ported from upstream OpenStack-Helm change 966771.


### PR DESCRIPTION
Backport upstream change [966771](https://review.opendev.org/c/openstack/openstack-helm/+/966771) to add `/var/tmp` mount to the `ovs-vswitchd` container. This ensures proper operation when using DPDK with the Mellanox driver.