### PR TITLE
feat(deploy): simulate: pre-pull container images before parallel waves

### DIFF
--- a/cmd/atmosphere/deploy.go
+++ b/cmd/atmosphere/deploy.go
@@ -14,6 +14,7 @@ func newDeployCmd() *cobra.Command {
 		inventory   string
 		tags        string
 		concurrency int
+		prepull     bool
 	)
 
 	cmd := &cobra.Command{
@@ -37,10 +38,11 @@ and runs them in parallel where possible.`,
 			}
 
 			orchestrator := &deploy.Orchestrator{
-				Deployer:    deployer,
-				Inventory:   inventory,
-				Output:      os.Stdout,
-				Concurrency: concurrency,
+				Deployer:      deployer,
+				Inventory:     inventory,
+				Output:        os.Stdout,
+				Concurrency:   concurrency,
+				PrepullImages: prepull,
 			}
 
 			// Parse tags
@@ -59,6 +61,7 @@ and runs them in parallel where possible.`,
 	cmd.Flags().StringVarP(&inventory, "inventory", "i", "", "Path to Ansible inventory file (required)")
 	cmd.Flags().StringVarP(&tags, "tags", "t", "", "Comma-separated list of component tags to deploy")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 0, "Max concurrent deployments per wave (0 = unlimited)")
+	cmd.Flags().BoolVar(&prepull, "prepull", false, "Pre-pull all container images after foundation wave")
 
 	return cmd
 }

--- a/internal/deploy/orchestrator.go
+++ b/internal/deploy/orchestrator.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // preflightPlaybook contains validation checks that mirror pre_tasks from the
@@ -41,6 +43,9 @@ type Orchestrator struct {
 	Output io.Writer
 	// Concurrency limits parallel deployments per wave (0 = unlimited).
 	Concurrency int
+	// PrepullImages enables pre-pulling all container images after the
+	// foundation wave (kubernetes) completes but before service deployments.
+	PrepullImages bool
 }
 
 // Deploy runs the deployment based on the provided tags.
@@ -107,6 +112,9 @@ func (o *Orchestrator) runPreflightChecks(ctx context.Context, output io.Writer)
 }
 
 // deployFullDAG runs all components in parallel waves.
+// When PrepullImages is enabled, it injects an image prepull step after the
+// first wave (foundation: kubernetes, ceph) so that subsequent parallel
+// deployments don't block on image pulls.
 func (o *Orchestrator) deployFullDAG(ctx context.Context, output io.Writer) error {
 	if err := o.runPreflightChecks(ctx, output); err != nil {
 		return err
@@ -117,24 +125,106 @@ func (o *Orchestrator) deployFullDAG(ctx context.Context, output io.Writer) erro
 		return fmt.Errorf("building dependency graph: %w", err)
 	}
 
+	waves, err := g.Waves()
+	if err != nil {
+		return fmt.Errorf("computing wave schedule: %w", err)
+	}
+
 	rc := NewResourceCoordinator(Components)
+	prepullDone := false
 
-	fmt.Fprintln(output, "==> Starting parallel deployment")
-	return g.Run(ctx, o.Concurrency, func(ctx context.Context, id string, comp Component) error {
-		fmt.Fprintf(output, "==> [%s] Starting deployment\n", id)
-
-		release, err := rc.Acquire(ctx, comp)
-		if err != nil {
-			return fmt.Errorf("component %s: %w", id, err)
+	fmt.Fprintf(output, "==> Starting parallel deployment (%d waves)\n", len(waves))
+	for i, wave := range waves {
+		// After the foundation wave completes (kubernetes/ceph are ready),
+		// pre-pull all container images so later waves don't block on pulls.
+		if o.PrepullImages && !prepullDone && i > 0 {
+			if err := o.runImagePrepull(ctx, output); err != nil {
+				// Log warning but don't fail the deployment for prepull errors
+				fmt.Fprintf(output, "==> WARNING: Image pre-pull failed (continuing): %v\n", err)
+			}
+			prepullDone = true
 		}
-		defer release()
 
-		if err := o.Deployer.Deploy(ctx, comp); err != nil {
-			return fmt.Errorf("component %s failed: %w", id, err)
+		fmt.Fprintf(output, "==> Wave %d: %s\n", i, strings.Join(wave, ", "))
+
+		eg, waveCtx := errgroup.WithContext(ctx)
+		if o.Concurrency > 0 {
+			eg.SetLimit(o.Concurrency)
 		}
-		fmt.Fprintf(output, "==> [%s] Deployment complete\n", id)
-		return nil
-	})
+
+		for _, id := range wave {
+			comp, ok := g.Node(id)
+			if !ok {
+				return fmt.Errorf("component %s not found in graph", id)
+			}
+
+			eg.Go(func() error {
+				fmt.Fprintf(output, "==> [%s] Starting deployment\n", id)
+
+				release, err := rc.Acquire(waveCtx, comp)
+				if err != nil {
+					return fmt.Errorf("component %s: %w", id, err)
+				}
+				defer release()
+
+				if err := o.Deployer.Deploy(waveCtx, comp); err != nil {
+					return fmt.Errorf("component %s failed: %w", id, err)
+				}
+				fmt.Fprintf(output, "==> [%s] Deployment complete\n", id)
+				return nil
+			})
+		}
+
+		if err := eg.Wait(); err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintln(output, "==> Parallel deployment complete")
+	return nil
+}
+
+// runImagePrepull pre-pulls all container images defined in atmosphere_images
+// by invoking the prepull_images playbook. This warms the containerd image
+// cache so parallel deployments don't compete for bandwidth.
+func (o *Orchestrator) runImagePrepull(ctx context.Context, output io.Writer) error {
+	fmt.Fprintln(output, "==> Pre-pulling container images")
+
+	cmd := exec.CommandContext(ctx, "ansible-playbook",
+		"vexxhost.atmosphere.prepull_images",
+		"--inventory", o.Inventory)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting image prepull: %w", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		prefixOutput("prepull", stdout, output)
+	}()
+	go func() {
+		defer wg.Done()
+		prefixOutput("prepull", stderr, output)
+	}()
+	wg.Wait()
+
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("image prepull failed: %w", err)
+	}
+
+	fmt.Fprintln(output, "==> Image pre-pull complete")
+	return nil
 }
 
 // deploySingleTag passes through to ansible-playbook with the tag.

--- a/molecule/aio/converge.yml
+++ b/molecule/aio/converge.yml
@@ -19,6 +19,7 @@
           . .venv/bin/activate &&
           ./bin/atmosphere deploy
           --inventory ./inventory.yaml
+          --prepull
           {{ '--tags ' + atmosphere_deploy_tags if atmosphere_deploy_tags is defined else '' }}
         executable: /bin/bash
       args:

--- a/molecule/csi/converge.yml
+++ b/molecule/csi/converge.yml
@@ -32,6 +32,7 @@
           . .venv/bin/activate &&
           ./bin/atmosphere deploy
           --inventory ./inventory.yaml
+          --prepull
           {{ '--tags ' + atmosphere_deploy_tags if atmosphere_deploy_tags is defined else '' }}
         executable: /bin/bash
       args:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -32,6 +32,7 @@
           . .venv/bin/activate &&
           ./bin/atmosphere deploy
           --inventory {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/workspace
+          --prepull
           {{ '--tags ' + atmosphere_deploy_tags if atmosphere_deploy_tags is defined else '' }}
         executable: /bin/bash
       args:

--- a/molecule/keycloak/converge.yml
+++ b/molecule/keycloak/converge.yml
@@ -32,6 +32,7 @@
           . .venv/bin/activate &&
           ./bin/atmosphere deploy
           --inventory ./inventory.yaml
+          --prepull
           {{ '--tags ' + atmosphere_deploy_tags if atmosphere_deploy_tags is defined else '' }}
         executable: /bin/bash
       args:

--- a/molecule/pxc/converge.yml
+++ b/molecule/pxc/converge.yml
@@ -32,6 +32,7 @@
           . .venv/bin/activate &&
           ./bin/atmosphere deploy
           --inventory {{ lookup('env', 'MOLECULE_INVENTORY_FILE') }}
+          --prepull
           {{ '--tags ' + atmosphere_deploy_tags if atmosphere_deploy_tags is defined else '' }}
         executable: /bin/bash
       args:

--- a/pkg/dag/dag.go
+++ b/pkg/dag/dag.go
@@ -90,6 +90,13 @@ func (g *Graph[T]) Waves() ([][]string, error) {
 	return waves, nil
 }
 
+// Node returns the value associated with the given node ID.
+// The second return value is false if the ID does not exist.
+func (g *Graph[T]) Node(id string) (T, bool) {
+	val, ok := g.nodes[id]
+	return val, ok
+}
+
 // Subgraph extracts a new graph containing only the specified nodes, preserving
 // edges between them. Returns an error if any node ID is not found.
 func (g *Graph[T]) Subgraph(nodeIDs []string) (*Graph[T], error) {

--- a/playbooks/prepull_images.yml
+++ b/playbooks/prepull_images.yml
@@ -1,0 +1,49 @@
+# Copyright (c) 2025 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Pre-pull all container images required by Atmosphere components.
+# Run this after Kubernetes (containerd) is available to warm the image
+# cache so that subsequent parallel deployments don't block on pulls.
+
+- name: Pre-pull container images
+  hosts: all
+  become: true
+  roles:
+    - role: vexxhost.atmosphere.defaults
+  tasks:
+    - name: Build unique image list
+      ansible.builtin.set_fact:
+        _prepull_images: "{{ atmosphere_images.values() | unique | sort }}"
+
+    - name: Pull all container images in parallel
+      ansible.builtin.command:
+        cmd: "crictl pull {{ item }}"
+      loop: "{{ _prepull_images }}"
+      loop_control:
+        label: "{{ item | regex_replace('.*/', '') | truncate(60, True) }}"
+      async: 900
+      poll: 0
+      register: _prepull_jobs
+      changed_when: false
+      failed_when: false
+
+    - name: Wait for all image pulls to complete
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      loop: "{{ _prepull_jobs.results }}"
+      loop_control:
+        label: "{{ item.item | default('') | regex_replace('.*/', '') | truncate(60, True) }}"
+      register: _prepull_results
+      until: _prepull_results.finished
+      retries: 90
+      delay: 10
+      changed_when: false
+      failed_when: false
+
+    - name: Report pre-pull summary
+      ansible.builtin.debug:
+        msg: >-
+          Pre-pulled {{ _prepull_results.results | selectattr('finished', 'defined')
+            | selectattr('finished') | list | length }}/{{ _prepull_images | length }} images
+          ({{ _prepull_results.results | selectattr('rc', 'defined')
+            | selectattr('rc', 'ne', 0) | list | length }} failures ignored)


### PR DESCRIPTION
## Summary

Adds a `--prepull` flag to the parallel deploy orchestrator (from #3818) that pre-pulls all container images after the foundation wave (kubernetes/ceph) completes but before service deployments begin.

This prevents parallel waves from competing for network bandwidth when pulling images simultaneously, reducing overall deployment time.

## How It Works

1. **Wave 0** deploys foundation components (kubernetes, ceph) — containerd becomes available
2. **Prepull step** runs `playbooks/prepull_images.yml` which:
   - Loads `atmosphere_images` via the `defaults` role
   - Extracts all unique image references
   - Async-pulls every image using `crictl pull` on all nodes in parallel
   - Reports a summary (failures are non-fatal)
3. **Waves 1–10** proceed with all images already cached locally

## Changes

| File | Description |
|------|-------------|
| `playbooks/prepull_images.yml` | New Ansible playbook that async-pulls all `atmosphere_images` via `crictl` |
| `internal/deploy/orchestrator.go` | Added `PrepullImages` field, `runImagePrepull()` method, manual wave iteration with prepull injection after wave 0 |
| `cmd/atmosphere/deploy.go` | Added `--prepull` CLI flag |
| `pkg/dag/dag.go` | Added `Node()` accessor for wave-level iteration |
| `molecule/*/converge.yml` | All converge files pass `--prepull` to the orchestrator |

## Design Decisions

- **Non-fatal prepull**: Prepull failures are logged as warnings but don't abort the deployment — images will be pulled on-demand as before
- **After wave 0**: The prepull runs after kubernetes/ceph (wave 0) since containerd must be available for `crictl pull`
- **Opt-in flag**: `--prepull` defaults to `false` for backwards compatibility; CI jobs opt in via converge.yml

Depends on #3818