### PR TITLE
[Backport stable/2025.1] Add IPMI SEL alerts for memory and CPU errors

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -16,7 +16,10 @@ CSI
 Ceph
 Cinder
 CoreDNS
+DIMM
 DNS
+Dell
+ECC
 FQDN
 FQDNs
 Galera
@@ -53,6 +56,7 @@ READY
 RGW
 RPC
 RabbitMQ
+SEL
 SLOs?
 SMART
 SQLAlchemy

--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -908,6 +908,82 @@ experiencing network issues.
      kubectl debug node/<affected-node> -it --image=busybox -- \
        cat /host/var/log/syslog | tail -100
 
+``IpmiUncorrectableMemoryError``
+================================
+
+This alert fires when the Intelligent Platform Management Interface (IPMI)
+exporter reports a recent ``uncorrectable_memory_error`` System Event Log
+(SEL) event. These events
+indicate a non-recoverable memory error on the host and often require
+hardware intervention.
+
+**Likely Root Causes**
+
+- Failing dual in-line memory module (DIMM) or memory controller
+- Unstable firmware or Basic Input/Output System (BIOS) configuration
+- Recent hardware changes or maintenance introducing faulty memory
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected host from the alert ``instance`` label.
+
+2. Check the SEL (System Event Log) on the host for uncorrectable memory errors:
+
+   .. code-block:: console
+
+     ipmitool sel list | grep -i "uncorrectable"
+
+3. Review system logs for error-correcting code (ECC) or memory errors:
+
+   .. code-block:: console
+
+     journalctl -k | grep -i -e ecc -e memory -e edac
+
+4. If the error recurs, replace the failing DIMM (dual in-line memory module)
+   and run a memory test
+   (for example, ``memtest86``) before returning the host to service.
+
+``IpmiUnrecoverableCpuError``
+=============================
+
+This alert fires when the IPMI (Intelligent Platform Management Interface)
+exporter reports a recent ``unrecoverable_cpu_error`` SEL (System Event Log)
+event. These events
+indicate a fatal CPU error that typically requires hardware
+intervention and may precede a crash.
+
+**Likely Root Causes**
+
+- Failing CPU or socket
+- Hardware instability due to power or thermal issues
+- Firmware or microcode issues
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected host from the alert ``instance`` label.
+
+2. Check the SEL (System Event Log) on the host for CPU errors:
+
+   .. code-block:: console
+
+     ipmitool sel list | grep -i -e "processor" -e "err"
+
+3. Review system logs for machine check or CPU errors:
+
+   .. code-block:: console
+
+     journalctl -k | grep -i -e mce -e machine -e cpu
+
+4. Check CPU temperatures and system health:
+
+   .. code-block:: console
+
+     ipmitool sdr type temperature
+     ipmitool sdr type processor
+
+5. If the error recurs, schedule hardware maintenance and replace the
+   affected CPU or motherboard as needed.
+
 ``MySQLGaleraOutOfSync``
 ========================
 

--- a/releasenotes/notes/ipmi-sel-alerts-2026022757713d47.yaml
+++ b/releasenotes/notes/ipmi-sel-alerts-2026022757713d47.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add IPMI SEL-based P1 alerts for uncorrectable memory and unrecoverable CPU
+    errors using the latest SEL event timestamp, and update the monitoring
+    documentation and tests accordingly.

--- a/roles/ipmi_exporter/defaults/main.yml
+++ b/roles/ipmi_exporter/defaults/main.yml
@@ -17,7 +17,7 @@
 ipmi_exporter_config:
   modules:
     default:
-      collectors: ["bmc", "ipmi", "chassis", "sel"]
+      collectors: ["bmc", "ipmi", "chassis", "sel", "sel-events"]
       exclude_sensor_ids:
         - 42
         - 45 # Entity Presence (Dell PowerEdge servers)
@@ -45,5 +45,10 @@ ipmi_exporter_config:
       custom_args:
         ipmi:
           - "--entity-sensor-names"
+      sel_events:
+        - name: uncorrectable_memory_error
+          regex: Uncorrectable memory error
+        - name: unrecoverable_cpu_error
+          regex: IERR
 
                                                                    # ]]]

--- a/roles/kube_prometheus_stack/files/jsonnet/legacy.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/legacy.libsonnet
@@ -109,6 +109,37 @@
             },
           ],
         },
+        {
+          name: 'ipmi-exporter-sel',
+          rules: [
+            {
+              alert: 'IpmiUncorrectableMemoryError',
+              expr: 'time() - max by (instance) (ipmi_sel_events_latest_timestamp{name="uncorrectable_memory_error"}) < 86400',
+              'for': '2m',
+              labels: {
+                severity: 'P1',
+              },
+              annotations: {
+                summary: 'IPMI: recent uncorrectable memory error may affect host stability on {{ $labels.instance }}',
+                description: 'The metric ipmi_sel_events_latest_timestamp{name="uncorrectable_memory_error"} for {{ $labels.instance }} indicates the most recent uncorrectable memory SEL event is {{ $value | humanizeDuration }} old, which is within the alert window of 24 hours. Normal behavior is that no uncorrectable memory SEL events occur, or the latest such event is older than 24 hours.',
+                runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#ipmiuncorrectablememoryerror',
+              },
+            },
+            {
+              alert: 'IpmiUnrecoverableCpuError',
+              expr: 'time() - max by (instance) (ipmi_sel_events_latest_timestamp{name="unrecoverable_cpu_error"}) < 86400',
+              'for': '2m',
+              labels: {
+                severity: 'P1',
+              },
+              annotations: {
+                summary: 'IPMI: recent unrecoverable CPU error may affect host stability on {{ $labels.instance }}',
+                description: 'The metric ipmi_sel_events_latest_timestamp{name="unrecoverable_cpu_error"} for {{ $labels.instance }} indicates the most recent unrecoverable CPU SEL event is {{ $value | humanizeDuration }} old, which is within the alert window of 24 hours. Normal behavior is that no unrecoverable CPU SEL events occur, or the latest such event is older than 24 hours.',
+                runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#ipmiunrecoverablecpuerror',
+              },
+            },
+          ],
+        },
       ],
     },
   },

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -232,6 +232,56 @@ tests:
 
   - interval: 1m
     input_series:
+      - series: 'ipmi_sel_events_latest_timestamp{instance="192.0.2.10",name="uncorrectable_memory_error"}'
+        values: '0x2880'
+    alert_rule_test:
+      - eval_time: 2d
+        alertname: IpmiUncorrectableMemoryError
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_latest_timestamp{instance="192.0.2.10",name="uncorrectable_memory_error"}'
+        values: '172740x2880'
+    alert_rule_test:
+      - eval_time: 2d
+        alertname: IpmiUncorrectableMemoryError
+        exp_alerts:
+          - exp_labels:
+              instance: 192.0.2.10
+              severity: P1
+            exp_annotations:
+              summary: "IPMI: recent uncorrectable memory error may affect host stability on 192.0.2.10"
+              description: "The metric ipmi_sel_events_latest_timestamp{name=\"uncorrectable_memory_error\"} for 192.0.2.10 indicates the most recent uncorrectable memory SEL event is 1m 0s old, which is within the alert window of 24 hours. Normal behavior is that no uncorrectable memory SEL events occur, or the latest such event is older than 24 hours."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#ipmiuncorrectablememoryerror"
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_latest_timestamp{instance="192.0.2.11",name="unrecoverable_cpu_error"}'
+        values: '0x2880'
+    alert_rule_test:
+      - eval_time: 2d
+        alertname: IpmiUnrecoverableCpuError
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'ipmi_sel_events_latest_timestamp{instance="192.0.2.11",name="unrecoverable_cpu_error"}'
+        values: '172740x2880'
+    alert_rule_test:
+      - eval_time: 2d
+        alertname: IpmiUnrecoverableCpuError
+        exp_alerts:
+          - exp_labels:
+              instance: 192.0.2.11
+              severity: P1
+            exp_annotations:
+              summary: "IPMI: recent unrecoverable CPU error may affect host stability on 192.0.2.11"
+              description: "The metric ipmi_sel_events_latest_timestamp{name=\"unrecoverable_cpu_error\"} for 192.0.2.11 indicates the most recent unrecoverable CPU SEL event is 1m 0s old, which is within the alert window of 24 hours. Normal behavior is that no unrecoverable CPU SEL events occur, or the latest such event is older than 24 hours."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#ipmiunrecoverablecpuerror"
+
+  - interval: 1m
+    input_series:
       - series: 'openstack_loadbalancer_loadbalancer_status{id="d4e449ad-fad5-4d9e-a039-f71c773ec999", job="openstack-exporter", name="test-lb", operating_status="ONLINE", provisioning_status="PENDING_UPDATE"}'
         values: '0x15'
       - series: 'openstack_loadbalancer_loadbalancer_status{id="25dcf79f-b09d-4d0c-9e29-b69ded2ec734", job="openstack-exporter", name="test-lb-2", operating_status="ONLINE", provisioning_status="ACTIVE"}'


### PR DESCRIPTION
# Description
Backport of #3697 to `stable/2025.1`.