### PR TITLE
fix(magnum): update paste config to deploy healthcheck as app

### DIFF
--- a/charts/magnum/values.yaml
+++ b/charts/magnum/values.yaml
@@ -52,8 +52,12 @@ images:
 
 conf:
   paste:
-    pipeline:main:
-      pipeline: cors healthcheck request_id authtoken api_v1
+    composite:main:
+      paste.composite_factory: magnum.api:root_app_factory
+      /: api
+      /healthcheck: healthcheck
+    pipeline:api:
+      pipeline: cors request_id authtoken api_v1
     app:api_v1:
       paste.app_factory: magnum.api.app:app_factory
     filter:authtoken:
@@ -64,8 +68,8 @@ conf:
     filter:cors:
       paste.filter_factory: oslo_middleware.cors:filter_factory
       oslo_config_project: magnum
-    filter:healthcheck:
-      paste.filter_factory: oslo_middleware:Healthcheck.factory
+    app:healthcheck:
+      paste.app_factory: oslo_middleware:Healthcheck.app_factory
       backends: disable_by_file
       disable_by_file_path: /etc/magnum/healthcheck_disable
   policy: {}

--- a/charts/patches/magnum/0003-update-paste-config-healthcheck-as-app.patch
+++ b/charts/patches/magnum/0003-update-paste-config-healthcheck-as-app.patch
@@ -1,0 +1,29 @@
+diff --git a/magnum/values.yaml b/magnum/values.yaml
+--- a/magnum/values.yaml
++++ b/magnum/values.yaml
+@@ -52,8 +52,12 @@
+ 
+ conf:
+   paste:
+-    pipeline:main:
+-      pipeline: cors healthcheck request_id authtoken api_v1
++    composite:main:
++      paste.composite_factory: magnum.api:root_app_factory
++      /: api
++      /healthcheck: healthcheck
++    pipeline:api:
++      pipeline: cors request_id authtoken api_v1
+     app:api_v1:
+       paste.app_factory: magnum.api.app:app_factory
+     filter:authtoken:
+@@ -64,8 +68,8 @@
+     filter:cors:
+       paste.filter_factory: oslo_middleware.cors:filter_factory
+       oslo_config_project: magnum
+-    filter:healthcheck:
+-      paste.filter_factory: oslo_middleware:Healthcheck.factory
++    app:healthcheck:
++      paste.app_factory: oslo_middleware:Healthcheck.app_factory
+       backends: disable_by_file
+       disable_by_file_path: /etc/magnum/healthcheck_disable
+   policy: {}

--- a/releasenotes/notes/fix-magnum-healthcheck-paste-config-4d8c448802cf398f.yaml
+++ b/releasenotes/notes/fix-magnum-healthcheck-paste-config-4d8c448802cf398f.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    The Magnum API paste configuration now deploys the health check
+    as a standalone app with path-based routing instead of an inline
+    pipeline filter. This fixes a boot failure caused by newer versions
+    of ``oslo.middleware`` that require ``HealthcheckMiddleware`` to run
+    as an app.


### PR DESCRIPTION
The Magnum API paste configuration now deploys the health check as a standalone app with path-based routing instead of an inline pipeline filter. This mirrors the change previously made for Glance in #3698.

Newer versions of `oslo.middleware` require `HealthcheckMiddleware` to be deployed as an app, not a filter, raising:

```
NotImplementedError: HealthcheckMiddleware should be deployed as an app, not a filter
```

which caused the `magnum-api` WSGI workers to crash on startup.