### PR TITLE
ci(molecule): skip idempotence step in check pipeline

### DIFF
--- a/molecule/aio/molecule.yml
+++ b/molecule/aio/molecule.yml
@@ -12,3 +12,18 @@ ansible:
     args:
       ansible_playbook:
         - --inventory=${MOLECULE_PROJECT_DIRECTORY}/inventory.yaml
+
+scenario:
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/releasenotes/notes/ci-skip-idempotence-in-check-acb7981100725f67.yaml
+++ b/releasenotes/notes/ci-skip-idempotence-in-check-acb7981100725f67.yaml
@@ -1,0 +1,10 @@
+---
+other:
+  - |
+    CI runs of the ``aio`` Molecule scenario now skip the
+    ``idempotence`` step in the check pipeline. The full
+    ``molecule test`` sequence, including ``idempotence``, still
+    runs in the gate pipeline and in periodic jobs, so gate still
+    verifies roles converge cleanly on a second run before a
+    change merges. This shortens the typical check run by the cost
+    of a second converge.

--- a/test-playbooks/molecule/pre.yml
+++ b/test-playbooks/molecule/pre.yml
@@ -10,3 +10,16 @@
         update_cache: true
       when:
         - ansible_facts['os_family'] | lower == 'debian'
+
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Drop "idempotence" from AIO test sequence in check pipeline
+      run_once: true
+      ansible.builtin.lineinfile:
+        path: "{{ zuul.project.src_dir }}/molecule/aio/molecule.yml"
+        regexp: '^\s*-\s*idempotence\s*$'
+        state: absent
+      when:
+        - molecule_scenario | default('') == 'aio'
+        - zuul.pipeline | default('') == 'check'


### PR DESCRIPTION
## Summary

Idempotence re-runs the full AIO converge (~20-30 minutes) to assert that every role converges with zero changed tasks on a second run. Running it on **every** check build is wasteful: it roughly doubles the wall time of the AIO job and the same guarantee is re-verified in the gate pipeline before merge.

## Change

- Make the AIO scenario's `test_sequence` explicit in `molecule/aio/molecule.yml` (otherwise Molecule uses its built-in default).
- In `test-playbooks/molecule/pre.yml`, drop the `idempotence` line from that sequence when `zuul.pipeline == 'check'`.
- Gate and periodic runs are untouched — they still execute the full `molecule test` including `idempotence`.

## Expected saving

On a clean check run of `atmosphere-molecule-aio-*`, the idempotence converge accounts for **~20-30 minutes of a ~60 minute job**. Most PRs push multiple times before merging, so this compounds across the life of a change.

## Stacking

Branched from `feat/parallel-deploy-orchestrator` (#3818) per request. Once #3818 lands, this PR's diff against main will just be the 3 files above.

The same change will also be rolled into #3841.

## Caveats

- If a role regresses idempotence on a `main` branch that has no direct gate run (e.g. scheduled jobs), the periodic job will still catch it.
- Check-pipeline reviewers no longer get a per-push signal that a role is idempotent. That is a deliberate trade-off: gate blocks merge anyway.

Signed-off-by: Rico Lin <ricolin@ricolky.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
