### PR TITLE
[Backport stable/zed] upgrade capo from 0.12.4 to 0.12.7

### DIFF
--- a/releasenotes/notes/upgrade-capo-b8d1ae334a82ac73.yaml
+++ b/releasenotes/notes/upgrade-capo-b8d1ae334a82ac73.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Upgrade CAPO version to 0.12.7.

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -39,7 +39,7 @@ _atmosphere_images:
   cluster_api_controller: "{{ atmosphere_image_prefix }}registry.k8s.io/cluster-api/cluster-api-controller:v1.10.5"
   cluster_api_kubeadm_bootstrap_controller: "{{ atmosphere_image_prefix }}registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.10.5"
   cluster_api_kubeadm_control_plane_controller: "{{ atmosphere_image_prefix }}registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.10.5"
-  cluster_api_openstack_controller: "{{ atmosphere_image_prefix }}registry.k8s.io/capi-openstack/capi-openstack-controller:v0.12.4"
+  cluster_api_openstack_controller: "{{ atmosphere_image_prefix }}registry.k8s.io/capi-openstack/capi-openstack-controller:v0.12.7"
   csi_node_driver_registrar: "{{ atmosphere_image_prefix }}registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.4.0"
   csi_rbd_attacher: "{{ atmosphere_image_prefix }}registry.k8s.io/sig-storage/csi-attacher:v3.4.0"
   csi_rbd_plugin: "{{ atmosphere_image_prefix }}quay.io/cephcsi/cephcsi:v3.5.1"

--- a/roles/magnum/meta/main.yml
+++ b/roles/magnum/meta/main.yml
@@ -42,7 +42,7 @@ dependencies:
       clusterctl_config: "{{ magnum_clusterctl_config }}"
       cluster_api_version: 1.10.5
       cluster_api_infrastructure_provider: openstack
-      cluster_api_infrastructure_version: 0.12.4
+      cluster_api_infrastructure_version: 0.12.7
       cluster_api_node_selector:
         openstack-control-plane: enabled
       openstack_resource_controller_node_selector:


### PR DESCRIPTION
# Description
Backport of #3863 to `stable/zed`.

Manual backport: the automated backport failed due to unrelated context conflicts in `roles/defaults/vars/main.yml` (different CSI image versions in zed). Only the capo version was updated to 0.12.7.