### PR TITLE
feat(magnum,libvirt): add priorityClassName support for libvirt and Magnum aux workloads

### DIFF
--- a/charts/libvirt/templates/daemonset-libvirt.yaml
+++ b/charts/libvirt/templates/daemonset-libvirt.yaml
@@ -65,6 +65,7 @@ spec:
         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "helm-toolkit.utils.hash" }}
         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "helm-toolkit.utils.hash" }}
     spec:
+{{ tuple "libvirt" . | include "helm-toolkit.snippets.kubernetes_pod_priority_class" | indent 6 }}
 {{ dict "envAll" $envAll "application" "libvirt" | include "helm-toolkit.snippets.kubernetes_pod_security_context" | indent 6 }}
       serviceAccountName: {{ $serviceAccountName }}
       nodeSelector:

--- a/charts/libvirt/values.yaml
+++ b/charts/libvirt/values.yaml
@@ -217,6 +217,8 @@ conf:
       fi
 
 pod:
+  priorityClassName:
+    libvirt: ""
   probes:
     libvirt:
       libvirt:

--- a/charts/patches/libvirt/0003-add-priorityClassName-support.patch
+++ b/charts/patches/libvirt/0003-add-priorityClassName-support.patch
@@ -1,0 +1,25 @@
+diff --git a/libvirt/templates/daemonset-libvirt.yaml b/libvirt/templates/daemonset-libvirt.yaml
+index a64318e9..508f163c 100644
+--- a/libvirt/templates/daemonset-libvirt.yaml
++++ b/libvirt/templates/daemonset-libvirt.yaml
+@@ -65,6 +65,7 @@ spec:
+         configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "helm-toolkit.utils.hash" }}
+         configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "helm-toolkit.utils.hash" }}
+     spec:
++{{ tuple "libvirt" . | include "helm-toolkit.snippets.kubernetes_pod_priority_class" | indent 6 }}
+ {{ dict "envAll" $envAll "application" "libvirt" | include "helm-toolkit.snippets.kubernetes_pod_security_context" | indent 6 }}
+       serviceAccountName: {{ $serviceAccountName }}
+       nodeSelector:
+diff --git a/libvirt/values.yaml b/libvirt/values.yaml
+index 626efd3a..8ff4b8f4 100644
+--- a/libvirt/values.yaml
++++ b/libvirt/values.yaml
+@@ -217,6 +217,8 @@ conf:
+       fi
+ 
+ pod:
++  priorityClassName:
++    libvirt: ""
+   probes:
+     libvirt:
+       libvirt:

--- a/releasenotes/notes/add-priorityclassname-libvirt-magnum-8b40dedb989e1b9d.yaml
+++ b/releasenotes/notes/add-priorityclassname-libvirt-magnum-8b40dedb989e1b9d.yaml
@@ -1,11 +1,11 @@
 ---
 features:
   - |
-    The ``libvirt`` daemonset now honors the standard
+    The ``libvirt`` DaemonSet now honors the standard
     ``pod.priorityClassName.libvirt`` Helm value, so operators can assign a
-    Kubernetes PriorityClass to it as with the other OpenStack components.
+    Kubernetes PriorityClass to it as with other OpenStack components.
   - |
-    The ``magnum-cluster-api-proxy`` daemonset and ``magnum-registry``
-    deployment can now be assigned a Kubernetes PriorityClass through the
-    new ``magnum_cluster_api_proxy_priority_class_name`` and
-    ``magnum_registry_priority_class_name`` Ansible variables.
+    The Magnum cluster API proxy DaemonSet and Magnum registry deployment
+    now support the ``magnum_cluster_api_proxy_priority_class_name`` and
+    ``magnum_registry_priority_class_name`` Ansible variables to set a
+    Kubernetes PriorityClass.

--- a/releasenotes/notes/add-priorityclassname-libvirt-magnum-8b40dedb989e1b9d.yaml
+++ b/releasenotes/notes/add-priorityclassname-libvirt-magnum-8b40dedb989e1b9d.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    The ``libvirt`` daemonset now honors the standard
+    ``pod.priorityClassName.libvirt`` Helm value, so operators can assign a
+    Kubernetes PriorityClass to it as with the other OpenStack components.
+  - |
+    The ``magnum-cluster-api-proxy`` daemonset and ``magnum-registry``
+    deployment can now be assigned a Kubernetes PriorityClass through the
+    new ``magnum_cluster_api_proxy_priority_class_name`` and
+    ``magnum_registry_priority_class_name`` Ansible variables.

--- a/roles/magnum/defaults/main.yml
+++ b/roles/magnum/defaults/main.yml
@@ -53,3 +53,15 @@ magnum_cluster_api_proxy_ovs_node_selector:
   openstack-control-plane: enabled
 magnum_cluster_api_proxy_ovn_node_selector:
   openvswitch: enabled
+
+# Name of the Kubernetes PriorityClass to assign to the magnum-cluster-api-proxy
+# daemonset pods. Leave empty to omit the field (no priority class).
+#
+# magnum_cluster_api_proxy_priority_class_name: platform
+magnum_cluster_api_proxy_priority_class_name: ""
+
+# Name of the Kubernetes PriorityClass to assign to the magnum-registry
+# deployment pods. Leave empty to omit the field (no priority class).
+#
+# magnum_registry_priority_class_name: platform
+magnum_registry_priority_class_name: ""

--- a/roles/magnum/tasks/main.yml
+++ b/roles/magnum/tasks/main.yml
@@ -48,6 +48,46 @@
 
 - name: Deploy "magnum-cluster-api-proxy"
   run_once: true
+  vars:
+    _magnum_cluster_api_proxy_pod_spec:
+      containers:
+        - name: magnum-cluster-api-proxy
+          command: ["magnum-cluster-api-proxy"]
+          image: "{{ atmosphere_images['magnum_cluster_api_proxy'] | vexxhost.kubernetes.docker_image('ref') }}"
+          securityContext:
+            privileged: true
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: pod-tmp
+              mountPath: /tmp
+            - name: pod-run
+              mountPath: /run
+            - name: config
+              mountPath: /etc/sudoers.d/magnum_capi_sudoers
+              subPath: magnum_capi_sudoers
+              readOnly: true
+            - name: haproxy-state
+              mountPath: /var/lib/magnum/.magnum-cluster-api-proxy
+            - name: host-run-netns
+              mountPath: /run/netns
+              mountPropagation: Bidirectional
+      nodeSelector: "{{ magnum_cluster_api_proxy_ovn_node_selector if atmosphere_network_backend == 'ovn' else magnum_cluster_api_proxy_ovs_node_selector }}"  # noqa: yaml[line-length]
+      securityContext:
+        runAsUser: 42424
+      serviceAccountName: magnum-conductor
+      volumes:
+        - name: pod-tmp
+          emptyDir: {}
+        - name: pod-run
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: magnum-cluster-api-proxy-config
+        - name: haproxy-state
+          emptyDir: {}
+        - name: host-run-netns
+          hostPath:
+            path: /run/netns
   kubernetes.core.k8s:
     state: present
     definition:
@@ -80,45 +120,7 @@
               labels:
                 application: magnum
                 component: cluster-api-proxy
-            spec:
-              containers:
-                - name: magnum-cluster-api-proxy
-                  command: ["magnum-cluster-api-proxy"]
-                  image: "{{ atmosphere_images['magnum_cluster_api_proxy'] | vexxhost.kubernetes.docker_image('ref') }}"
-                  securityContext:
-                    privileged: true
-                    readOnlyRootFilesystem: true
-                  volumeMounts:
-                    - name: pod-tmp
-                      mountPath: /tmp
-                    - name: pod-run
-                      mountPath: /run
-                    - name: config
-                      mountPath: /etc/sudoers.d/magnum_capi_sudoers
-                      subPath: magnum_capi_sudoers
-                      readOnly: true
-                    - name: haproxy-state
-                      mountPath: /var/lib/magnum/.magnum-cluster-api-proxy
-                    - name: host-run-netns
-                      mountPath: /run/netns
-                      mountPropagation: Bidirectional
-              nodeSelector: "{{ magnum_cluster_api_proxy_ovn_node_selector if atmosphere_network_backend == 'ovn' else magnum_cluster_api_proxy_ovs_node_selector }}"  # noqa: yaml[line-length]
-              securityContext:
-                runAsUser: 42424
-              serviceAccountName: magnum-conductor
-              volumes:
-                - name: pod-tmp
-                  emptyDir: {}
-                - name: pod-run
-                  emptyDir: {}
-                - name: config
-                  configMap:
-                    name: magnum-cluster-api-proxy-config
-                - name: haproxy-state
-                  emptyDir: {}
-                - name: host-run-netns
-                  hostPath:
-                    path: /run/netns
+            spec: "{{ _magnum_cluster_api_proxy_pod_spec | combine({'priorityClassName': magnum_cluster_api_proxy_priority_class_name} if magnum_cluster_api_proxy_priority_class_name else {}) }}"  # noqa: yaml[line-length]
 
 - name: Create Ingress
   ansible.builtin.include_role:
@@ -132,6 +134,30 @@
 
 - name: Deploy magnum registry
   run_once: true
+  vars:
+    _magnum_registry_pod_spec:
+      containers:
+        - name: registry
+          image: "{{ atmosphere_images['magnum_registry'] | vexxhost.kubernetes.docker_image('ref') }}"
+          env:
+            - name: REGISTRY_STORAGE_MAINTENANCE_READONLY
+              value: '{"enabled": true}'
+          ports:
+            - name: registry
+              containerPort: 5000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 5000
+              scheme: HTTP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 5000
+              scheme: HTTP
+      nodeSelector:
+        openstack-control-plane: enabled
   kubernetes.core.k8s:
     state: present
     definition:
@@ -154,29 +180,7 @@
               labels:
                 application: magnum
                 component: registry
-            spec:
-              containers:
-                - name: registry
-                  image: "{{ atmosphere_images['magnum_registry'] | vexxhost.kubernetes.docker_image('ref') }}"
-                  env:
-                    - name: REGISTRY_STORAGE_MAINTENANCE_READONLY
-                      value: '{"enabled": true}'
-                  ports:
-                    - name: registry
-                      containerPort: 5000
-                      protocol: TCP
-                  livenessProbe:
-                    httpGet:
-                      path: /
-                      port: 5000
-                      scheme: HTTP
-                  readinessProbe:
-                    httpGet:
-                      path: /
-                      port: 5000
-                      scheme: HTTP
-              nodeSelector:
-                openstack-control-plane: enabled
+            spec: "{{ _magnum_registry_pod_spec | combine({'priorityClassName': magnum_registry_priority_class_name} if magnum_registry_priority_class_name else {}) }}"  # noqa: yaml[line-length]
 
       - apiVersion: v1
         kind: Service


### PR DESCRIPTION
## Summary

Closes #3896.

Atmosphere lets operators assign a Kubernetes `priorityClassName` to most OpenStack workloads through the OpenStack-Helm `pod.priorityClassName.<component>` values, but three workloads have had no way to be configured this way:

- `libvirt-libvirt-default` daemonset (`charts/libvirt`)
- `magnum-cluster-api-proxy` daemonset (inline manifest in `roles/magnum/tasks/main.yml`)
- `magnum-registry` deployment (inline manifest in `roles/magnum/tasks/main.yml`)

This PR closes those three gaps.

## Changes

### libvirt chart

- Wire the existing `helm-toolkit.snippets.kubernetes_pod_priority_class` snippet into `charts/libvirt/templates/daemonset-libvirt.yaml`.
- Add the corresponding `pod.priorityClassName.libvirt` key to `charts/libvirt/values.yaml` (default empty).
- Track the change as a new vendored chart patch at `charts/patches/libvirt/0003-add-priorityClassName-support.patch` so `chart-vendor` reapplies it on the next chart bump.

### magnum role

- Restructure the inline `magnum-cluster-api-proxy` daemonset and `magnum-registry` deployment manifests so the pod spec is built from a `vars` block and merged with a conditional `priorityClassName` via the `combine` filter.
- Introduce two new defaults in `roles/magnum/defaults/main.yml`:
  - `magnum_cluster_api_proxy_priority_class_name` (default empty)
  - `magnum_registry_priority_class_name` (default empty)
- When unset, the `priorityClassName` field is omitted from the pod spec, preserving existing behavior.

### Release note

Added under `features`.

## Usage

```yaml
# group_vars or host_vars
magnum_cluster_api_proxy_priority_class_name: platform
magnum_registry_priority_class_name: platform

atmosphere_libvirt_helm_values_overrides:
  pod:
    priorityClassName:
      libvirt: platform
```

## Testing

- `go test ./roles/magnum/` passes (existing helm-values priority-class assertions still hold).
- `vale` is clean on the new release note.
- Helm chart unit tests run in CI.

## Customer reference

Reported by an operator rolling out Atmosphere 5.8.0 who needs every OpenStack pod to run with a chosen `priorityClassName` so infrastructure pods are protected from preemption / eviction under node pressure (Zendesk #369923).