### PR TITLE
feat(monitoring): add HostNICSpeedUnknown alert

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -88,6 +88,7 @@ backport
 boolean
 cgroup
 etcd
+ethtool
 image_manifest
 kek
 libvirt

--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -1044,6 +1044,62 @@ the risk of a full outage if another node fails.
 
      kubectl -n openstack get pxc-backup
 
+``HostNICSpeedUnknown``
+=======================
+
+This alert fires when ``node_network_speed_bytes`` reports a negative value for
+a network interface for at least 5 minutes. ``node_exporter`` returns a
+negative value when the kernel cannot read the interface speed via ethtool
+(``Speed: Unknown!``), which typically indicates a silent data-plane failure:
+the OS keeps the link administratively up but the transceiver, cable, or
+switch port is degraded so no link speed can be negotiated. Bonded interfaces
+will not detect this state because MII status remains up, so the underlying
+slave can stay in the bond as a "zombie" carrying no traffic.
+
+**Likely root causes:**
+
+- Failed or marginal transceiver, DAC/AOC cable, or fiber patch
+- Switch port disabled, errdisabled, or in an unexpected operational state
+- NIC firmware bug after a host or switch reboot
+- NIC hardware fault (queue or PHY failure) that does not raise a carrier event
+
+**Diagnostic and remediation steps:**
+
+1. Identify the affected host and interface from the alert labels (``instance``
+   and ``device``).
+
+2. Confirm the speed is unknown on the host:
+
+   .. code-block:: console
+
+      ethtool <device> | grep -E "Speed|Link detected"
+
+3. Check whether the interface is part of a bond and how traffic is split
+   across slaves:
+
+   .. code-block:: console
+
+      cat /proc/net/bonding/<bond>
+      ip -s link show <device>
+
+4. Inspect the kernel log for transceiver, link, or driver events:
+
+   .. code-block:: console
+
+      dmesg -T | grep -i -E "<device>|link|sfp|phy|transceiver" | tail -50
+
+5. If the interface is connected to a managed switch, validate the peer port
+   state, optics, and counters from the switch side. Compare with the healthy
+   slave on the same host.
+
+6. If the speed remains unknown after checks, schedule a maintenance window
+   to:
+
+   - Reseat or replace the transceiver and cable.
+   - Move the connection to a known-good switch port.
+   - Reboot the host to reload the NIC driver and firmware (this often clears
+     the condition when the root cause is a firmware glitch).
+
 ``NodeDiskHighLatency``
 =======================
 

--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -911,25 +911,34 @@ experiencing network issues.
 ``HostNICSpeedUnknown``
 =======================
 
-This alert fires when ``node_network_speed_bytes`` reports a negative value for
-a physical Ethernet interface whose carrier is still up, for at least 5
-minutes. The expression also requires ``node_network_protocol_type == 1``
-(ARPHRD_ETHER) and ``node_network_carrier == 1`` so that virtual tunnel
-devices and simply disconnected ports are excluded. ``node_exporter`` returns
-a negative value (typically ``-125000``) when the kernel can't read the
-interface speed via ethtool (``Speed: Unknown!``), which typically indicates a
-silent data-plane failure: the OS keeps the link administratively up but the
-transceiver, cable, or switch port is degraded so no link speed can be
-negotiated. Bonded interfaces will not detect this state because MII status
-remains up, so the underlying slave can stay in the bond as a "zombie"
-carrying no traffic.
+This alert fires when ``node_network_speed_bytes`` reports a negative value
+for a physical Ethernet interface whose carrier is still up, for at least
+5 minutes.
+
+The expression also requires ``node_network_protocol_type == 1``
+(``ARPHRD_ETHER``) and ``node_network_carrier == 1``. This filter skips
+virtual tunnel devices and physical ports that the operator has shut.
+
+``node_exporter`` returns a negative value (typically ``-125000``) when the
+kernel can't read the interface speed via ``ethtool``
+(``Speed: Unknown!``). A negative value typically points to a silent
+data-plane failure. The OS keeps the link administratively up, but a fault
+on the transceiver, cable, or switch port prevents the kernel from
+negotiating a link speed.
+
+Bonded interfaces won't detect this state because the Media-Independent
+Interface (MII) status remains up. The underlying slave then stays in the
+bond as a "zombie" carrying no traffic.
 
 **Likely root causes:**
 
-- Failed or marginal transceiver, DAC/AOC cable, or fiber patch
-- Switch port disabled, errdisabled, or in an unexpected operational state
-- NIC firmware bug after a host or switch reboot
-- NIC hardware fault (queue or PHY failure) that doesn't raise a carrier event
+- Failed or marginal transceiver, Direct Attach Copper (DAC) or Active
+  Optical Cable (AOC), or fiber patch
+- Switch port that the operator has shut, an ``err-disabled`` port, or a
+  port in an unexpected operational state
+- Network Interface Card (NIC) firmware bug after a host or switch reboot
+- NIC hardware fault, such as a queue or Physical Layer (PHY) failure that
+  doesn't raise a carrier event
 
 **Diagnostic and remediation steps:**
 
@@ -942,8 +951,8 @@ carrying no traffic.
 
       ethtool <device> | grep -E "Speed|Link detected"
 
-3. Check whether the interface is part of a bond and how traffic is split
-   across slaves:
+3. Check whether the interface is part of a bond and how the bond splits
+   traffic across slaves:
 
    .. code-block:: console
 
@@ -956,7 +965,7 @@ carrying no traffic.
 
       dmesg -T | grep -i -E "<device>|link|sfp|phy|transceiver" | tail -50
 
-5. If the interface is connected to a managed switch, validate the peer port
+5. If the interface connects to a managed switch, validate the peer port
    state, optics, and counters from the switch side. Compare with the healthy
    slave on the same host.
 
@@ -965,8 +974,8 @@ carrying no traffic.
 
    - Reseat or replace the transceiver and cable.
    - Move the connection to a known-good switch port.
-   - Reboot the host to reload the NIC driver and firmware (this often clears
-     the condition when the root cause is a firmware glitch).
+   - Reboot the host to reload the NIC driver and firmware. This often clears
+     the condition when the root cause is a firmware glitch.
 
 ``IpmiUncorrectableMemoryError``
 ================================

--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -916,7 +916,7 @@ a physical Ethernet interface whose carrier is still up, for at least 5
 minutes. The expression also requires ``node_network_protocol_type == 1``
 (ARPHRD_ETHER) and ``node_network_carrier == 1`` so that virtual tunnel
 devices and simply disconnected ports are excluded. ``node_exporter`` returns
-a negative value (typically ``-125000``) when the kernel cannot read the
+a negative value (typically ``-125000``) when the kernel can't read the
 interface speed via ethtool (``Speed: Unknown!``), which typically indicates a
 silent data-plane failure: the OS keeps the link administratively up but the
 transceiver, cable, or switch port is degraded so no link speed can be
@@ -929,7 +929,7 @@ carrying no traffic.
 - Failed or marginal transceiver, DAC/AOC cable, or fiber patch
 - Switch port disabled, errdisabled, or in an unexpected operational state
 - NIC firmware bug after a host or switch reboot
-- NIC hardware fault (queue or PHY failure) that does not raise a carrier event
+- NIC hardware fault (queue or PHY failure) that doesn't raise a carrier event
 
 **Diagnostic and remediation steps:**
 

--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -908,6 +908,66 @@ experiencing network issues.
      kubectl debug node/<affected-node> -it --image=busybox -- \
        cat /host/var/log/syslog | tail -100
 
+``HostNICSpeedUnknown``
+=======================
+
+This alert fires when ``node_network_speed_bytes`` reports a negative value for
+a physical Ethernet interface whose carrier is still up, for at least 5
+minutes. The expression also requires ``node_network_protocol_type == 1``
+(ARPHRD_ETHER) and ``node_network_carrier == 1`` so that virtual tunnel
+devices and simply disconnected ports are excluded. ``node_exporter`` returns
+a negative value (typically ``-125000``) when the kernel cannot read the
+interface speed via ethtool (``Speed: Unknown!``), which typically indicates a
+silent data-plane failure: the OS keeps the link administratively up but the
+transceiver, cable, or switch port is degraded so no link speed can be
+negotiated. Bonded interfaces will not detect this state because MII status
+remains up, so the underlying slave can stay in the bond as a "zombie"
+carrying no traffic.
+
+**Likely root causes:**
+
+- Failed or marginal transceiver, DAC/AOC cable, or fiber patch
+- Switch port disabled, errdisabled, or in an unexpected operational state
+- NIC firmware bug after a host or switch reboot
+- NIC hardware fault (queue or PHY failure) that does not raise a carrier event
+
+**Diagnostic and remediation steps:**
+
+1. Identify the affected host and interface from the alert labels (``instance``
+   and ``device``).
+
+2. Confirm the speed is unknown on the host:
+
+   .. code-block:: console
+
+      ethtool <device> | grep -E "Speed|Link detected"
+
+3. Check whether the interface is part of a bond and how traffic is split
+   across slaves:
+
+   .. code-block:: console
+
+      cat /proc/net/bonding/<bond>
+      ip -s link show <device>
+
+4. Inspect the kernel log for transceiver, link, or driver events:
+
+   .. code-block:: console
+
+      dmesg -T | grep -i -E "<device>|link|sfp|phy|transceiver" | tail -50
+
+5. If the interface is connected to a managed switch, validate the peer port
+   state, optics, and counters from the switch side. Compare with the healthy
+   slave on the same host.
+
+6. If the speed remains unknown after checks, schedule a maintenance window
+   to:
+
+   - Reseat or replace the transceiver and cable.
+   - Move the connection to a known-good switch port.
+   - Reboot the host to reload the NIC driver and firmware (this often clears
+     the condition when the root cause is a firmware glitch).
+
 ``IpmiUncorrectableMemoryError``
 ================================
 
@@ -1043,62 +1103,6 @@ the risk of a full outage if another node fails.
    .. code-block:: console
 
      kubectl -n openstack get pxc-backup
-
-``HostNICSpeedUnknown``
-=======================
-
-This alert fires when ``node_network_speed_bytes`` reports a negative value for
-a network interface for at least 5 minutes. ``node_exporter`` returns a
-negative value when the kernel cannot read the interface speed via ethtool
-(``Speed: Unknown!``), which typically indicates a silent data-plane failure:
-the OS keeps the link administratively up but the transceiver, cable, or
-switch port is degraded so no link speed can be negotiated. Bonded interfaces
-will not detect this state because MII status remains up, so the underlying
-slave can stay in the bond as a "zombie" carrying no traffic.
-
-**Likely root causes:**
-
-- Failed or marginal transceiver, DAC/AOC cable, or fiber patch
-- Switch port disabled, errdisabled, or in an unexpected operational state
-- NIC firmware bug after a host or switch reboot
-- NIC hardware fault (queue or PHY failure) that does not raise a carrier event
-
-**Diagnostic and remediation steps:**
-
-1. Identify the affected host and interface from the alert labels (``instance``
-   and ``device``).
-
-2. Confirm the speed is unknown on the host:
-
-   .. code-block:: console
-
-      ethtool <device> | grep -E "Speed|Link detected"
-
-3. Check whether the interface is part of a bond and how traffic is split
-   across slaves:
-
-   .. code-block:: console
-
-      cat /proc/net/bonding/<bond>
-      ip -s link show <device>
-
-4. Inspect the kernel log for transceiver, link, or driver events:
-
-   .. code-block:: console
-
-      dmesg -T | grep -i -E "<device>|link|sfp|phy|transceiver" | tail -50
-
-5. If the interface is connected to a managed switch, validate the peer port
-   state, optics, and counters from the switch side. Compare with the healthy
-   slave on the same host.
-
-6. If the speed remains unknown after checks, schedule a maintenance window
-   to:
-
-   - Reseat or replace the transceiver and cable.
-   - Move the connection to a known-good switch port.
-   - Reboot the host to reload the NIC driver and firmware (this often clears
-     the condition when the root cause is a firmware glitch).
 
 ``NodeDiskHighLatency``
 =======================

--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -4,7 +4,7 @@ Monitoring and operations
 
 Atmosphere includes a Grafana deployment with dashboards created by default and
 a Prometheus deployment that collects metrics from the cluster and sends alerts
-to AlertManager. Loki also collects logs from the cluster using Vector.
+to Alertmanager. Loki also collects logs from the cluster using Vector.
 
 ******************************
 Philosophy and alerting levels
@@ -49,7 +49,7 @@ Inhibition and grouping
 -----------------------
 
 Alerts have dependency awareness. When a parent component fails (for example, a
-node goes down), inhibition rules in AlertManager suppress child component
+node goes down), inhibition rules in Alertmanager suppress child component
 alerts (for example, pods on that node) to avoid cascading alert storms.
 The system groups related alerts so that a single notification represents a
 coherent incident rather than dozens of individual symptoms.
@@ -126,23 +126,23 @@ as an admin user.
       :alt: Silences menu
       :width: 200
 
-2. Make sure that you select "AlertManager" on the top right corner of the page,
-   this ensures that you create a silence inside of the AlertManager
+2. Make sure that you select "Alertmanager" on the top right corner of the page,
+   this ensures that you create a silence inside of the Alertmanager
    that's managed by the Prometheus operator instead of the built-in Grafana
-   AlertManager which isn't used.
+   Alertmanager which isn't used.
 
     .. image:: images/monitoring-alertmanger-list.png
-        :alt: AlertManager list
+        :alt: Alertmanager list
         :width: 200
 
-   .. admonition:: AlertManager selection
+   .. admonition:: Alertmanager selection
     :class: warning
 
-    It's important that you select the AlertManager that's managed by the
+    It's important that you select the Alertmanager that's managed by the
     Prometheus operator, otherwise your silence won't apply to the
     Prometheus instance that Atmosphere deploys.
 
-3. Click the "Add Silence" button and use the AlertManager format to create
+3. Click the "Add Silence" button and use the Alertmanager format to create
    your silence, which you can test by seeing if it matches any alerts in the
    list labeled "Affected alert instances".
 
@@ -211,7 +211,7 @@ Viewing data
 ************
 
 The monitoring stack offers a few different ways to view collected data. The most
-common ways are through AlertManager, Grafana, and Prometheus.
+common ways are through Alertmanager, Grafana, and Prometheus.
 
 Grafana dashboard
 =================
@@ -298,10 +298,10 @@ changes to your inventory:
 In this example, the configuration restricts access to the IP range
 ``10.0.0.0/24`` and the IP address ``172.10.0.1``.
 
-AlertManager
+Alertmanager
 ============
 
-By default, the AlertManager dashboard points to the Ansible variable
+By default, the Alertmanager dashboard points to the Ansible variable
 ``kube_prometheus_stack_alertmanager_host`` and sits behind an ``Ingress``
 with the `oauth2-proxy` service, protected by Keycloak similar to Prometheus.
 
@@ -309,10 +309,10 @@ with the `oauth2-proxy` service, protected by Keycloak similar to Prometheus.
 Integrations
 ************
 
-Since Atmosphere relies on AlertManager to send alerts, you can integrate it
+Since Atmosphere relies on Alertmanager to send alerts, you can integrate it
 with services like OpsGenie, PagerDuty, email, and more. To receive monitoring
 alerts using your preferred notification tools, integrate them with
-AlertManager.
+Alertmanager.
 
 OpsGenie
 ========
@@ -912,23 +912,27 @@ experiencing network issues.
 =======================
 
 This alert fires when ``node_network_speed_bytes`` reports a negative value
-for a physical Ethernet interface whose carrier is still up, for at least
-5 minutes.
+for a candidate physical Ethernet interface whose carrier is still up, for at
+least 1 hour.
 
 The expression also requires ``node_network_protocol_type == 1``
-(``ARPHRD_ETHER``) and ``node_network_carrier == 1``. This filter skips
-virtual tunnel devices and physical ports that the operator has shut.
+(``ARPHRD_ETHER``) and ``node_network_carrier == 1``. It excludes common
+virtual interface prefixes such as ``bond``, ``veth``, ``team``, ``macvlan``,
+bridge, tap, Open vSwitch, and overlay tunnel devices. This filter skips
+virtual network plumbing and physical ports that the operator has shut.
 
 ``node_exporter`` returns a negative value (typically ``-125000``) when the
 kernel can't read the interface speed via ``ethtool``
-(``Speed: Unknown!``). A negative value typically points to a silent
-data-plane failure. The OS keeps the link administratively up, but a fault
-on the transceiver, cable, or switch port prevents the kernel from
-negotiating a link speed.
+(``Speed: Unknown!``). A negative value can point to a silent data-plane
+failure. The OS keeps the link administratively up, but a fault on the
+transceiver, cable, or switch port prevents the kernel from negotiating a link
+speed.
 
-Bonded interfaces won't detect this state because the Media-Independent
-Interface (MII) status remains up. The underlying slave then stays in the
-bond as a "zombie" carrying no traffic.
+This is a cause-based P4 early warning because it affects one host interface
+and may reduce data-plane capacity or redundancy before a user-visible
+symptom appears. Bonded interfaces may not detect this state because the
+Media-Independent Interface (MII) status can remain up while the underlying
+slave carries no traffic.
 
 **Likely root causes:**
 

--- a/releasenotes/notes/host-nic-speed-unknown-alert-7c5a49ac2c0f9b1e.yaml
+++ b/releasenotes/notes/host-nic-speed-unknown-alert-7c5a49ac2c0f9b1e.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Add a new ``HostNICSpeedUnknown`` alert that fires when
+    ``node_network_speed_bytes`` reports a negative value (ethtool
+    ``Speed: Unknown!``) on a network interface for more than 5 minutes. This
+    catches silent data-plane failures on bond slaves where the link stays
+    administratively up but cannot negotiate a speed, a condition that is not
+    detected by ``NodeBondingDegraded`` because MII status remains up.

--- a/releasenotes/notes/host-nic-speed-unknown-alert-7c5a49ac2c0f9b1e.yaml
+++ b/releasenotes/notes/host-nic-speed-unknown-alert-7c5a49ac2c0f9b1e.yaml
@@ -3,8 +3,9 @@ features:
   - |
     Add a new ``HostNICSpeedUnknown`` alert that fires when
     ``node_network_speed_bytes`` reports a negative value (ethtool
-    ``Speed: Unknown!``) on a network interface for more than 5 minutes. This
-    catches silent data-plane failures on bond slaves where the link stays
-    administratively up but can't negotiate a speed. ``NodeBondingDegraded``
-    doesn't detect this condition because the Media-Independent Interface (MII)
-    status remains up.
+    ``Speed: Unknown!``) on a candidate physical network interface for more
+    than 1 hour. This catches possible silent data-plane failures where the link
+    stays administratively up but can't negotiate a speed, while filtering
+    common virtual Ethernet, bridge, tap, Open vSwitch, and overlay interfaces.
+    The alert is P4 because it's a cause-based early warning for reduced host
+    data-plane capacity or redundancy.

--- a/releasenotes/notes/host-nic-speed-unknown-alert-7c5a49ac2c0f9b1e.yaml
+++ b/releasenotes/notes/host-nic-speed-unknown-alert-7c5a49ac2c0f9b1e.yaml
@@ -5,5 +5,5 @@ features:
     ``node_network_speed_bytes`` reports a negative value (ethtool
     ``Speed: Unknown!``) on a network interface for more than 5 minutes. This
     catches silent data-plane failures on bond slaves where the link stays
-    administratively up but cannot negotiate a speed, a condition that is not
+    administratively up but can't negotiate a speed, a condition that isn't
     detected by ``NodeBondingDegraded`` because MII status remains up.

--- a/releasenotes/notes/host-nic-speed-unknown-alert-7c5a49ac2c0f9b1e.yaml
+++ b/releasenotes/notes/host-nic-speed-unknown-alert-7c5a49ac2c0f9b1e.yaml
@@ -5,5 +5,6 @@ features:
     ``node_network_speed_bytes`` reports a negative value (ethtool
     ``Speed: Unknown!``) on a network interface for more than 5 minutes. This
     catches silent data-plane failures on bond slaves where the link stays
-    administratively up but can't negotiate a speed, a condition that isn't
-    detected by ``NodeBondingDegraded`` because MII status remains up.
+    administratively up but can't negotiate a speed. ``NodeBondingDegraded``
+    doesn't detect this condition because the Media-Independent Interface (MII)
+    status remains up.

--- a/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
@@ -207,6 +207,7 @@ local mixins = {
       _config+:: {
         nodeExporterSelector: 'job="node-exporter"',
         diskDeviceSelector: 'device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"',
+        physicalNetworkDeviceSelector: 'device!~"^(bond|br|cilium_|docker|dummy|flannel|genev_sys|gre_sys|gretap|ifb|lxc|macvlan|macvtap|ovs-system|qbr|qvb|qvo|tap|tbr|team|tun|veth|vlan|vrf|vxlan|[0-9a-f]+_eth).*$"',
       },
       prometheusAlerts+:: {
         groups+: [
@@ -230,17 +231,17 @@ local mixins = {
               {
                 alert: 'HostNICSpeedUnknown',
                 expr: |||
-                  node_network_speed_bytes{%(nodeExporterSelector)s} < 0
+                  node_network_speed_bytes{%(nodeExporterSelector)s, %(physicalNetworkDeviceSelector)s} < 0
                     and on(instance, device) node_network_protocol_type{%(nodeExporterSelector)s} == 1
                     and on(instance, device) node_network_carrier{%(nodeExporterSelector)s} == 1
                 ||| % mixins.node._config,
-                'for': '5m',
+                'for': '1h',
                 labels: {
-                  severity: 'warning',
+                  severity: 'P4',
                 },
                 annotations: {
-                  summary: 'Host NIC: link is up but speed cannot be negotiated on {{ $labels.device }}',
-                  description: 'Interface {{ $labels.device }} on {{ $labels.instance }} reports node_network_speed_bytes={{ $value }} for more than 5 minutes while the link carrier is still up and the device is a physical Ethernet interface. A value below 0 (typically -125000) means the kernel cannot read the interface speed via ethtool ("Speed: Unknown!"); the threshold is < 0 bytes/sec. Normal behaviour is the negotiated link speed in bytes/sec (for example 3125000000 for 25 Gbps or 1250000000 for 10 Gbps). Bonded interfaces will not detect this state because MII status remains up, so the slave can stay in the bond as a "zombie" carrying no traffic.',
+                  summary: 'Host NIC: reduced data-plane capacity on {{ $labels.instance }} {{ $labels.device }}',
+                  description: 'Interface {{ $labels.device }} on {{ $labels.instance }} reports node_network_speed_bytes={{ $value }} for more than 1 hour while the link carrier is still up and the device passes the physical Ethernet interface filters. A value below 0 (typically -125000) means the kernel cannot read the interface speed via ethtool ("Speed: Unknown!"); the threshold is < 0 bytes/sec. Normal behaviour is the negotiated link speed in bytes/sec (for example 3125000000 for 25 Gbps or 1250000000 for 10 Gbps). This is a cause-based early warning for reduced host data-plane capacity or redundancy; bonded interfaces may not detect this state because MII status can remain up while the slave carries no traffic.',
                   runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#hostnicspeedunknown',
                 },
               },

--- a/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
@@ -228,6 +228,21 @@ local mixins = {
                 },
               },
               {
+                alert: 'HostNICSpeedUnknown',
+                expr: |||
+                  node_network_speed_bytes{%(nodeExporterSelector)s} < 0
+                ||| % mixins.node._config,
+                'for': '5m',
+                labels: {
+                  severity: 'warning',
+                },
+                annotations: {
+                  summary: 'NIC link speed is unknown',
+                  description: 'Interface {{ $labels.device }} on {{ $labels.instance }} is reporting an unknown link speed (ethtool "Speed: Unknown!") for more than 5 minutes. This typically indicates a silent data-plane failure where the OS keeps the link administratively up while the underlying transceiver, cable, or switch port is degraded, so the kernel cannot negotiate or read the speed. Bonded interfaces will not detect this condition because MII status remains up.',
+                  runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#hostnicspeedunknown',
+                },
+              },
+              {
                 alert: 'NodeDiskHighLatency',
                 expr: |||
                   (

--- a/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
@@ -231,14 +231,16 @@ local mixins = {
                 alert: 'HostNICSpeedUnknown',
                 expr: |||
                   node_network_speed_bytes{%(nodeExporterSelector)s} < 0
+                    and on(instance, device) node_network_protocol_type{%(nodeExporterSelector)s} == 1
+                    and on(instance, device) node_network_carrier{%(nodeExporterSelector)s} == 1
                 ||| % mixins.node._config,
                 'for': '5m',
                 labels: {
                   severity: 'warning',
                 },
                 annotations: {
-                  summary: 'NIC link speed is unknown',
-                  description: 'Interface {{ $labels.device }} on {{ $labels.instance }} is reporting an unknown link speed (ethtool "Speed: Unknown!") for more than 5 minutes. This typically indicates a silent data-plane failure where the OS keeps the link administratively up while the underlying transceiver, cable, or switch port is degraded, so the kernel cannot negotiate or read the speed. Bonded interfaces will not detect this condition because MII status remains up.',
+                  summary: 'Host NIC: link is up but speed cannot be negotiated on {{ $labels.device }}',
+                  description: 'Interface {{ $labels.device }} on {{ $labels.instance }} reports node_network_speed_bytes={{ $value }} for more than 5 minutes while the link carrier is still up and the device is a physical Ethernet interface. A value below 0 (typically -125000) means the kernel cannot read the interface speed via ethtool ("Speed: Unknown!"); the threshold is < 0 bytes/sec. Normal behaviour is the negotiated link speed in bytes/sec (for example 3125000000 for 25 Gbps or 1250000000 for 10 Gbps). Bonded interfaces will not detect this state because MII status remains up, so the slave can stay in the bond as a "zombie" carrying no traffic.',
                   runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#hostnicspeedunknown',
                 },
               },

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -106,6 +106,39 @@ tests:
         alertname: NodeTimeSkewDetected
         exp_alerts: []
 
+  # HostNICSpeedUnknown - negative test (normal positive speed, no alert)
+  - interval: 1m
+    input_series:
+      - series: 'node_network_speed_bytes{instance="192.0.2.1:9100", job="node-exporter", device="ens3f0np0"}'
+        values: '25000000000x10'
+      - series: 'node_network_speed_bytes{instance="192.0.2.1:9100", job="node-exporter", device="ens3f1np1"}'
+        values: '25000000000x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: HostNICSpeedUnknown
+        exp_alerts: []
+
+  # HostNICSpeedUnknown - positive test (negative speed indicates ethtool "Speed: Unknown!")
+  - interval: 1m
+    input_series:
+      - series: 'node_network_speed_bytes{instance="192.0.2.2:9100", job="node-exporter", device="ens3f0np0"}'
+        values: '-125000x10'
+      - series: 'node_network_speed_bytes{instance="192.0.2.2:9100", job="node-exporter", device="ens3f1np1"}'
+        values: '25000000000x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: HostNICSpeedUnknown
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+              instance: "192.0.2.2:9100"
+              job: node-exporter
+              device: ens3f0np0
+            exp_annotations:
+              summary: "NIC link speed is unknown"
+              description: 'Interface ens3f0np0 on 192.0.2.2:9100 is reporting an unknown link speed (ethtool "Speed: Unknown!") for more than 5 minutes. This typically indicates a silent data-plane failure where the OS keeps the link administratively up while the underlying transceiver, cable, or switch port is degraded, so the kernel cannot negotiate or read the speed. Bonded interfaces will not detect this condition because MII status remains up.'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#hostnicspeedunknown"
+
   # NodeDiskHighLatency - negative test (normal latency, no alert)
   - interval: 1m
     input_series:

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -113,18 +113,62 @@ tests:
         values: '25000000000x10'
       - series: 'node_network_speed_bytes{instance="192.0.2.1:9100", job="node-exporter", device="ens3f1np1"}'
         values: '25000000000x10'
+      - series: 'node_network_protocol_type{instance="192.0.2.1:9100", job="node-exporter", device="ens3f0np0"}'
+        values: '1x10'
+      - series: 'node_network_protocol_type{instance="192.0.2.1:9100", job="node-exporter", device="ens3f1np1"}'
+        values: '1x10'
+      - series: 'node_network_carrier{instance="192.0.2.1:9100", job="node-exporter", device="ens3f0np0"}'
+        values: '1x10'
+      - series: 'node_network_carrier{instance="192.0.2.1:9100", job="node-exporter", device="ens3f1np1"}'
+        values: '1x10'
     alert_rule_test:
       - eval_time: 10m
         alertname: HostNICSpeedUnknown
         exp_alerts: []
 
-  # HostNICSpeedUnknown - positive test (negative speed indicates ethtool "Speed: Unknown!")
+  # HostNICSpeedUnknown - negative test (virtual interface with unknown speed, no alert)
+  - interval: 1m
+    input_series:
+      - series: 'node_network_speed_bytes{instance="192.0.2.3:9100", job="node-exporter", device="genev_sys_6081"}'
+        values: '-125000x10'
+      - series: 'node_network_protocol_type{instance="192.0.2.3:9100", job="node-exporter", device="genev_sys_6081"}'
+        values: '65534x10'
+      - series: 'node_network_carrier{instance="192.0.2.3:9100", job="node-exporter", device="genev_sys_6081"}'
+        values: '1x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: HostNICSpeedUnknown
+        exp_alerts: []
+
+  # HostNICSpeedUnknown - negative test (physical Ethernet, link down with carrier=0, no alert)
+  - interval: 1m
+    input_series:
+      - series: 'node_network_speed_bytes{instance="192.0.2.4:9100", job="node-exporter", device="ens5f0np0"}'
+        values: '-125000x10'
+      - series: 'node_network_protocol_type{instance="192.0.2.4:9100", job="node-exporter", device="ens5f0np0"}'
+        values: '1x10'
+      - series: 'node_network_carrier{instance="192.0.2.4:9100", job="node-exporter", device="ens5f0np0"}'
+        values: '0x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: HostNICSpeedUnknown
+        exp_alerts: []
+
+  # HostNICSpeedUnknown - positive test (physical Ethernet, negative speed, carrier still up)
   - interval: 1m
     input_series:
       - series: 'node_network_speed_bytes{instance="192.0.2.2:9100", job="node-exporter", device="ens3f0np0"}'
         values: '-125000x10'
       - series: 'node_network_speed_bytes{instance="192.0.2.2:9100", job="node-exporter", device="ens3f1np1"}'
         values: '25000000000x10'
+      - series: 'node_network_protocol_type{instance="192.0.2.2:9100", job="node-exporter", device="ens3f0np0"}'
+        values: '1x10'
+      - series: 'node_network_protocol_type{instance="192.0.2.2:9100", job="node-exporter", device="ens3f1np1"}'
+        values: '1x10'
+      - series: 'node_network_carrier{instance="192.0.2.2:9100", job="node-exporter", device="ens3f0np0"}'
+        values: '1x10'
+      - series: 'node_network_carrier{instance="192.0.2.2:9100", job="node-exporter", device="ens3f1np1"}'
+        values: '1x10'
     alert_rule_test:
       - eval_time: 10m
         alertname: HostNICSpeedUnknown
@@ -135,8 +179,8 @@ tests:
               job: node-exporter
               device: ens3f0np0
             exp_annotations:
-              summary: "NIC link speed is unknown"
-              description: 'Interface ens3f0np0 on 192.0.2.2:9100 is reporting an unknown link speed (ethtool "Speed: Unknown!") for more than 5 minutes. This typically indicates a silent data-plane failure where the OS keeps the link administratively up while the underlying transceiver, cable, or switch port is degraded, so the kernel cannot negotiate or read the speed. Bonded interfaces will not detect this condition because MII status remains up.'
+              summary: "Host NIC: link is up but speed cannot be negotiated on ens3f0np0"
+              description: 'Interface ens3f0np0 on 192.0.2.2:9100 reports node_network_speed_bytes=-125000 for more than 5 minutes while the link carrier is still up and the device is a physical Ethernet interface. A value below 0 (typically -125000) means the kernel cannot read the interface speed via ethtool ("Speed: Unknown!"); the threshold is < 0 bytes/sec. Normal behaviour is the negotiated link speed in bytes/sec (for example 3125000000 for 25 Gbps or 1250000000 for 10 Gbps). Bonded interfaces will not detect this state because MII status remains up, so the slave can stay in the bond as a "zombie" carrying no traffic.'
               runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#hostnicspeedunknown"
 
   # NodeDiskHighLatency - negative test (normal latency, no alert)

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -110,19 +110,19 @@ tests:
   - interval: 1m
     input_series:
       - series: 'node_network_speed_bytes{instance="192.0.2.1:9100", job="node-exporter", device="ens3f0np0"}'
-        values: '25000000000x10'
+        values: '3125000000x70'
       - series: 'node_network_speed_bytes{instance="192.0.2.1:9100", job="node-exporter", device="ens3f1np1"}'
-        values: '25000000000x10'
+        values: '3125000000x70'
       - series: 'node_network_protocol_type{instance="192.0.2.1:9100", job="node-exporter", device="ens3f0np0"}'
-        values: '1x10'
+        values: '1x70'
       - series: 'node_network_protocol_type{instance="192.0.2.1:9100", job="node-exporter", device="ens3f1np1"}'
-        values: '1x10'
+        values: '1x70'
       - series: 'node_network_carrier{instance="192.0.2.1:9100", job="node-exporter", device="ens3f0np0"}'
-        values: '1x10'
+        values: '1x70'
       - series: 'node_network_carrier{instance="192.0.2.1:9100", job="node-exporter", device="ens3f1np1"}'
-        values: '1x10'
+        values: '1x70'
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 65m
         alertname: HostNICSpeedUnknown
         exp_alerts: []
 
@@ -130,13 +130,45 @@ tests:
   - interval: 1m
     input_series:
       - series: 'node_network_speed_bytes{instance="192.0.2.3:9100", job="node-exporter", device="genev_sys_6081"}'
-        values: '-125000x10'
+        values: '-125000x70'
       - series: 'node_network_protocol_type{instance="192.0.2.3:9100", job="node-exporter", device="genev_sys_6081"}'
-        values: '65534x10'
+        values: '65534x70'
       - series: 'node_network_carrier{instance="192.0.2.3:9100", job="node-exporter", device="genev_sys_6081"}'
-        values: '1x10'
+        values: '1x70'
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 65m
+        alertname: HostNICSpeedUnknown
+        exp_alerts: []
+
+  # HostNICSpeedUnknown - negative test (virtual Ethernet-style interfaces, no alert)
+  - interval: 1m
+    input_series:
+      - series: 'node_network_speed_bytes{instance="192.0.2.5:9100", job="node-exporter", device="bond0"}'
+        values: '-125000x70'
+      - series: 'node_network_protocol_type{instance="192.0.2.5:9100", job="node-exporter", device="bond0"}'
+        values: '1x70'
+      - series: 'node_network_carrier{instance="192.0.2.5:9100", job="node-exporter", device="bond0"}'
+        values: '1x70'
+      - series: 'node_network_speed_bytes{instance="192.0.2.5:9100", job="node-exporter", device="vethabcd123"}'
+        values: '-125000x70'
+      - series: 'node_network_protocol_type{instance="192.0.2.5:9100", job="node-exporter", device="vethabcd123"}'
+        values: '1x70'
+      - series: 'node_network_carrier{instance="192.0.2.5:9100", job="node-exporter", device="vethabcd123"}'
+        values: '1x70'
+      - series: 'node_network_speed_bytes{instance="192.0.2.5:9100", job="node-exporter", device="team0"}'
+        values: '-125000x70'
+      - series: 'node_network_protocol_type{instance="192.0.2.5:9100", job="node-exporter", device="team0"}'
+        values: '1x70'
+      - series: 'node_network_carrier{instance="192.0.2.5:9100", job="node-exporter", device="team0"}'
+        values: '1x70'
+      - series: 'node_network_speed_bytes{instance="192.0.2.5:9100", job="node-exporter", device="macvlan0"}'
+        values: '-125000x70'
+      - series: 'node_network_protocol_type{instance="192.0.2.5:9100", job="node-exporter", device="macvlan0"}'
+        values: '1x70'
+      - series: 'node_network_carrier{instance="192.0.2.5:9100", job="node-exporter", device="macvlan0"}'
+        values: '1x70'
+    alert_rule_test:
+      - eval_time: 65m
         alertname: HostNICSpeedUnknown
         exp_alerts: []
 
@@ -144,13 +176,27 @@ tests:
   - interval: 1m
     input_series:
       - series: 'node_network_speed_bytes{instance="192.0.2.4:9100", job="node-exporter", device="ens5f0np0"}'
-        values: '-125000x10'
+        values: '-125000x70'
       - series: 'node_network_protocol_type{instance="192.0.2.4:9100", job="node-exporter", device="ens5f0np0"}'
-        values: '1x10'
+        values: '1x70'
       - series: 'node_network_carrier{instance="192.0.2.4:9100", job="node-exporter", device="ens5f0np0"}'
-        values: '0x10'
+        values: '0x70'
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 65m
+        alertname: HostNICSpeedUnknown
+        exp_alerts: []
+
+  # HostNICSpeedUnknown - negative test (condition clears before one hour, no alert)
+  - interval: 1m
+    input_series:
+      - series: 'node_network_speed_bytes{instance="192.0.2.6:9100", job="node-exporter", device="ens6f0np0"}'
+        values: '-125000x30 3125000000x40'
+      - series: 'node_network_protocol_type{instance="192.0.2.6:9100", job="node-exporter", device="ens6f0np0"}'
+        values: '1x70'
+      - series: 'node_network_carrier{instance="192.0.2.6:9100", job="node-exporter", device="ens6f0np0"}'
+        values: '1x70'
+    alert_rule_test:
+      - eval_time: 65m
         alertname: HostNICSpeedUnknown
         exp_alerts: []
 
@@ -158,29 +204,29 @@ tests:
   - interval: 1m
     input_series:
       - series: 'node_network_speed_bytes{instance="192.0.2.2:9100", job="node-exporter", device="ens3f0np0"}'
-        values: '-125000x10'
+        values: '-125000x70'
       - series: 'node_network_speed_bytes{instance="192.0.2.2:9100", job="node-exporter", device="ens3f1np1"}'
-        values: '25000000000x10'
+        values: '3125000000x70'
       - series: 'node_network_protocol_type{instance="192.0.2.2:9100", job="node-exporter", device="ens3f0np0"}'
-        values: '1x10'
+        values: '1x70'
       - series: 'node_network_protocol_type{instance="192.0.2.2:9100", job="node-exporter", device="ens3f1np1"}'
-        values: '1x10'
+        values: '1x70'
       - series: 'node_network_carrier{instance="192.0.2.2:9100", job="node-exporter", device="ens3f0np0"}'
-        values: '1x10'
+        values: '1x70'
       - series: 'node_network_carrier{instance="192.0.2.2:9100", job="node-exporter", device="ens3f1np1"}'
-        values: '1x10'
+        values: '1x70'
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 65m
         alertname: HostNICSpeedUnknown
         exp_alerts:
           - exp_labels:
-              severity: P3
+              severity: P4
               instance: "192.0.2.2:9100"
               job: node-exporter
               device: ens3f0np0
             exp_annotations:
-              summary: "Host NIC: link is up but speed cannot be negotiated on ens3f0np0"
-              description: 'Interface ens3f0np0 on 192.0.2.2:9100 reports node_network_speed_bytes=-125000 for more than 5 minutes while the link carrier is still up and the device is a physical Ethernet interface. A value below 0 (typically -125000) means the kernel cannot read the interface speed via ethtool ("Speed: Unknown!"); the threshold is < 0 bytes/sec. Normal behaviour is the negotiated link speed in bytes/sec (for example 3125000000 for 25 Gbps or 1250000000 for 10 Gbps). Bonded interfaces will not detect this state because MII status remains up, so the slave can stay in the bond as a "zombie" carrying no traffic.'
+              summary: "Host NIC: reduced data-plane capacity on 192.0.2.2:9100 ens3f0np0"
+              description: 'Interface ens3f0np0 on 192.0.2.2:9100 reports node_network_speed_bytes=-125000 for more than 1 hour while the link carrier is still up and the device passes the physical Ethernet interface filters. A value below 0 (typically -125000) means the kernel cannot read the interface speed via ethtool ("Speed: Unknown!"); the threshold is < 0 bytes/sec. Normal behaviour is the negotiated link speed in bytes/sec (for example 3125000000 for 25 Gbps or 1250000000 for 10 Gbps). This is a cause-based early warning for reduced host data-plane capacity or redundancy; bonded interfaces may not detect this state because MII status can remain up while the slave carries no traffic.'
               runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#hostnicspeedunknown"
 
   # NodeDiskHighLatency - negative test (normal latency, no alert)


### PR DESCRIPTION
## What

Adds a new Prometheus alert `HostNICSpeedUnknown` that fires when `node_network_speed_bytes < 0` for more than 5 minutes. `node_exporter` emits a negative value when the kernel cannot read the interface speed via ethtool (`Speed: Unknown!`).

## Why

This catches a class of silent data-plane failures on bond slaves where:

- The link stays administratively up (carrier on, MII up)
- But the transceiver / cable / switch port is degraded so no link speed can be negotiated
- And `node_exporter` therefore reports a negative speed

`NodeBondingDegraded` does not catch this because the bond driver still considers the slave active (MII up). In a recent customer incident, a control-node bond ran on a single healthy slave for 9+ days without paging, because the broken slave's MII never went down.

`HostNICSpeedUnknown` would have paged immediately on the same condition.

## Changes

- `roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet` — add `HostNICSpeedUnknown` rule to the existing `node-exporter-extras` group (severity: warning → P3)
- `roles/kube_prometheus_stack/files/jsonnet/tests.yml` — positive test (negative speed → alert fires) and negative test (normal speed → no alert)
- `doc/source/admin/monitoring.rst` — runbook entry with diagnostic and remediation steps
- `releasenotes/notes/host-nic-speed-unknown-alert-*.yaml` — feature release note

## Testing

```
$ cd roles/kube_prometheus_stack && go test -run TestPrometheusRules -v
...
--- PASS: TestPrometheusRules/HostNICSpeedUnknown (0.39s)
--- PASS: TestPrometheusRules/HostNICSpeedUnknown#01 (0.38s)
```

(Pre-existing `MysqlClusterDown` failures on `main` are unrelated to this change.)
