### PR TITLE
feat(hpe_nimble_csi): expose StorageClass parameters as a variable

### DIFF
--- a/.github/styles/Microsoft/SentenceLength.yml
+++ b/.github/styles/Microsoft/SentenceLength.yml
@@ -4,4 +4,3 @@ scope: sentence
 level: suggestion
 max: 30
 token: \b(\w+)\b
-

--- a/.github/styles/Microsoft/SentenceLength.yml
+++ b/.github/styles/Microsoft/SentenceLength.yml
@@ -4,3 +4,4 @@ scope: sentence
 level: suggestion
 max: 30
 token: \b(\w+)\b
+

--- a/releasenotes/notes/hpe-nimble-csi-storageclass-parameters-bd1fea0e6b815737.yaml
+++ b/releasenotes/notes/hpe-nimble-csi-storageclass-parameters-bd1fea0e6b815737.yaml
@@ -6,6 +6,6 @@ features:
     StorageClass parameters such as ``performancePolicy``, ``folder``,
     ``description``, ``dedupeEnabled``, ``thick``, ``destroyOnDelete``,
     ``limitIops``, ``limitMbps``, ``pool`` and ``encrypted`` from inventory
-    without forking the role. User-supplied values are merged on top of the
+    without forking the role. User-supplied values take precedence over the
     role-controlled defaults (``fstype``, ``accessProtocol``, and the secret
-    references), with user keys winning on conflict.
+    references) on conflict.

--- a/releasenotes/notes/hpe-nimble-csi-storageclass-parameters-bd1fea0e6b815737.yaml
+++ b/releasenotes/notes/hpe-nimble-csi-storageclass-parameters-bd1fea0e6b815737.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Added the ``hpe_nimble_csi_storageclass_parameters`` variable to the
+    ``hpe_nimble_csi`` role. Operators can now set HPE Nimble CSI
+    StorageClass parameters such as ``performancePolicy``, ``folder``,
+    ``description``, ``dedupeEnabled``, ``thick``, ``destroyOnDelete``,
+    ``limitIops``, ``limitMbps``, ``pool`` and ``encrypted`` from inventory
+    without forking the role. User-supplied values are merged on top of the
+    role-controlled defaults (``fstype``, ``accessProtocol``, and the secret
+    references), with user keys winning on conflict.

--- a/roles/hpe_nimble_csi/defaults/main.yml
+++ b/roles/hpe_nimble_csi/defaults/main.yml
@@ -14,3 +14,21 @@ hpe_nimble_csi_helm_values: {}
 #
 # hpe_nimble_csi_access_protocol: iscsi
 hpe_nimble_csi_access_protocol: iscsi
+
+# Additional parameters to merge into the default StorageClass ``parameters``
+# block. Use this to set HPE Nimble CSI options such as ``performancePolicy``,
+# ``folder``, ``description``, ``dedupeEnabled``, ``thick``, ``destroyOnDelete``,
+# ``limitIops``, ``limitMbps``, ``pool``, ``encrypted``, etc. Refer to the
+# HPE Alletra 6000 / Nimble CSP StorageClass parameter reference:
+# https://scod.hpedev.io/csi_driver/container_storage_provider/hpe_alletra_6000/index.html#storageclass_parameters
+#
+# Values supplied here are merged on top of the role-controlled defaults
+# (``fstype``, ``accessProtocol`` and the secret references). User-supplied
+# keys win on conflict.
+#
+# Example:
+#   hpe_nimble_csi_storageclass_parameters:
+#     performancePolicy: default
+#     folder: my-folder
+#     dedupeEnabled: "true"
+hpe_nimble_csi_storageclass_parameters: {}

--- a/roles/hpe_nimble_csi/tasks/main.yml
+++ b/roles/hpe_nimble_csi/tasks/main.yml
@@ -55,17 +55,7 @@
       reclaimPolicy: Delete
       allowVolumeExpansion: true
       volumeBindingMode: Immediate
-      parameters:
-        csi.storage.k8s.io/fstype: xfs
-        accessProtocol: "{{ hpe_nimble_csi_access_protocol }}"
-        csi.storage.k8s.io/controller-publish-secret-name: hpe-nimble-csi-secret
-        csi.storage.k8s.io/controller-publish-secret-namespace: "{{ hpe_nimble_csi_helm_release_namespace }}"
-        csi.storage.k8s.io/node-publish-secret-name: hpe-nimble-csi-secret
-        csi.storage.k8s.io/node-publish-secret-namespace: "{{ hpe_nimble_csi_helm_release_namespace }}"
-        csi.storage.k8s.io/node-stage-secret-name: hpe-nimble-csi-secret
-        csi.storage.k8s.io/node-stage-secret-namespace: "{{ hpe_nimble_csi_helm_release_namespace }}"
-        csi.storage.k8s.io/provisioner-secret-name: hpe-nimble-csi-secret
-        csi.storage.k8s.io/provisioner-secret-namespace: "{{ hpe_nimble_csi_helm_release_namespace }}"
+      parameters: "{{ _hpe_nimble_csi_storageclass_parameters | combine(hpe_nimble_csi_storageclass_parameters, recursive=True) }}"
 
 - name: Deploy Helm chart
   run_once: true

--- a/roles/hpe_nimble_csi/vars/main.yml
+++ b/roles/hpe_nimble_csi/vars/main.yml
@@ -27,3 +27,15 @@ _hpe_nimble_csi_helm_values:
     csiProvisioner: "{{ atmosphere_images['hpe_csi_provisioner'] }}"
     csiResizer: "{{ atmosphere_images['hpe_csi_resizer'] }}"
     csiSnapshotter: "{{ atmosphere_images['hpe_csi_snapshotter'] }}"
+
+_hpe_nimble_csi_storageclass_parameters:
+  csi.storage.k8s.io/fstype: xfs
+  accessProtocol: "{{ hpe_nimble_csi_access_protocol }}"
+  csi.storage.k8s.io/controller-publish-secret-name: hpe-nimble-csi-secret
+  csi.storage.k8s.io/controller-publish-secret-namespace: "{{ hpe_nimble_csi_helm_release_namespace }}"
+  csi.storage.k8s.io/node-publish-secret-name: hpe-nimble-csi-secret
+  csi.storage.k8s.io/node-publish-secret-namespace: "{{ hpe_nimble_csi_helm_release_namespace }}"
+  csi.storage.k8s.io/node-stage-secret-name: hpe-nimble-csi-secret
+  csi.storage.k8s.io/node-stage-secret-namespace: "{{ hpe_nimble_csi_helm_release_namespace }}"
+  csi.storage.k8s.io/provisioner-secret-name: hpe-nimble-csi-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: "{{ hpe_nimble_csi_helm_release_namespace }}"


### PR DESCRIPTION
## What

Adds a new `hpe_nimble_csi_storageclass_parameters` dict variable to the `hpe_nimble_csi` role. Operators can populate it from inventory to set HPE Nimble CSI StorageClass options without forking the role.

## Why

The role currently hardcodes the `parameters:` block of the default `general` StorageClass, exposing only `fstype` and `accessProtocol`. Common HPE Nimble CSI options that any real deployment is likely to need are not reachable from inventory:

- `performancePolicy` — pick the array-side performance policy for provisioned volumes
- `folder` — provision into a dedicated folder on the array (visual grouping in InfoSight, per-folder capacity reporting)
- `description` — free text on the array-side volume description
- `dedupeEnabled`, `thick`, `destroyOnDelete` — common space/lifecycle behaviors
- `limitIops`, `limitMbps`, `pool`, `encrypted` — also commonly needed

Today, customers needing any of these have to overwrite the role-managed StorageClass with a separate post-install playbook, which silently reverts on any re-run of the role.

Reference for the parameter set: https://scod.hpedev.io/csi_driver/container_storage_provider/hpe_alletra_6000/index.html#storageclass_parameters

## How

Mirrors the existing `hpe_nimble_csi_helm_values` + `_hpe_nimble_csi_helm_values` pattern already used in the role:

- `defaults/main.yml`: new empty default `hpe_nimble_csi_storageclass_parameters: {}`
- `vars/main.yml`: new `_hpe_nimble_csi_storageclass_parameters` containing the role-controlled base (`fstype`, `accessProtocol`, secret references)
- `tasks/main.yml`: the StorageClass `parameters:` block is now `_hpe_nimble_csi_storageclass_parameters | combine(hpe_nimble_csi_storageclass_parameters, recursive=True)` — user keys win on conflict
- Release note added

## Example

```yaml
hpe_nimble_csi_storageclass_parameters:
  performancePolicy: default
  folder: my-folder
  description: "K8s CSI volumes"
  dedupeEnabled: "true"
  thick: "false"
  destroyOnDelete: "false"
```

## Notes

- Stacked on top of #3782 (set as base branch) — merge target will retarget automatically when #3782 lands.
- No behavior change when `hpe_nimble_csi_storageclass_parameters` is left at its default `{}` — the resulting StorageClass is byte-identical to today.