### PR TITLE
feat: switch token validation to use oauth2 and jwks endpoint per realm

### DIFF
--- a/releasenotes/notes/keystone-oauth2-token-verify-for-cli-federation-ed103b571f6fb304.yaml
+++ b/releasenotes/notes/keystone-oauth2-token-verify-for-cli-federation-ed103b571f6fb304.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    The Keystone Apache configuration for the federation
+    ``/v3/OS-FEDERATION/identity_providers/<domain>/protocols/openid/auth``
+    endpoint now uses ``mod_auth_oauth2`` with an explicit
+    ``OAuth2TokenVerify jwks_uri`` pointing at the per-domain Keycloak
+    realm, replacing the previous generic ``AuthType oauth20``
+    configuration. Apache validates JWT access tokens presented by the
+    OpenStack CLI through the realm's JSON Web Key Set (JWKS) endpoint,
+    allowing each Keystone domain to trust tokens issued by its own
+    Keycloak realm.

--- a/roles/keystone/vars/main.yml
+++ b/roles/keystone/vars/main.yml
@@ -85,18 +85,20 @@ _keystone_helm_values:
           Require valid-user
         </Location>
         <Location /v3/auth/OS-FEDERATION/websso/openid>
-          Require valid-user
           AuthType openid-connect
+          Require valid-user
         </Location>
         {% for domain in keystone_domains %}
         <Location /v3/OS-FEDERATION/identity_providers/{{ domain.name }}/protocols/openid/auth>
+          AuthType oauth2
+          OAuth2TokenVerify jwks_uri {{ domain.keycloak_server_url }}/realms/{{ domain.keycloak_realm }}/protocol/openid-connect/certs
+          OAuth2TargetPass prefix=OIDC-
           Require valid-user
-          AuthType oauth20
         </Location>
         <Location /v3/auth/OS-FEDERATION/identity_providers/{{ domain.name }}/protocols/openid/websso>
-          Require valid-user
           AuthType openid-connect
           OIDCDiscoverURL {{ keystone_oidc_redirect_uri }}?iss={{ domain | vexxhost.atmosphere.urlencoded_issuer_from_domain }}
+          Require valid-user
         </Location>
         {% endfor %}
       </VirtualHost>


### PR DESCRIPTION
Improve security and flexibility for more possible integrations.

Depends on: https://github.com/vexxhost/docker-keystone/pull/753