### PR TITLE
[Backport stable/2025.1] fix(libvirt): bump TLS sidecar to v1.0.2

### DIFF
--- a/charts/libvirt/values.yaml
+++ b/charts/libvirt/values.yaml
@@ -27,7 +27,7 @@ labels:
 images:
   tags:
     libvirt: docker.io/openstackhelm/libvirt:latest-ubuntu_focal
-    libvirt_tls_sidecar: ghcr.io/vexxhost/libvirt-tls-sidecar:v1.0.0
+    libvirt_tls_sidecar: ghcr.io/vexxhost/libvirt-tls-sidecar:v1.0.2
     libvirt_exporter: vexxhost/libvirtd-exporter:latest
     ceph_config_helper: 'docker.io/openstackhelm/ceph-config-helper:ubuntu_jammy_19.2.3-1-20250805'
     dep_check: quay.io/airshipit/kubernetes-entrypoint:latest-ubuntu_focal

--- a/charts/patches/libvirt/0001-Update-libvirt-tls-sidecar-image-to-ghcr.patch
+++ b/charts/patches/libvirt/0001-Update-libvirt-tls-sidecar-image-to-ghcr.patch
@@ -7,7 +7,7 @@ index ece77e70..3e1b6b0b 100644
    tags:
      libvirt: docker.io/openstackhelm/libvirt:latest-ubuntu_focal
 -    libvirt_tls_sidecar: ghcr.io/vexxhost/atmosphere/libvirt-tls-sidecar:latest
-+    libvirt_tls_sidecar: ghcr.io/vexxhost/libvirt-tls-sidecar:v1.0.0
++    libvirt_tls_sidecar: ghcr.io/vexxhost/libvirt-tls-sidecar:v1.0.2
      libvirt_exporter: vexxhost/libvirtd-exporter:latest
      ceph_config_helper: 'docker.io/openstackhelm/ceph-config-helper:ubuntu_jammy_19.2.3-1-20250805'
      dep_check: quay.io/airshipit/kubernetes-entrypoint:latest-ubuntu_focal

--- a/releasenotes/notes/bump-libvirt-tls-sidecar-v1.0.2-54ce75437b5c7222.yaml
+++ b/releasenotes/notes/bump-libvirt-tls-sidecar-v1.0.2-54ce75437b5c7222.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The ``libvirt-tls-sidecar`` image now uses version v1.0.2 instead of
+    v1.0.1. This update skips unnecessary certificate reloads when
+    certificate files haven't changed and reports certificate reload
+    errors as failures.

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -123,7 +123,7 @@ _atmosphere_images:
   kube_vip: "{{ atmosphere_image_prefix }}ghcr.io/kube-vip/kube-vip:v0.6.4"
   kubectl: "{{ atmosphere_image_prefix }}docker.io/rancher/kubectl:v1.34.1"
   libvirt: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/libvirtd:2025.1@sha256:d429155e81ab514000759eab87a6b4e583a3998ac24716ce695c2a743ee4f3ce"
-  libvirt_tls_sidecar: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/libvirt-tls-sidecar:v1.0.0@sha256:b0c5b8ea65fa007b2efbedf75fe8b54981173929e80b921fd4c5847dadb560a6"
+  libvirt_tls_sidecar: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/libvirt-tls-sidecar:v1.0.2@sha256:c994bf3302a9ae9d8e356ed1e192d4e2f8f9d290e89499d30bb75f285eb55074"
   libvirt_exporter: "{{ atmosphere_image_prefix }}ghcr.io/inovex/prometheus-libvirt-exporter:2.2.0"
   local_path_provisioner_helper: "{{ atmosphere_image_prefix }}ghcr.io/containerd/busybox:1.36"
   local_path_provisioner: "{{ atmosphere_image_prefix }}docker.io/rancher/local-path-provisioner:v0.0.24"


### PR DESCRIPTION
# Description
Backport of #3907 to `stable/2025.1`.

# Validation
- `SKIP=ansible-lint pre-commit run --from-ref HEAD~1 --to-ref HEAD` passed for the changed files.
- Full pre-commit was checked on `stable/2025.2` and hit the same unrelated repository-level `ansible-lint` `galaxy[no-changelog]` failure on `galaxy.yml`.