### PR TITLE
feat(neutron): add neutron ironic agent support

### DIFF
--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -6,3 +6,4 @@ User Guide
    :maxdepth: 2
 
    auth
+   ironic

--- a/doc/source/user/ironic.rst
+++ b/doc/source/user/ironic.rst
@@ -1,0 +1,87 @@
+######
+Ironic
+######
+
+***********************************************************
+Make Neutron aware of bare metal physical network topology
+***********************************************************
+
+.. note::
+
+   This feature requires an environment with the Neutron Ironic agent.
+   `Atmosphere PR 3925 <https://github.com/vexxhost/atmosphere/pull/3925>`__
+   adds support for enabling that agent through
+   ``neutron_helm_values.manifests.deployment_ironic_agent``.
+
+Atmosphere can enable the Neutron Ironic agent together with the Neutron
+``baremetal`` backend so Neutron can understand the physical network topology
+of Ironic bare metal nodes.
+
+The Neutron Ironic agent reports Ironic bare metal port and physical network
+information to Neutron. The ``baremetal`` backend lets the ML2 binding flow use
+that information when it binds Neutron ports with ``vnic_type=baremetal``.
+Neutron needs both parts to place bare metal ports on the correct provider or
+routed provider network segment.
+
+Bare metal networking lets virtual machines and Ironic bare metal nodes use the
+same provider network. This is useful when a workload needs direct network
+communication between virtual machine instances and bare metal instances.
+
+.. warning::
+
+   This currently works only in OVN environments. The Neutron network used for
+   virtual machine to bare metal traffic must not use security groups.
+
+Create the Neutron network without port security:
+
+.. code-block:: console
+
+   openstack network create bm-network \
+     --provider-network-type vlan \
+     --provider-physical-network external \
+     --provider-segment 200 \
+     --disable-port-security
+
+For an existing network, disable port security before you use it for bare metal
+traffic:
+
+.. code-block:: console
+
+   openstack network set bm-network --disable-port-security
+
+When you create the Neutron port for the bare metal instance, request the bare
+metal port binding type:
+
+.. code-block:: console
+
+   openstack port create baremetal-port \
+     --network bm-network \
+     --vnic-type baremetal
+
+Use the Neutron port when you create the bare metal server:
+
+.. code-block:: console
+
+   openstack server create bm-server \
+     --flavor baremetal \
+     --image baremetal-image \
+     --port baremetal-port
+
+The Ironic bare metal port must also include the physical network name that
+matches the Neutron provider network. For the default external provider
+network, set ``external`` on the Ironic bare metal port:
+
+.. code-block:: console
+
+   openstack baremetal port set <port> --physical-network external
+
+You can verify the value with:
+
+.. code-block:: console
+
+   openstack baremetal port list --long \
+     -c UUID -c "Node UUID" -c "Physical Network"
+
+If the deployment uses another physical network name, use that name instead of
+``external``. Ports without the matching physical network can fail to bind to
+the provider network.

--- a/releasenotes/notes/neutron-ironic-agent-values-8f4c5c9f1a2d7b3e.yaml
+++ b/releasenotes/notes/neutron-ironic-agent-values-8f4c5c9f1a2d7b3e.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Operators can now make the physical network topology of Ironic bare metal
+    nodes available to the bare metal port binding flow. When operators enable
+    ``manifests.deployment_ironic_agent`` in the final Helm values, Atmosphere
+    appends the ``baremetal`` ML2 backend alongside the selected Neutron
+    network backend and derives the ``[ironic]`` credentials from the
+    generated OpenStack-Helm endpoint data. This keeps the default Neutron
+    deployment unchanged while making the opt-in Neutron Ironic agent path
+    complete.

--- a/roles/neutron/tasks/main.yml
+++ b/roles/neutron/tasks/main.yml
@@ -57,7 +57,8 @@
     _neutron_helm_values: "{{ _neutron_helm_values | combine(__neutron_generic_switch_keys_helm_values, recursive=True) }}"
 
 - name: Append Helm values (ironic agent)
-  when: (_neutron_helm_values | combine(neutron_helm_values, recursive=True)).manifests.deployment_ironic_agent | bool
+  when: >-
+    (((_neutron_helm_values | combine(neutron_helm_values, recursive=True)).manifests | default({})).deployment_ironic_agent | default(false)) | bool
   ansible.builtin.set_fact:
     _neutron_helm_values: "{{ _neutron_helm_values | combine(__neutron_ironic_helm_values, recursive=True) }}"
 

--- a/roles/neutron/tasks/main.yml
+++ b/roles/neutron/tasks/main.yml
@@ -56,6 +56,11 @@
   ansible.builtin.set_fact:
     _neutron_helm_values: "{{ _neutron_helm_values | combine(__neutron_generic_switch_keys_helm_values, recursive=True) }}"
 
+- name: Append Helm values (ironic agent)
+  when: (_neutron_helm_values | combine(neutron_helm_values, recursive=True)).manifests.deployment_ironic_agent | bool
+  ansible.builtin.set_fact:
+    _neutron_helm_values: "{{ _neutron_helm_values | combine(__neutron_ironic_helm_values, recursive=True) }}"
+
 - name: Deploy Helm chart
   run_once: true
   kubernetes.core.helm:

--- a/roles/neutron/vars/main.yml
+++ b/roles/neutron/vars/main.yml
@@ -55,6 +55,9 @@ __neutron_helm_values:
       nova:
         live_migration_events: true
       ironic:
+        region_name: "{{ openstack_helm_endpoints_ironic_region_name }}"
+        username: "ironic-{{ openstack_helm_endpoints_ironic_region_name }}"
+        password: "{{ openstack_helm_endpoints_ironic_keystone_password }}"
         valid_interfaces: internal
       placement:
         region_name: "{{ openstack_helm_endpoints_neutron_region_name }}"
@@ -157,6 +160,12 @@ __neutron_ovn_helm_values:
     daemonset_ovn_metadata_agent: true
     daemonset_ovn_vpn_agent: true
     daemonset_ovs_agent: false
+
+__neutron_ironic_helm_values:
+  network:
+    backend:
+      - "{{ atmosphere_network_backend }}"
+      - baremetal
 
 __neutron_policy_server_helm_values:
   conf:


### PR DESCRIPTION
## Summary

- add Neutron Helm values for the baremetal ML2 backend and `[ironic]` credentials
- append those values only when the final Helm values enable `manifests.deployment_ironic_agent`
- source Ironic region, username, and password from `openstack_helm_endpoints` instead of hardcoding Keystone auth details

### short version for ironic-neutron-agent  and baremetal driver intro

  ironic-neutron-agent tells Neutron which physical networks each Ironic bare metal node can reach. That information lets Neutron
  place bare metal ports on the right network segment, VLAN, provider network, or routed provider network.

  This PR enables two required pieces together:

  - ironic-neutron-agent syncs Ironic node and port network information into Neutron.
  - baremetal in network.backend enables the ML2 binding path for Neutron ports using vnic_type=baremetal.

  Without the baremetal backend, the agent can report the topology, but Neutron may still fail to bind bare metal ports because ML2
  does not have the driver for that binding path.

  This stays opt-in through manifests.deployment_ironic_agent, so the default Neutron deployment remains unchanged.

### Long version for ironic-neutron-agent  and baremetal driver intro

ironic-neutron-agent is a Neutron-side service used with OpenStack Ironic bare-metal nodes.

Its main job is to tell Neutron which physical networks each bare-metal node can reach. This allows Neutron to correctly bind bare-metal ports to the right network segment, VLAN, provider network, or routed network.

In practice, it helps with:

* Mapping Ironic nodes to physical networks
* Supporting bare-metal Neutron port binding
* Enabling tenant, provisioning, cleaning, and rescue network transitions
* Helping ML2/switch drivers configure the correct switch ports or VLANs
* Supporting routed provider networks
* Improving OVN bare-metal networking features in newer deployments

It does not power on servers, install operating systems, run inside the bare-metal node, or directly manage hardware. Those tasks are handled by Ironic, ironic-python-agent, and hardware drivers.

In short: ironic-neutron-agent lets Neutron understand and manage networking for Ironic bare-metal nodes.

Adding some context on why this PR enables the baremetal ML2 backend together with the Neutron Ironic agent:

The Neutron Ironic agent is only the service that reports Ironic bare metal port and physical network information back to Neutron. That gives Neutron the inventory and reachability data it needs, but it does not by itself teach ML2 how to bind a Neutron port whose binding:vnic_type is baremetal.

For the bind flow to work end to end, Neutron also needs the baremetal mechanism/backend enabled in network.backend. That backend is what lets ML2 recognize bare metal ports, use the Ironic-side physical network information, and produce a valid binding for provider or routed provider networks. Without it, we can deploy ironic-neutron-agent, but Neutron can still reject or fail to bind bare metal ports because the ML2 backend list does not include the driver responsible for that binding path.

So these two pieces cover different sides of the same feature:

ironic-neutron-agent syncs Ironic node/port network information into Neutron.
baremetal in network.backend enables the ML2 binding path for Neutron ports using vnic_type=baremetal.
That is why this change appends baremetal alongside the existing Atmosphere network backend only when operators opt in by enabling manifests.deployment_ironic_agent. It keeps the default Neutron deployment unchanged, while making the opt-in Ironic networking path complete.

## Notes

This intentionally ports only the `roles/neutron/vars/main.yml` and `roles/neutron/tasks/main.yml` portions from `ricolin/atmosphere#11`. It does not set `manifests.deployment_ironic_agent`; operators still opt in through `neutron_helm_values`.

## Validation

- `python3` YAML parse for `roles/neutron/vars/main.yml` and `roles/neutron/tasks/main.yml`
- local `ansible-playbook` smoke test for false/true `deployment_ironic_agent` conditional behavior
- `git diff --check`