### PR TITLE
fix: update cert-manager webhook infoblox wapi chart repo

### DIFF
--- a/.charts.yml
+++ b/.charts.yml
@@ -38,9 +38,9 @@ charts:
     repository:
       url: https://snowdrop.github.io/godaddy-webhook
   - name: cert-manager-webhook-infoblox-wapi
-    version: 1.5.2
+    version: 2.0.0
     repository:
-      url: https://luisico.github.io/cert-manager-webhook-infoblox-wapi
+      url: https://sarg3nt.github.io/cert-manager-webhook-infoblox-wapi
   - name: cinder
     version: 0.3.23
     repository: *openstack_helm_repository

--- a/charts/cert-manager-webhook-infoblox-wapi/Chart.yaml
+++ b/charts/cert-manager-webhook-infoblox-wapi/Chart.yaml
@@ -1,7 +1,7 @@
-apiVersion: v1
-appVersion: 1.5.0
+apiVersion: v2
+appVersion: 2.0.0
 description: Cert-manager webhook for interacting with InfoBlox WAPI servers
-home: https://github.com/luisico/cert-manager-webhook-infoblox-wapi
+home: https://github.com/sarg3nt/cert-manager-webhook-infoblox-wapi
 keywords:
 - cert-manager
 - webhook
@@ -10,9 +10,10 @@ keywords:
 - dns01
 - infoblox
 maintainers:
-- email: lgracia@rockefeller.edu
-  name: Luis Gracia
+- email: dave@sarg3.net
+  name: Dave Sargent
 name: cert-manager-webhook-infoblox-wapi
 sources:
-- https://github.com/luisico/cert-manager-webhook-infoblox-wapi
-version: 1.5.2
+- https://github.com/sarg3nt/cert-manager-webhook-infoblox-wapi
+type: application
+version: 2.0.0

--- a/charts/cert-manager-webhook-infoblox-wapi/ci-config.yaml
+++ b/charts/cert-manager-webhook-infoblox-wapi/ci-config.yaml
@@ -1,0 +1,2 @@
+source:
+  image: ghcr.io/sarg3nt/cert-manager-webhook-infoblox-wapi

--- a/charts/cert-manager-webhook-infoblox-wapi/templates/NOTES.txt
+++ b/charts/cert-manager-webhook-infoblox-wapi/templates/NOTES.txt
@@ -1,0 +1,50 @@
+🎉 {{ include "webhook.fullname" . }} has been successfully installed!
+
+📋 NEXT STEPS:
+
+1. Verify the webhook is running:
+   kubectl get pods -n {{ .Release.Namespace }} -l app={{ include "webhook.name" . }}
+
+2. Check the webhook logs:
+   kubectl logs -n {{ .Release.Namespace }} -l app={{ include "webhook.name" . }}
+
+3. Create an Issuer or ClusterIssuer that uses this webhook. Example:
+
+   apiVersion: cert-manager.io/v1
+   kind: ClusterIssuer
+   metadata:
+     name: letsencrypt-production
+   spec:
+     acme:
+       email: your-email@example.com
+       server: https://acme-v02.api.letsencrypt.org/directory
+       privateKeySecretRef:
+         name: letsencrypt-account-key
+       solvers:
+       - dns01:
+           webhook:
+             groupName: {{ .Values.groupName }}
+             solverName: infoblox-wapi
+             config:
+               host: your-infoblox-server.example.com
+               view: "Your DNS View"
+               usernameSecretRef:
+                 name: infoblox-credentials
+                 key: username
+               passwordSecretRef:
+                 name: infoblox-credentials
+                 key: password
+
+4. Don't forget to create the Infoblox credentials secret:
+   kubectl create secret generic infoblox-credentials \
+     -n {{ .Release.Namespace }} \
+     --from-literal=username=YOUR_USERNAME \
+     --from-literal=password=YOUR_PASSWORD
+
+📚 For more information, visit:
+   https://github.com/sarg3nt/cert-manager-webhook-infoblox-wapi
+
+⚙️  Configuration:
+   - Group Name: {{ .Values.groupName }}
+   - Namespace: {{ .Release.Namespace }}
+   - Replicas: {{ .Values.replicaCount }}

--- a/charts/cert-manager-webhook-infoblox-wapi/templates/_helpers.tpl
+++ b/charts/cert-manager-webhook-infoblox-wapi/templates/_helpers.tpl
@@ -9,18 +9,12 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
 */}}
 {{- define "webhook.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/cert-manager-webhook-infoblox-wapi/templates/deployment.yaml
+++ b/charts/cert-manager-webhook-infoblox-wapi/templates/deployment.yaml
@@ -19,12 +19,33 @@ spec:
       labels:
         app: {{ include "webhook.name" . }}
         release: {{ .Release.Name }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "webhook.fullname" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           args:
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key
@@ -40,18 +61,46 @@ spec:
               scheme: HTTPS
               path: /healthz
               port: https
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               scheme: HTTPS
               path: /healthz
               port: https
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: https
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 30
           volumeMounts:
             - name: certs
               mountPath: /tls
               readOnly: true
+            {{- if .Values.secretVolume.hostPath }}
+            - name: secret-volume
+              mountPath: /etc/secrets/creds.json
+              readOnly: true
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:
+        {{- if .Values.secretVolume.hostPath }}
+        - name: secret-volume
+          hostPath:
+            path: {{ .Values.secretVolume.hostPath }}
+            type: FileOrCreate
+        {{- end }}
         - name: certs
           secret:
             secretName: {{ include "webhook.servingCertificate" . }}
@@ -65,5 +114,9 @@ spec:
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/charts/cert-manager-webhook-infoblox-wapi/templates/networkpolicy.yaml
+++ b/charts/cert-manager-webhook-infoblox-wapi/templates/networkpolicy.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "webhook.name" . }}
+    chart: {{ include "webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "webhook.name" . }}
+      release: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow traffic from cert-manager
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.certManager.namespace }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: TCP
+          port: 443
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow access to Kubernetes API
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443
+    {{- with .Values.networkPolicy.egressRules }}
+    # Custom egress rules (e.g., to Infoblox server)
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/cert-manager-webhook-infoblox-wapi/templates/pdb.yaml
+++ b/charts/cert-manager-webhook-infoblox-wapi/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "webhook.name" . }}
+    chart: {{ include "webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ include "webhook.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/cert-manager-webhook-infoblox-wapi/templates/pki.yaml
+++ b/charts/cert-manager-webhook-infoblox-wapi/templates/pki.yaml
@@ -34,6 +34,8 @@ spec:
     name: {{ include "webhook.selfSignedIssuer" . }}
   commonName: "ca.webhook.cert-manager"
   isCA: true
+  privateKey:
+    rotationPolicy: Never
 
 ---
 
@@ -74,3 +76,5 @@ spec:
   - {{ include "webhook.fullname" . }}
   - {{ include "webhook.fullname" . }}.{{ .Release.Namespace }}
   - {{ include "webhook.fullname" . }}.{{ .Release.Namespace }}.svc
+  privateKey:
+    rotationPolicy: Never

--- a/charts/cert-manager-webhook-infoblox-wapi/templates/servicemonitor.yaml
+++ b/charts/cert-manager-webhook-infoblox-wapi/templates/servicemonitor.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "webhook.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: {{ include "webhook.name" . }}
+    chart: {{ include "webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: https
+      scheme: https
+      {{- if .Values.serviceMonitor.interval }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      tlsConfig:
+        insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ include "webhook.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/cert-manager-webhook-infoblox-wapi/templates/tests/test-connection.yaml
+++ b/charts/cert-manager-webhook-infoblox-wapi/templates/tests/test-connection.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "webhook.fullname" . }}-test
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "webhook.name" . }}
+    chart: {{ include "webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: webhook-test
+      image: curlimages/curl:latest
+      command: ['sh', '-c']
+      args:
+        - |
+          echo "Testing webhook health endpoint..."
+          curl -k -s -o /dev/null -w "%{http_code}" \
+            https://{{ include "webhook.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/healthz \
+            | grep -q "200" && echo "✓ Webhook is healthy" || (echo "✗ Webhook health check failed" && exit 1)

--- a/charts/cert-manager-webhook-infoblox-wapi/values.schema.json
+++ b/charts/cert-manager-webhook-infoblox-wapi/values.schema.json
@@ -1,0 +1,299 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "title": "cert-manager-webhook-infoblox-wapi Helm Values",
+  "description": "Values schema for the cert-manager-webhook-infoblox-wapi Helm chart",
+  "properties": {
+    "groupName": {
+      "type": "string",
+      "description": "The API group name for the webhook. Must be unique to your organization.",
+      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+      "examples": [
+        "acme.mycompany.com"
+      ]
+    },
+    "replicaCount": {
+      "type": "integer",
+      "description": "Number of webhook replicas",
+      "minimum": 1,
+      "default": 1
+    },
+    "certManager": {
+      "type": "object",
+      "description": "cert-manager configuration",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Namespace where cert-manager is installed",
+          "default": "cert-manager"
+        },
+        "serviceAccountName": {
+          "type": "string",
+          "description": "Service account name of cert-manager",
+          "default": "cert-manager"
+        }
+      },
+      "required": [
+        "namespace",
+        "serviceAccountName"
+      ]
+    },
+    "rootCACertificate": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "description": "Duration of the root CA certificate",
+          "pattern": "^[0-9]+h$",
+          "default": "43800h"
+        }
+      }
+    },
+    "servingCertificate": {
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "description": "Duration of the serving certificate",
+          "pattern": "^[0-9]+h$",
+          "default": "8760h"
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "description": "Container image configuration",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Image repository",
+          "default": "ghcr.io/sarg3nt/cert-manager-webhook-infoblox-wapi"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Image tag (defaults to chart appVersion)"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "description": "Image pull policy",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ],
+          "default": "IfNotPresent"
+        }
+      },
+      "required": [
+        "repository",
+        "pullPolicy"
+      ]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "Image pull secrets for private registries",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "default": []
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the name of the chart"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full name of the chart"
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Annotations to add to the pod",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "secretVolume": {
+      "type": "object",
+      "description": "Configuration for loading secrets from a host path",
+      "properties": {
+        "hostPath": {
+          "type": "string",
+          "description": "Path on the host to mount for secrets"
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "description": "Service configuration",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Kubernetes service type",
+          "enum": [
+            "ClusterIP",
+            "NodePort",
+            "LoadBalancer"
+          ],
+          "default": "ClusterIP"
+        },
+        "port": {
+          "type": "integer",
+          "description": "Service port",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 443
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the service",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "description": "Resource limits and requests",
+      "properties": {
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          }
+        },
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node selector for pod scheduling",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Tolerations for pod scheduling",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity rules for pod scheduling",
+      "default": {}
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "description": "Topology spread constraints for pod distribution",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "description": "Pod Disruption Budget configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable PodDisruptionBudget",
+          "default": false
+        },
+        "minAvailable": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "Minimum number of available pods"
+        },
+        "maxUnavailable": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "Maximum number of unavailable pods"
+        }
+      }
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "description": "ServiceMonitor configuration for Prometheus Operator",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable ServiceMonitor",
+          "default": false
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace for ServiceMonitor"
+        },
+        "interval": {
+          "type": "string",
+          "description": "Scrape interval"
+        },
+        "scrapeTimeout": {
+          "type": "string",
+          "description": "Scrape timeout"
+        },
+        "additionalLabels": {
+          "type": "object",
+          "description": "Additional labels for ServiceMonitor",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "description": "NetworkPolicy configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable NetworkPolicy",
+          "default": false
+        },
+        "egressRules": {
+          "type": "array",
+          "description": "Egress rules for NetworkPolicy",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "groupName"
+  ]
+}

--- a/charts/cert-manager-webhook-infoblox-wapi/values.yaml
+++ b/charts/cert-manager-webhook-infoblox-wapi/values.yaml
@@ -1,3 +1,4 @@
+# cspell:ignore mycompany
 # The GroupName here is used to identify your company or business unit that
 # created this webhook.
 # For example, this may be "acme.mycompany.com".
@@ -7,6 +8,7 @@
 # This group name should be **unique**, hence using your own company's domain
 # here is recommended.
 groupName: acme.mycompany.com
+replicaCount: 1
 
 certManager:
   namespace: cert-manager
@@ -18,31 +20,80 @@ servingCertificate:
   duration: "8760h"
 
 image:
-  repository: ghcr.io/luisico/cert-manager-webhook-infoblox-wapi
-  tag: 1.5
+  repository: ghcr.io/sarg3nt/cert-manager-webhook-infoblox-wapi
+  # Override the image tag whose default is the chart appVersion.
+  tag: ""
   pullPolicy: IfNotPresent
+
+# Optionally specify image pull secrets for private registries
+imagePullSecrets: []
+# - name: my-registry-secret
 
 nameOverride: ""
 fullnameOverride: ""
 
+# Annotations to add to the pod
+podAnnotations: {}
+
+# Used if loading the secret from a file on disk.
+secretVolume:
+  hostPath: ""
+  # hostPath: /etc/secrets/secrets.json
+
 service:
   type: ClusterIP
   port: 443
+  # Annotations to add to the service
+  annotations: {}
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# Resource limits and requests for the webhook container
+# We recommend setting these for production deployments
+resources:
+  {}
   # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
+  #   cpu: 100m
+  #   memory: 128Mi
   # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+  #   cpu: 50m
+  #   memory: 64Mi
 
 nodeSelector: {}
 
 tolerations: []
 
 affinity: {}
+
+# Topology spread constraints for pod distribution across zones/nodes
+# https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+topologySpreadConstraints: []
+# - maxSkew: 1
+#   topologyKey: topology.kubernetes.io/zone
+#   whenUnsatisfiable: ScheduleAnyway
+#   labelSelector:
+#     matchLabels:
+#       app: cert-manager-webhook-infoblox-wapi
+
+# Pod Disruption Budget for high availability
+podDisruptionBudget:
+  enabled: false
+  # minAvailable: 1
+  # maxUnavailable: 1
+
+# ServiceMonitor for Prometheus Operator
+serviceMonitor:
+  enabled: false
+  # namespace: monitoring
+  # interval: 30s
+  # scrapeTimeout: 10s
+  # additionalLabels: {}
+
+# NetworkPolicy to restrict egress traffic
+networkPolicy:
+  enabled: false
+  # egressRules:
+  #   - to:
+  #       - ipBlock:
+  #           cidr: 10.0.0.0/8  # Your Infoblox server CIDR
+  #     ports:
+  #       - protocol: TCP
+  #         port: 443

--- a/releasenotes/notes/cert-manager-webhook-infoblox-wapi-k8s-compatibility-c4f2df7ed5ac5ca7.yaml
+++ b/releasenotes/notes/cert-manager-webhook-infoblox-wapi-k8s-compatibility-c4f2df7ed5ac5ca7.yaml
@@ -1,0 +1,11 @@
+---
+upgrade:
+  - |
+    Upgrade the ``cert-manager-webhook-infoblox-wapi`` chart from ``1.5.2`` to
+    ``2.0.0`` and switch its source repository to the actively maintained
+    ``sarg3nt`` fork.
+fixes:
+  - |
+    Fixed ``cert-manager-webhook-infoblox-wapi`` deployments on Kubernetes
+    ``1.26`` and later. The previous webhook image depended on the removed
+    ``flowcontrol.apiserver.k8s.io/v1beta1`` API and could fail to start.


### PR DESCRIPTION
The luisico repo chart image is built with k8s.io/client-go@v0.21.3, which tries to watch flowcontrol.apiserver.k8s.io/v1beta1 resources (FlowSchema and PriorityLevelConfiguration). These v1beta1 APIs were removed in Kubernetes 1.26, therefore the webhook fails to run in current 1.28.x environment.
This patch update the chart to use a fork version of the luisico repo.