### PR TITLE
fix(kube-prometheus-stack): account for hugepage memory

### DIFF
--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -4,7 +4,7 @@ Monitoring and operations
 
 Atmosphere includes a Grafana deployment with dashboards created by default and
 a Prometheus deployment that collects metrics from the cluster and sends alerts
-to AlertManager. Loki also collects logs from the cluster using Vector.
+to Alertmanager. Loki also collects logs from the cluster using Vector.
 
 ******************************
 Philosophy and alerting levels
@@ -49,7 +49,7 @@ Inhibition and grouping
 -----------------------
 
 Alerts have dependency awareness. When a parent component fails (for example, a
-node goes down), inhibition rules in AlertManager suppress child component
+node goes down), inhibition rules in Alertmanager suppress child component
 alerts (for example, pods on that node) to avoid cascading alert storms.
 The system groups related alerts so that a single notification represents a
 coherent incident rather than dozens of individual symptoms.
@@ -126,23 +126,23 @@ as an admin user.
       :alt: Silences menu
       :width: 200
 
-2. Make sure that you select "AlertManager" on the top right corner of the page,
-   this ensures that you create a silence inside of the AlertManager
+2. Make sure that you select "Alertmanager" on the top right corner of the page,
+   this ensures that you create a silence inside of the Alertmanager
    that's managed by the Prometheus operator instead of the built-in Grafana
-   AlertManager which isn't used.
+   Alertmanager which isn't used.
 
     .. image:: images/monitoring-alertmanger-list.png
-        :alt: AlertManager list
+        :alt: Alertmanager list
         :width: 200
 
-   .. admonition:: AlertManager selection
+   .. admonition:: Alertmanager selection
     :class: warning
 
-    It's important that you select the AlertManager that's managed by the
+    It's important that you select the Alertmanager that's managed by the
     Prometheus operator, otherwise your silence won't apply to the
     Prometheus instance that Atmosphere deploys.
 
-3. Click the "Add Silence" button and use the AlertManager format to create
+3. Click the "Add Silence" button and use the Alertmanager format to create
    your silence, which you can test by seeing if it matches any alerts in the
    list labeled "Affected alert instances".
 
@@ -211,7 +211,7 @@ Viewing data
 ************
 
 The monitoring stack offers a few different ways to view collected data. The most
-common ways are through AlertManager, Grafana, and Prometheus.
+common ways are through Alertmanager, Grafana, and Prometheus.
 
 Grafana dashboard
 =================
@@ -298,10 +298,10 @@ changes to your inventory:
 In this example, the configuration restricts access to the IP range
 ``10.0.0.0/24`` and the IP address ``172.10.0.1``.
 
-AlertManager
+Alertmanager
 ============
 
-By default, the AlertManager dashboard points to the Ansible variable
+By default, the Alertmanager dashboard points to the Ansible variable
 ``kube_prometheus_stack_alertmanager_host`` and sits behind an ``Ingress``
 with the `oauth2-proxy` service, protected by Keycloak similar to Prometheus.
 
@@ -309,10 +309,10 @@ with the `oauth2-proxy` service, protected by Keycloak similar to Prometheus.
 Integrations
 ************
 
-Since Atmosphere relies on AlertManager to send alerts, you can integrate it
+Since Atmosphere relies on Alertmanager to send alerts, you can integrate it
 with services like OpsGenie, PagerDuty, email, and more. To receive monitoring
 alerts using your preferred notification tools, integrate them with
-AlertManager.
+Alertmanager.
 
 OpsGenie
 ========

--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -1393,6 +1393,46 @@ confirm the issue is both sustained and ongoing. At this burn rate, the entire
 6. Review recent deployments or configuration changes that might have
    introduced the issue.
 
+``NodeMemoryHighUtilization``
+=============================
+
+This alert fires when a node has more than 90% memory utilization for at least
+15 minutes. The alert counts free huge page capacity as available memory. It
+avoids alerts on compute nodes that reserve huge pages for virtual machines.
+Linux removes that memory from normal memory accounting.
+
+**Likely root causes:**
+
+- A runaway process or memory leak on the node
+- Memory pressure from virtual machine workloads
+- Too much memory reserved for huge pages compared to workload requirements
+- Host services or Kubernetes pods consuming more memory than expected
+
+**Diagnostic and remediation steps:**
+
+1. Identify the affected host from the ``instance`` label.
+
+2. Check normal and huge page memory accounting:
+
+   .. code-block:: console
+
+      free -h
+      grep -E "MemTotal|MemAvailable|HugePages|Hugepagesize" /proc/meminfo
+
+3. Check whether the alert comes from normal memory pressure or reserved
+   huge pages:
+
+   .. code-block:: console
+
+      ps -eo pid,comm,rss,%mem --sort=-rss | head -20
+
+4. If most huge pages are free, confirm the expected reservation for
+   Nova/libvirt workloads. Confirm that it doesn't exceed the capacity needed
+   by the flavors scheduled to the host.
+
+5. If normal memory is genuinely low, reduce workload pressure, migrate
+   instances away from the host, or investigate the largest resident processes.
+
 ``NodeNetworkMulticast``
 ========================
 

--- a/releasenotes/notes/node-memory-huge-pages-alert-3934.yaml
+++ b/releasenotes/notes/node-memory-huge-pages-alert-3934.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed ``NodeMemoryHighUtilization`` so it counts free huge page
+    capacity as available memory. This prevents false high memory alerts
+    on compute nodes that reserve memory for virtual machine huge pages.

--- a/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
@@ -204,13 +204,46 @@ local mixins = {
     },
   },
   node:
-    (import 'vendor/github.com/prometheus/node_exporter/docs/node-mixin/mixin.libsonnet') {
+    local base = (import 'vendor/github.com/prometheus/node_exporter/docs/node-mixin/mixin.libsonnet') {
       _config+:: {
         nodeExporterSelector: 'job="node-exporter"',
         diskDeviceSelector: 'device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"',
       },
-      prometheusAlerts+:: {
-        groups+: [
+    };
+    base {
+      prometheusAlerts:: {
+        groups: [
+          if group.name == 'node-exporter' then group {
+            rules: [
+              if rule.alert == 'NodeMemoryHighUtilization' then rule {
+                expr: |||
+                  100 - (
+                    (
+                      node_memory_MemAvailable_bytes{%(nodeExporterSelector)s}
+                      +
+                      (
+                        (
+                          node_memory_HugePages_Free{%(nodeExporterSelector)s}
+                          *
+                          node_memory_Hugepagesize_bytes{%(nodeExporterSelector)s}
+                        )
+                        or
+                        (node_memory_MemAvailable_bytes{%(nodeExporterSelector)s} * 0)
+                      )
+                    ) / node_memory_MemTotal_bytes{%(nodeExporterSelector)s} * 100
+                  ) > %(memoryHighUtilizationThreshold)d
+                ||| % base._config,
+                annotations+: {
+                  summary: 'Node memory: high utilization affecting host workloads',
+                  description: 'Memory utilization at {{ $labels.instance }} is {{ printf "%%.2f" $value }}%%, which exceeds the threshold of %(memoryHighUtilizationThreshold)d%%. Free hugepage capacity is counted as available memory to avoid alerting on intentionally reserved VM memory.' % base._config,
+                  runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodememoryhighutilization',
+                },
+              } else rule
+              for rule in group.rules
+            ],
+          } else group
+          for group in base.prometheusAlerts.groups
+        ] + [
           {
             name: 'node-exporter-extras',
             rules: [
@@ -218,7 +251,7 @@ local mixins = {
                 alert: 'NodeTimeSkewDetected',
                 expr: |||
                   abs(timestamp(node_time_seconds{%(nodeExporterSelector)s}) - node_time_seconds{%(nodeExporterSelector)s}) > 1
-                ||| % mixins.node._config,
+                ||| % base._config,
                 'for': '5m',
                 labels: {
                   severity: 'warning',
@@ -250,7 +283,7 @@ local mixins = {
                     +
                     rate(node_disk_writes_completed_total{%(nodeExporterSelector)s, %(diskDeviceSelector)s}[5m])
                   ) > 0
-                ||| % mixins.node._config,
+                ||| % base._config,
                 'for': '1h',
                 labels: {
                   severity: 'P4',

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -106,6 +106,42 @@ tests:
         alertname: NodeTimeSkewDetected
         exp_alerts: []
 
+  # NodeMemoryHighUtilization - hugepage-backed compute node, no alert
+  - interval: 1m
+    input_series:
+      - series: 'node_memory_MemTotal_bytes{instance="compute1", job="node-exporter"}'
+        values: '810889825280x20'
+      - series: 'node_memory_MemAvailable_bytes{instance="compute1", job="node-exporter"}'
+        values: '18253611008x20'
+      - series: 'node_memory_HugePages_Free{instance="compute1", job="node-exporter"}'
+        values: '720x20'
+      - series: 'node_memory_Hugepagesize_bytes{instance="compute1", job="node-exporter"}'
+        values: '1073741824x20'
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: NodeMemoryHighUtilization
+        exp_alerts: []
+
+  # NodeMemoryHighUtilization - low normal memory, alert fires
+  - interval: 1m
+    input_series:
+      - series: 'node_memory_MemTotal_bytes{instance="node1", job="node-exporter"}'
+        values: '135063486464x20'
+      - series: 'node_memory_MemAvailable_bytes{instance="node1", job="node-exporter"}'
+        values: '5368709120x20'
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: NodeMemoryHighUtilization
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+              instance: node1
+              job: node-exporter
+            exp_annotations:
+              summary: "Node memory: high utilization affecting host workloads"
+              description: "Memory utilization at node1 is 96.03%, which exceeds the threshold of 90%. Free hugepage capacity is counted as available memory to avoid alerting on intentionally reserved VM memory."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodememoryhighutilization"
+
   # NodeDiskHighLatency - negative test (normal latency, no alert)
   - interval: 1m
     input_series:


### PR DESCRIPTION
## Summary

- update `NodeMemoryHighUtilization` to count free hugepage capacity as available memory
- keep normal behavior for nodes without hugepage metrics by falling back to zero hugepage capacity
- add rule tests for the hugepage-backed compute false positive and the genuine low-memory alert path
- add a runbook entry for `NodeMemoryHighUtilization`

Fixes #3934

## Test Method and Result

### Generated rule check

Method:

```console
jsonnet -J roles/kube_prometheus_stack/files/jsonnet/vendor \
  -J roles/kube_prometheus_stack/files/jsonnet \
  -e 'local rules = import "rules.jsonnet"; rules.node'
```

Result:

The generated `NodeMemoryHighUtilization` expression includes free hugepage capacity via `node_memory_HugePages_Free * node_memory_Hugepagesize_bytes`, plus a fallback for nodes without hugepage metrics using `node_memory_MemAvailable_bytes * 0`.

### Local rule unit test

Method:

```console
CGO_ENABLED=0 go test -count=1 -v -run 'TestPrometheusRules/NodeMemoryHighUtilization' ./roles/kube_prometheus_stack/
```

Result:

```text
--- PASS: TestPrometheusRules
    --- PASS: TestPrometheusRules/NodeMemoryHighUtilization
    --- PASS: TestPrometheusRules/NodeMemoryHighUtilization#01
PASS
```

### Live Prometheus validation on 38.108.68.19

Method:

- Queried the deployed Prometheus pod `prometheus-kube-prometheus-stack-prometheus-0`.
- Confirmed the AIO host currently has no reserved hugepages:

```text
HugePages_Total:       0
HugePages_Free:        0
```

- Queried current and fixed expressions against live node-exporter metrics.
- Ran a synthetic `promtool test rules` case inside the live Prometheus pod using the issue shape: 755 GiB total memory, 17 GiB `MemAvailable`, and 720 free 1 GiB hugepages.
- Also tested the genuine low-memory path for a node without hugepage metrics.

Result:

- Live AIO host: current and fixed utilization both evaluated to `44.86987878263691`; both alert vectors were empty, which is expected for this host.
- Synthetic production-shaped case: current expression fired; fixed expression did not fire.
- Synthetic real low-memory case: fixed expression still fired.
- Prometheus pod validation completed with:

```text
Unit Testing:  /prometheus/node-memory-hugepages-test.yml
  SUCCESS
```
