### PR TITLE
fix(ci): use zuul checkouts for molecule collections

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -28,6 +28,19 @@
     nodeset: atmosphere-ubuntu-jammy-single-node
     pre-run: test-playbooks/molecule/pre.yml
     post-run: test-playbooks/molecule/post.yml
+    required-projects:
+      - ansible-collections/ansible.netcommon
+      - ansible-collections/ansible.posix
+      - ansible-collections/ansible.utils
+      - ansible-collections/community.crypto
+      - ansible-collections/community.general
+      - ansible-collections/community.mysql
+      - ansible-collections/kubernetes.core
+      - openstack/ansible-collections-openstack
+      - vexxhost/ansible-collection-ceph
+      - vexxhost/ansible-collection-containers
+      - vexxhost/ansible-collection-kubernetes
+      - vexxhost/atmosphere.common
     roles:
       - zuul: opendev.org/openstack/openstack-helm
     vars:

--- a/releasenotes/notes/use-zuul-checkouts-for-molecule-collections-c2ede341.yaml
+++ b/releasenotes/notes/use-zuul-checkouts-for-molecule-collections-c2ede341.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Molecule CI jobs now use checked-out sibling collection projects for
+    Atmosphere's Galaxy dependencies, avoiding external Galaxy downloads for
+    those collections during setup.


### PR DESCRIPTION
## Summary
- add all Galaxy collection dependencies as required projects for Molecule jobs
- rely on the shared Molecule sibling-collection installer from `vexxhost/zuul-jobs`

Depends-On: https://github.com/vexxhost/zuul-jobs/pull/2

## Validation
- `git diff --check`
- YAML parse check for `.zuul.yaml` and the release note
- `vale releasenotes/notes/use-zuul-checkouts-for-molecule-collections-c2ede341.yaml`
- shared `vexxhost/zuul-jobs` module validated with Python compile, Ansible syntax check, and a disposable all-sibling Ansible fixture
- `oss/check` passed in Zuul buildset https://zuul.oss.vexxhost.dev/buildset/a53ef7fc45674c7da6e93a0c83e22d0f
- live Zuul logs resolved `vexxhost.kubernetes` to `v3.1.0` for `>=2.5.0` and checked out `vexxhost.containers` to `v1.6.6`
