### PR TITLE
[Backport stable/2023.1] fix(keycloak): space Keystone user lookup retries

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ description: Simple & easy private cloud platform featuring VMs, Kubernetes & ba
 license:
   - GPL-3.0-or-later
 dependencies:
-  ansible.netcommon: 1.2.0
+  ansible.netcommon: ">=1.2.0"
   ansible.posix: 1.6.0
   ansible.utils: ">=2.9.0"
   community.crypto: 2.2.3

--- a/molecule/keycloak/verify.yml
+++ b/molecule/keycloak/verify.yml
@@ -44,10 +44,11 @@
         name: "{{ keycloak_user_info.username }}"
       register: identity_user_info_result
       # XXX(mnaser): GHA seems to be slow so the user doesn't show up right
-      #              away, it could also be a Keystone caching issue, for now
-      #              we try a few more times.
+      #              away, it could also be a Keystone caching issue.  Poll
+      #              less aggressively and give Keystone up to five minutes to
+      #              see the federated Keycloak user.
       retries: 30
-      delay: 1
+      delay: 10
       until: identity_user_info_result.openstack_users | length > 0
 
     - name: Assert that the user exists


### PR DESCRIPTION
# Description
Backport of #3946 to `stable/2023.1`.

Includes a small stable-branch CI compatibility fix for `ansible.netcommon`: this branch already requires `ansible-core >=2.15`, so the old `ansible.netcommon: 1.2.0` pin cannot be resolved by current ansible-lint on a fresh runner.

## Validation
- `git diff --check HEAD~2..HEAD`
- `nix-shell -p python3Packages.pyyaml --run "python -c 'import yaml; yaml.safe_load(open(\"molecule/keycloak/verify.yml\")); yaml.safe_load(open(\"galaxy.yml\")); print(\"yaml ok\")'"`
- Clean-home ansible-lint provisioning now succeeds locally; the remaining local-only stop is `galaxy[no-changelog]` because the GitHub workflow generates `CHANGELOG.rst` before running pre-commit.
