### PR TITLE
[DNM] test(deps): validate vexxhost.ceph 4.0.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,7 +16,7 @@ dependencies:
   community.mysql: 3.6.0
   kubernetes.core: 2.4.0
   openstack.cloud: ">=2.0.0"
-  vexxhost.ceph: ">=3.2.0"
+  vexxhost.ceph: ">=4.0.0"
   atmosphere.common: ">=0.6.0"
   vexxhost.kubernetes: ">=2.5.0"
 tags:


### PR DESCRIPTION
DNM / WIP validation PR.

This bumps Atmosphere's `vexxhost.ceph` collection requirement to `>=4.0.0` so Zuul can exercise the pending collection release before it is merged/published.

Depends-On: https://github.com/vexxhost/ansible-collection-ceph/pull/72
Depends-On: https://github.com/vexxhost/ansible-collection-ceph/pull/109
