### PR TITLE
[Backport stable/2023.1] feat(monitoring): add smartctl exporter for disk health monitoring

### DIFF
--- a/.charts.yml
+++ b/.charts.yml
@@ -198,6 +198,10 @@ charts:
     version: 2.12.0
     repository:
       url: https://prometheus-community.github.io/helm-charts
+  - name: prometheus-smartctl-exporter
+    version: 0.16.0
+    repository:
+      url: https://prometheus-community.github.io/helm-charts
   - name: pxc-operator
     version: 1.17.0
     repository:

--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -3,6 +3,8 @@
 ACL
 ACME
 ALLOCATED
+AMD
+ATA
 AVX
 Alertmanager
 Ansible
@@ -31,12 +33,15 @@ IPMI
 JWT
 Keycloak
 Kubernetes
+LBAs
 LTS
 LUN
 Magnum
 Manila
 MySQL
+NAND
 NGINX
+NVM
 NVMe
 Neutron
 Nova
@@ -54,12 +59,18 @@ READY
 RGW
 RPC
 RabbitMQ
+SAS
+SATA
+SCSI
+SDK
 SEL
 SLOs?
 SMART
 SQLAlchemy
 SSD
+SSDs
 SST
+Smartctl
 Staffeln
 TLS
 VLAN
@@ -79,6 +90,7 @@ allowed-address-pair
 atmosphere_images
 backend
 backport
+bitfield
 boolean
 cgroup
 etcd
@@ -88,6 +100,7 @@ libvirt
 liveness
 neutron_pg_drop
 openstack_resource_controller
+prefailure
 readiness
 subnet
 systemd
@@ -96,3 +109,4 @@ udev
 vGPU
 vSwitch
 vrouter
+wearout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,8 @@ jobs:
         run: |
           curl -L -s https://github.com/prometheus/prometheus/releases/download/v${PROMTOOL_VERSION}/prometheus-${PROMTOOL_VERSION}.linux-amd64.tar.gz | sudo tar -xz -C /usr/local/bin --strip-components=1
       - uses: robherley/go-test-action@b19f6aadabfb1ad85079065b21aa2af132466468 # v0.6.0
+        with:
+          testArguments: -timeout=20m ./...
 
   vale:
     runs-on: ubuntu-latest

--- a/charts/prometheus-smartctl-exporter/.helmignore
+++ b/charts/prometheus-smartctl-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/prometheus-smartctl-exporter/Chart.yaml
+++ b/charts/prometheus-smartctl-exporter/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+appVersion: v0.14.0
+description: A Helm chart for Kubernetes
+home: https://github.com/prometheus-community/smartctl_exporter
+maintainers:
+- name: kfox1111
+  url: https://github.com/kfox1111
+- email: rootsandtrees@posteo.de
+  name: zeritti
+  url: https://github.com/zeritti
+name: prometheus-smartctl-exporter
+sources:
+- https://github.com/prometheus-community/smartctl_exporter
+type: application
+version: 0.16.0

--- a/charts/prometheus-smartctl-exporter/README.md
+++ b/charts/prometheus-smartctl-exporter/README.md
@@ -1,0 +1,56 @@
+# Prometheus smartctl Exporter
+
+Prometheus smartctl Exporter makes _smartctl_ statistics available to Prometheus for scraping.
+
+For more information on the exporter, please see the project's [repository](https://github.com/prometheus-community/smartctl_exporter).
+
+## Prerequisites
+
+- Kubernetes 1.13+ with Beta APIs enabled
+- Helm 3
+- smartmontools 7.0+
+
+## Usage
+
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-smartctl-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-smartctl-exporter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
+
+```console
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-smartctl-exporter
+```
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+### Uninstall Chart
+
+```console
+helm uninstall [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+### Upgrading Chart
+
+```shell
+helm upgrade [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-smartctl-exporter --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-smartctl-exporter
+```

--- a/charts/prometheus-smartctl-exporter/ci/default-values.yaml
+++ b/charts/prometheus-smartctl-exporter/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# default values

--- a/charts/prometheus-smartctl-exporter/ci/device-exclude-values.yaml
+++ b/charts/prometheus-smartctl-exporter/ci/device-exclude-values.yaml
@@ -1,0 +1,3 @@
+# exclude devices
+config:
+  device_exclude: "/dev/sr.*"

--- a/charts/prometheus-smartctl-exporter/ci/device-include-values.yaml
+++ b/charts/prometheus-smartctl-exporter/ci/device-include-values.yaml
@@ -1,0 +1,3 @@
+# include devices
+config:
+  device_include: "/dev/sd.*"

--- a/charts/prometheus-smartctl-exporter/ci/prometheusrules-values.yaml
+++ b/charts/prometheus-smartctl-exporter/ci/prometheusrules-values.yaml
@@ -1,0 +1,5 @@
+# enable prometheus rules
+prometheusRules:
+  enabled: true
+  extraLabels:
+    release: prometheus-operator

--- a/charts/prometheus-smartctl-exporter/ci/resources-values.yaml
+++ b/charts/prometheus-smartctl-exporter/ci/resources-values.yaml
@@ -1,0 +1,8 @@
+# set resources
+resources:
+  limits:
+    cpu: 100m
+    memory: 64Mi
+  requests:
+    cpu: 100m
+    memory: 64Mi

--- a/charts/prometheus-smartctl-exporter/ci/servicemonitor-values.yaml
+++ b/charts/prometheus-smartctl-exporter/ci/servicemonitor-values.yaml
@@ -1,0 +1,5 @@
+# enable service monitor
+serviceMonitor:
+  enabled: true
+  extraLabels:
+    release: prometheus-operator

--- a/charts/prometheus-smartctl-exporter/requirements.lock
+++ b/charts/prometheus-smartctl-exporter/requirements.lock
@@ -1,0 +1,3 @@
+dependencies: []
+digest: sha256:643d5437104296e21d906ecb15b2c96ad278f20cfc4af53b12bb6069bd853726
+generated: "0001-01-01T00:00:00Z"

--- a/charts/prometheus-smartctl-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-smartctl-exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-smartctl-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-smartctl-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-smartctl-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "prometheus-smartctl-exporter.labels" -}}
+helm.sh/chart: {{ include "prometheus-smartctl-exporter.chart" . }}
+{{ include "prometheus-smartctl-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prometheus-smartctl-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prometheus-smartctl-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prometheus-smartctl-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "prometheus-smartctl-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-smartctl-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/daemonset.yaml
@@ -1,0 +1,99 @@
+{{- $global := . }}
+{{- $base := dict "annotations" .Values.annotations "resources" .Values.resources "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "config" .Values.config  "hostNetwork" .Values.hostNetwork "priorityClassName" .Values.priorityClassName "extraArgs" .Values.extraArgs }}
+{{- $items := prepend .Values.extraInstances $base }}
+{{- range $idx, $item := $items }}
+{{- $config := mergeOverwrite $item.config $global.Values.common.config }}
+{{- $res := set $item "config" $config }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "prometheus-smartctl-exporter.fullname" $global }}-{{ $idx }}
+  {{- with $item.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "prometheus-smartctl-exporter.labels" $global | nindent 4 }}
+    idx: i{{ $idx }}
+spec:
+  {{- with $global.Values.updateStrategy }}
+  updateStrategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "prometheus-smartctl-exporter.selectorLabels" $global | nindent 6 }}
+      idx: i{{ $idx }}
+  template:
+    metadata:
+      {{- with $global.Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "prometheus-smartctl-exporter.selectorLabels" $global | nindent 8 }}
+        idx: i{{ $idx }}
+    spec:
+      {{- if $global.Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range $secret := $global.Values.image.pullSecrets }}
+        - name: {{ $secret }}
+        {{- end }}
+      {{- end }}
+      containers:
+      - image: "{{ $global.Values.image.repository }}:{{ $global.Values.image.tag | default $global.Chart.AppVersion }}"
+        imagePullPolicy: {{ $global.Values.image.pullPolicy }}
+        args:
+        - '--smartctl.path={{ $config.smartctl_location }}'
+        - '--smartctl.interval={{ $config.collect_not_more_than_period }}'
+{{- if $config.device_exclude }}
+        - '--smartctl.device-exclude={{ $config.device_exclude }}'
+{{- end }}
+{{- if $config.device_include }}
+        - '--smartctl.device-include={{ $config.device_include }}'
+{{- end }}
+{{ range $config.devices }}
+        - '--smartctl.device={{ . }}'
+{{ end }}
+        - '--web.listen-address={{ $config.bind_to }}'
+        - '--web.telemetry-path={{ $config.url_path }}'
+        {{- range $key, $value := $item.extraArgs }}
+        - '--{{ $key }}={{ $value }}'
+        {{- end }}
+        name: main
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        ports:
+        - name: http
+          containerPort: 9633
+          protocol: TCP
+        resources:
+{{ toYaml $item.resources | indent 10 }}
+        volumeMounts:
+        - mountPath: /hostdev
+          name: dev
+      dnsPolicy: ClusterFirst
+      hostNetwork: {{ $item.hostNetwork }}
+      {{- if $item.priorityClassName }}
+      priorityClassName: {{ $item.priorityClassName }}
+      {{- end }}
+      restartPolicy: Always
+      serviceAccountName: {{ template "prometheus-smartctl-exporter.fullname" $global }}
+      volumes:
+      - hostPath:
+          path: /dev
+        name: dev
+    {{- with $item.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with $item.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with $item.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/prometheus-smartctl-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/prometheusrule.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.prometheusRules.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "prometheus-smartctl-exporter.fullname" . }}.rules
+  labels:
+    {{- include "prometheus-smartctl-exporter.labels" . | nindent 4 }}
+{{- if ne (len .Values.prometheusRules.extraLabels) 0 }}
+{{ toYaml .Values.prometheusRules.extraLabels | indent 4 }}
+{{- end }}
+{{- if hasKey .Values.prometheusRules "namespace" }}
+  namespace: {{ .Values.prometheusRules.namespace }}
+{{- end }}
+spec:
+  groups:
+    - name: {{ template "prometheus-smartctl-exporter.name" $ }}
+      rules:
+      {{- range .Values.prometheusRules.rules }}
+        {{- if .enabled }}
+        - alert: {{ .alert | required "A rule requires a valid `alert` clause" }}
+          expr: {{ .expr | required "A rule requires a valid `expr` clause" }}
+          {{- with .for }}
+          for: {{ . }}
+          {{- end }}
+          {{- with .keep_firing_for }}
+          keep_firing_for: {{ . }}
+          {{- end }}
+          {{- with .annotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .labels }}
+          labels:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+{{- end }}

--- a/charts/prometheus-smartctl-exporter/templates/rolebinding.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "prometheus-smartctl-exporter.fullname" . }}
+  labels:
+    {{- include "prometheus-smartctl-exporter.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.rbac.podSecurityPolicy }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "prometheus-smartctl-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/prometheus-smartctl-exporter/templates/service.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-smartctl-exporter.fullname" . }}
+  labels:
+    {{- include "prometheus-smartctl-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.ipDualStack.enabled }}
+  ipFamilies: {{ toYaml .Values.service.ipDualStack.ipFamilies | nindent 4 }}
+  ipFamilyPolicy: {{ .Values.service.ipDualStack.ipFamilyPolicy }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "prometheus-smartctl-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/prometheus-smartctl-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prometheus-smartctl-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "prometheus-smartctl-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/prometheus-smartctl-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-smartctl-exporter.fullname" . }}
+  labels:
+    {{- include "prometheus-smartctl-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- if hasKey .Values.serviceMonitor "namespace" }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+{{- with .Values.serviceMonitor.attachMetadata }}
+  attachMetadata:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+  endpoints:
+    - interval: {{ .Values.serviceMonitor.interval }}
+      path: /metrics
+      port: http
+      scheme: http
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- with .Values.serviceMonitor.relabelings }}
+      relabelings: {{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml . | nindent 8 }}
+{{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "prometheus-smartctl-exporter.labels" . | nindent 6 }}
+{{- end }}

--- a/charts/prometheus-smartctl-exporter/values.yaml
+++ b/charts/prometheus-smartctl-exporter/values.yaml
@@ -1,0 +1,167 @@
+config: {}
+#  devices:
+#  - /dev/sda
+#  device_include: /dev/sd.*
+#  device_exclude: /dev/sr.*
+
+extraInstances: []
+# - config:
+#     devices:
+#     - /dev/nvme0n1
+#   nodeSelector:
+#     type: other
+
+common:
+  config:
+    bind_to: "0.0.0.0:9633"
+    url_path: "/metrics"
+    smartctl_location: /usr/sbin/smartctl
+    collect_not_more_than_period: 120s
+
+extraArgs: {}
+  # Add extra arguments to the smartctl exporter
+  # smartctl.powermode-check: never
+
+serviceMonitor:
+  enabled: false
+  # Specify namespace to load the monitor if not in the same namespace
+  # namespace: prometheus-operator
+  # Add Extra labels if needed. Prometeus operator may need them to find it.
+  extraLabels: {}
+  # release: prometheus-operator
+  interval: 60s
+  scrapeTimeout: 30s
+  # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  relabelings: []
+  metricRelabelings: []
+  ## Attach node metadata to discovered targets. Requires Prometheus v2.35.0 and above.
+  attachMetadata:
+    node: false
+
+prometheusRules:
+  enabled: false
+  # Specify namespace to load the rule if not in the same namespace
+  # namespace: prometheus-operator
+  # Add Extra labels if needed. Prometeus operator may need them to find it.
+  extraLabels: {}
+  # release: prometheus-operator
+  rules:
+    smartCTLDeviceMediaErrors:
+      enabled: true
+      alert: SmartCTLDeviceMediaErrors
+      expr: smartctl_device_media_errors != 0
+      for: 1m
+      annotations:
+        summary: Device has media errors
+        description: Device {{ $labels.device }} on instance {{ $labels.instance }} has media errors
+      labels:
+        severity: critical
+    smartCTLDeviceCriticalWarning:
+      enabled: true
+      alert: SmartCTLDeviceCriticalWarning
+      expr: smartctl_device_critical_warning != 0
+      for: 1m
+      annotations:
+        summary: Device has critical controller warnings
+        description: Device {{ $labels.device }} on instance {{ $labels.instance }} has critical controller warnings
+      labels:
+        severity: critical
+    smartCTLDeviceAvailableSpareUnderThreshold:
+      enabled: true
+      alert: SmartCTLDeviceAvailableSpareUnderThreshold
+      expr: smartctl_device_available_spare_threshold > smartctl_device_available_spare
+      for: 1m
+      annotations:
+        summary: Device is under available spare threshold
+        description: Device {{ $labels.device }} on instance {{ $labels.instance }} is under available spare threshold
+      labels:
+        severity: warning
+    smartCTLDeviceStatus:
+      enabled: true
+      alert: SmartCTLDeviceStatus
+      expr: smartctl_device_status != 1
+      for: 1m
+      annotations:
+        summary: Device has bad status
+        description: Device {{ $labels.device }} on instance {{ $labels.instance }} has bad status
+      labels:
+        severity: critical
+    smartCTLDInterfaceSlow:
+      enabled: true
+      alert: SmartCTLDInterfaceSlow
+      expr: smartctl_device_interface_speed{speed_type="current"} != on(device, instance, namespace, pod) smartctl_device_interface_speed{speed_type="max"}
+      for: 1m
+      annotations:
+        summary: Device interface is slower then it should be
+        description: Device {{ $labels.device }} on instance {{ $labels.instance }} interface is slower then it should be
+      labels:
+        severity: warning
+    smartCTLDDeviceTemperature:
+      enabled: true
+      alert: SmartCTLDDeviceTemperature
+      expr: smartctl_device_temperature{temperature_type="current"} > 60
+      for: 1m
+      annotations:
+        summary: Device has temperature higher than 60°C
+        description: Device {{ $labels.device }} on instance {{ $labels.instance }} has temperature higher than 60°C
+      labels:
+        severity: warning
+
+image:
+  repository: quay.io/prometheuscommunity/smartctl-exporter
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+updateStrategy:
+  rollingUpdate:
+    maxUnavailable: 1
+  type: RollingUpdate
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+rbac:
+  create: true
+  podSecurityPolicy: unrestricted-psp
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+hostNetwork: false
+
+priorityClassName: ""
+
+annotations: {}
+
+nodeSelector: {}
+
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+
+affinity: {}
+
+service:
+  type: ClusterIP
+  port: 80
+  ipDualStack:
+    enabled: false
+    ipFamilies: ["IPv6", "IPv4"]
+    ipFamilyPolicy: "PreferDualStack"

--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -1465,3 +1465,464 @@ behind it:
 .. code-block:: console
 
   openstack server list --all-projects --long -n --ip $IP
+
+
+``SmartctlDiskAttributeFailing``
+=================================
+
+This alert fires when a SMART attribute's normalized value drops at or
+below the per-attribute failure threshold the drive firmware itself
+defines (``smartctl_device_attribute{attribute_value_type="value"}`` is
+``<=`` the matching ``thresh``, where ``thresh > 0``). The drive itself
+declares one of its prefailure attributes has crossed into the failing
+zone. Common cases are end-of-life wear indicators on SATA SSDs and
+reallocation or pending-sector counters whose normalized values have
+decayed below the firmware threshold. Suppressed when
+``SmartctlDiskUnhealthy`` already fires for the same disk.
+
+**Likely Root Causes**
+
+- SATA SSD wear-out (vendor wearout indicator below threshold)
+- Sustained reallocation pressure dropping the normalized
+  ``Reallocated_Sector_Ct`` value
+- Any vendor-specific prefailure attribute the drive deems failing
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected disk and attribute from the alert labels
+   (``instance``, ``device``, ``attribute_id``, ``attribute_name``).
+
+2. Inspect all SMART attributes and note any flagged ``FAILING_NOW``:
+
+   .. code-block:: console
+
+     smartctl -A /dev/<device>
+
+3. Cross-check with ``SmartctlDiskUnhealthy``: if both fire, the
+   overall SMART status is also failing. Replace the drive immediately.
+
+4. If only this alert fires, the drive is still functional but the
+   firmware predicts the attribute will continue to degrade. Plan
+   replacement during the next maintenance window.
+
+``SmartctlDiskAvailableSpareLow``
+==================================
+
+This alert fires when an NVMe drive's ``available_spare`` percentage drops
+below the manufacturer-defined ``available_spare_threshold``. NVMe drives
+maintain a pool of spare blocks for media defects. Once that pool nears
+exhaustion the controller marks the drive at risk of imminent failure.
+
+**Likely Root Causes**
+
+- The drive is at end-of-life from sustained writes
+- The drive has experienced an unusually high number of bad blocks
+- Firmware degradation tracking the drive itself classifies as critical
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected disk from the alert labels (``instance`` and
+   ``device``).
+
+2. Review the spare and threshold values:
+
+   .. code-block:: console
+
+     smartctl -a /dev/<device> | grep -iE 'available_spare'
+
+3. Cross-check the NVMe ``critical_warning`` field, which the controller
+   sets in parallel:
+
+   .. code-block:: console
+
+     smartctl -a /dev/<device> | grep -i 'critical warning'
+
+4. Migrate any data off the disk and order an emergency replacement. Don't
+   wait for the next maintenance window.
+
+``SmartctlDiskCriticalWarning``
+================================
+
+This alert fires when an NVMe drive's ``critical_warning`` bitfield is
+non-zero. The controller sets bits to indicate available spare below
+threshold, temperature over critical, NVM subsystem reliability degraded,
+media in read-only mode, or volatile-memory backup failed. Any non-zero
+value is the manufacturer's own signal that the drive is unsafe.
+
+**Likely Root Causes**
+
+- Available spare exhausted (bit 0)
+- Temperature exceeded the drive's own critical threshold (bit 1)
+- NVM subsystem reliability degraded (bit 2)
+- Media in read-only mode (bit 3)
+- Volatile-memory backup device failed (bit 4)
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected disk from the alert labels (``instance`` and
+   ``device``).
+
+2. Decode the active bit:
+
+   .. code-block:: console
+
+     smartctl -a /dev/<device> | grep -iA1 'critical warning'
+
+3. Address the underlying cause: cooling for temperature, replacement for
+   reliability/media-read-only/spare-exhausted.
+
+4. Migrate data and replace the drive. Treat any non-zero
+   ``critical_warning`` as an imminent-failure signal.
+
+``SmartctlDiskMediaErrorsGrowing``
+===================================
+
+This alert fires when an NVMe drive's ``media_errors`` counter increased
+over the last 24 hours. The counter records occurrences where the
+controller couldn't recover data via ECC. A stable non-zero count from
+historical events is harmless, but ongoing growth means the media is
+actively degrading.
+
+**Likely Root Causes**
+
+- Media wear at end-of-life
+- A bad NAND die or controller bug
+- Sustained high temperatures damaging cells
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected disk from the alert labels (``instance`` and
+   ``device``).
+
+2. Confirm the current count and trend:
+
+   .. code-block:: console
+
+     smartctl -a /dev/<device> | grep -i 'media.*errors'
+
+3. Compare with ``smartctl_device_percentage_used`` to decide whether
+   wear-out or a localized fault is the cause.
+
+4. Schedule replacement during the next maintenance window. If the rate
+   of growth is high, escalate to immediate replacement.
+
+``SmartctlDiskPendingSectorsGrowing``
+======================================
+
+This alert fires when a SATA drive's ``Current_Pending_Sector`` (attribute
+197) grew over the last 24 hours. A stable non-zero count is harmless.
+The drive remaps those sectors on the next write attempt. Ongoing
+growth indicates active media degradation: the drive is encountering new
+sectors it can't read or write reliably.
+
+**Likely Root Causes**
+
+- Physical wear on platters or NAND cells
+- Mechanical shock or vibration
+- Read disturb errors on busy SSD blocks
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected disk from the alert labels (``instance`` and
+   ``device``).
+
+2. Check the current pending count and other reallocation attributes:
+
+   .. code-block:: console
+
+     smartctl -A /dev/<device> | grep -iE 'pending|reallocated|uncorrectable'
+
+3. Run a long self-test to force reallocation attempts:
+
+   .. code-block:: console
+
+     smartctl -t long /dev/<device>
+
+4. Re-check after the test completes (typically a few hours). If pending
+   sectors continue to grow, schedule replacement.
+
+``SmartctlDiskReallocatedSectorsGrowing``
+==========================================
+
+This alert fires when a SATA drive's ``Reallocated_Sector_Ct`` (attribute
+5) grew over the last 24 hours. A stable non-zero value (for example,
+factory remapping) is harmless, but ongoing growth means the drive is
+actively remapping new bad sectors.
+
+**Likely Root Causes**
+
+- Physical wear or age-related degradation
+- Mechanical shock or vibration
+- Overheating causing intermittent write failures
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected disk from the alert labels (``instance`` and
+   ``device``).
+
+2. Check the current count and trend:
+
+   .. code-block:: console
+
+     smartctl -A /dev/<device> | grep -iE 'reallocated|pending'
+
+3. Plan replacement during the next maintenance window. If the count is
+   accelerating, escalate to an unplanned replacement.
+
+``SmartctlDiskScsiGrownDefectsGrowing``
+========================================
+
+This alert fires when a SCSI/SAS drive's grown defect list
+(``smartctl_scsi_grown_defect_list``) gains entries over the last 24
+hours. A stable non-zero count is harmless. Ongoing growth means the
+drive is actively reallocating bad blocks. This alert is the SAS analog
+of ``SmartctlDiskReallocatedSectorsGrowing``.
+
+**Likely Root Causes**
+
+- Mechanical wear on SAS HDD platters
+- Vibration or shock damage
+- Approaching end of rated life
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected disk from the alert labels (``instance`` and
+   ``device``).
+
+2. Review the defect list and SMART attributes:
+
+   .. code-block:: console
+
+     smartctl -a /dev/<device>
+
+3. Plan replacement during the next maintenance window. Escalate if
+   growth is accelerating or if ``SmartctlDiskScsiUncorrectedErrors``
+   also fires for the same drive.
+
+``SmartctlDiskScsiUncorrectedErrors``
+======================================
+
+This alert fires when a SCSI/SAS drive's read or write
+total-uncorrected-error counter
+(``smartctl_read_total_uncorrected_errors`` /
+``smartctl_write_total_uncorrected_errors``) increases over the last 24
+hours. Any non-zero growth means the drive couldn't recover I/O via
+on-disk ECC, confirming data loss in the affected blocks.
+
+**Likely Root Causes**
+
+- Severe media degradation
+- Mechanical or electronics fault
+- SAS bus errors hammering the drive
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected disk from the alert labels (``instance`` and
+   ``device``).
+
+2. Inspect the SCSI error counter log and overall health:
+
+   .. code-block:: console
+
+     smartctl -l error /dev/<device>
+     smartctl -a /dev/<device>
+
+3. Migrate any data off the disk and replace it. Don't return the drive
+   to service.
+
+``SmartctlDiskSelfTestFailed``
+===============================
+
+This alert fires when a SATA drive reports one or more entries in its
+SMART self-test error log. Even one failed self-test indicates the
+drive couldn't complete an internal integrity check. The upstream
+``smartctl_exporter`` only emits this metric for ATA/SATA drives. NVMe
+self-test results aren't surfaced.
+
+**Likely Root Causes**
+
+- Bad sectors detected during the self-test
+- Mechanical or electronics fault
+- Drive firmware or controller errors
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected disk from the alert labels (``instance`` and
+   ``device``).
+
+2. Review the self-test log:
+
+   .. code-block:: console
+
+     smartctl -l selftest /dev/<device>
+
+3. Run a fresh self-test to confirm the failure:
+
+   .. code-block:: console
+
+     smartctl -t long /dev/<device>
+
+4. If failures persist, plan replacement during the next maintenance
+   window.
+
+``SmartctlDiskTemperatureHigh``
+================================
+
+This alert fires when a disk's current temperature exceeds 65°C sustained
+for at least one hour. Brief spikes during heavy I/O are normal,
+especially on NVMe drives, but sustained high temperatures accelerate
+flash memory wear and can cause data loss or mechanical failure.
+
+**Likely Root Causes**
+
+- Inadequate server cooling or airflow around the disk bay
+- Failed or degraded cooling fans
+- High ambient temperature in the data center
+- Sustained heavy workload with insufficient cooling
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected disk from the alert labels (``instance`` and
+   ``device``).
+
+2. Check current and historical temperatures:
+
+   .. code-block:: console
+
+     smartctl -a /dev/<device> | grep -i temperature
+
+3. Check the server's fan speeds via IPMI:
+
+   .. code-block:: console
+
+     ipmitool sdr type Fan
+
+4. Inspect airflow paths for obstruction. Verify that the disk bay isn't
+   blocked.
+
+5. If ambient temperature has risen, escalate to facilities.
+
+``SmartctlDiskUncorrectableSectorsGrowing``
+============================================
+
+This alert fires when a SATA drive's ``Offline_Uncorrectable`` (attribute
+198) grew over the last 24 hours. A stable non-zero count is harmless
+because those sectors represent already-acknowledged bad blocks. Ongoing
+growth means the drive is finding new sectors it can't recover during
+background scans, indicating confirmed unrecoverable data loss in newly
+affected LBAs.
+
+**Likely Root Causes**
+
+- Physical damage to platters
+- Severe NAND wear
+- Mechanical shock
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected disk from the alert labels (``instance`` and
+   ``device``).
+
+2. Determine which files (if any) live on the affected sectors:
+
+   .. code-block:: console
+
+     smartctl -a /dev/<device>
+
+3. Check filesystem integrity (offline if necessary):
+
+   .. code-block:: console
+
+     fsck -nv /dev/<device>
+
+4. Migrate any data off the disk and replace it. Don't return the drive
+   to service.
+
+``SmartctlDiskUnhealthy``
+==========================
+
+This alert fires when a disk fails its SMART overall-health
+self-assessment (``smartctl_device_smart_status == 0``). The drive
+firmware predicts imminent failure. Replace the disk immediately to
+prevent data loss.
+
+**Likely Root Causes**
+
+- The disk has exceeded its rated endurance
+- Reallocated, pending, or uncorrectable sector counts crossed the
+  manufacturer's critical threshold
+- Catastrophic hardware failure or firmware corruption
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected disk from the alert labels (``instance`` and
+   ``device``).
+
+2. Verify SMART health and review all attributes:
+
+   .. code-block:: console
+
+     smartctl -H /dev/<device>
+     smartctl -a /dev/<device>
+
+3. Migrate data immediately to a healthy replica. Don't defer.
+
+4. Order an emergency replacement; don't wait for a maintenance window.
+
+``SmartctlDiskWearoutCritical``
+================================
+
+This alert fires when an NVMe drive reports more than 90% of its rated
+endurance used (``smartctl_device_percentage_used > 90``) sustained for
+at least 15 minutes. At this wear level the manufacturer considers
+near-term failure likely. ``SmartctlDiskAttributeFailing`` covers SATA
+drives instead, since they expose wear via vendor-specific normalized
+attributes rather than ``percentage_used``.
+
+**Likely Root Causes**
+
+- The disk has been in heavy write workloads for an extended period
+- A workload exceeded the disk's rated endurance (write amplification)
+- The disk is approaching end of its rated lifetime
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected disk from the alert labels (``instance`` and
+   ``device``).
+
+2. Confirm the wear level:
+
+   .. code-block:: console
+
+     smartctl -a /dev/<device> | grep -i percentage_used
+
+3. Review workload sizing. If the workload exceeded the disk's rated
+   endurance, plan a higher-endurance class for the replacement.
+
+4. Order a replacement. Schedule replacement during the next maintenance
+   window, sooner if ``SmartctlDiskUnhealthy`` also fires.
+
+``SmartctlDiskWearoutWarning``
+================================
+
+This alert fires when an NVMe drive reports more than 75% of its rated
+endurance used (``smartctl_device_percentage_used > 75``) sustained for
+at least one hour. The drive still operates within specification but is
+approaching end of life. Suppressed automatically when
+``SmartctlDiskWearoutCritical`` fires for the same disk.
+``SmartctlDiskAttributeFailing`` covers SATA drives instead.
+
+**Likely Root Causes**
+
+- The disk has been in heavy write workloads for an extended period
+- A workload exceeded the disk's rated endurance (write amplification)
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected disk from the alert labels (``instance`` and
+   ``device``).
+
+2. Check the wear trend in Grafana or Prometheus to estimate time to
+   failure.
+
+3. Plan a replacement during the next scheduled maintenance window.

--- a/playbooks/monitoring.yml
+++ b/playbooks/monitoring.yml
@@ -40,6 +40,10 @@
       tags:
         - ipmi-exporter
 
+    - role: smartctl_exporter
+      tags:
+        - smartctl-exporter
+
     - role: prometheus_pushgateway
       tags:
         - prometheus-pushgateway

--- a/releasenotes/notes/smartctl-exporter-76c029503b875604.yaml
+++ b/releasenotes/notes/smartctl-exporter-76c029503b875604.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Added disk health monitoring using the ``smartctl_exporter`` deployed as a
+    DaemonSet on bare-metal nodes. The exporter collects SMART attributes from
+    all detected disks and exposes them as Prometheus metrics, enabling alerts
+    for disk wear, temperature, reallocated sectors, and overall SMART health
+    status.

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -206,6 +206,7 @@ _atmosphere_images:
   prometheus_memcached_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/memcached-exporter:v0.14.3"
   prometheus_mysqld_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/mysqld-exporter:v0.17.0"
   prometheus_node_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/node-exporter:v1.8.1"
+  prometheus_smartctl_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheuscommunity/smartctl-exporter:v0.14.0@sha256:cfe22c36d7d2fac48ebf619707305acb65eb0fb670656eb80f356e606d782bc1"
   prometheus_openstack_database_exporter: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/openstack-database-exporter:v1.1.0@sha256:b8ae955645124e5d6054a3ce98069169e29dc1464d7979a4431f496ead50958e"
   prometheus_openstack_exporter: "{{ atmosphere_image_prefix }}ghcr.io/openstack-exporter/openstack-exporter:1.7.0"
   prometheus_operator_kube_webhook_certgen: "{{ atmosphere_image_prefix }}registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6"

--- a/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
@@ -300,6 +300,7 @@ local mixins = {
   goldpinger: (import 'goldpinger.libsonnet'),
   nginx: (import 'nginx.libsonnet'),
   openstack: (import 'openstack.libsonnet'),
+  smartctl: (import 'smartctl.libsonnet'),
 } + (import 'legacy.libsonnet');
 
 {

--- a/roles/kube_prometheus_stack/files/jsonnet/smartctl.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/smartctl.libsonnet
@@ -1,0 +1,193 @@
+{
+  prometheusAlerts+: {
+    groups+: [
+      {
+        name: 'smartctl-health',
+        rules: [
+          {
+            alert: 'SmartctlDiskUnhealthy',
+            expr: 'smartctl_device_smart_status == 0',
+            'for': '5m',
+            labels: {
+              severity: 'P2',
+            },
+            annotations: {
+              summary: 'Disk: SMART overall health check failed',
+              description: 'The SMART overall-health self-assessment for disk {{ $labels.device }} on node {{ $labels.instance }} is reporting failure (smartctl_device_smart_status=0). The drive firmware predicts imminent failure. Normal value is 1.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskunhealthy',
+            },
+          },
+          {
+            alert: 'SmartctlDiskCriticalWarning',
+            expr: 'smartctl_device_critical_warning != 0',
+            'for': '5m',
+            labels: {
+              severity: 'P2',
+            },
+            annotations: {
+              summary: 'Disk: NVMe critical warning bit set',
+              description: 'The NVMe critical_warning bitfield for disk {{ $labels.device }} on node {{ $labels.instance }} is {{ $value }} (normal is 0). Bits indicate available spare below threshold, temperature above critical, NVM subsystem reliability degraded, media in read-only mode, or volatile memory backup failed.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskcriticalwarning',
+            },
+          },
+          {
+            alert: 'SmartctlDiskAvailableSpareLow',
+            expr: 'smartctl_device_available_spare < smartctl_device_available_spare_threshold',
+            'for': '5m',
+            labels: {
+              severity: 'P2',
+            },
+            annotations: {
+              summary: 'Disk: NVMe available spare below manufacturer threshold',
+              description: 'The NVMe available spare on disk {{ $labels.device }} on node {{ $labels.instance }} is {{ $value }}%, which is below the manufacturer-defined threshold. The drive has nearly exhausted its reserve blocks; failure is imminent. Normal is well above the threshold (typically 100% on a healthy drive).',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskavailablesparelow',
+            },
+          },
+          {
+            alert: 'SmartctlDiskWearoutCritical',
+            expr: 'smartctl_device_percentage_used > 90',
+            'for': '15m',
+            labels: {
+              severity: 'P3',
+            },
+            annotations: {
+              summary: 'Disk: NVMe wear level critical',
+              description: 'The NVMe disk {{ $labels.device }} on node {{ $labels.instance }} reports {{ $value }}% of its rated endurance used (smartctl_device_percentage_used), exceeding the 90% threshold. Plan immediate replacement. Normal operating range is below 75%. (NVMe-only; SATA drives are covered by SmartctlDiskAttributeFailing.)',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskwearoutcritical',
+            },
+          },
+          {
+            alert: 'SmartctlDiskAttributeFailing',
+            expr: '(smartctl_device_attribute{attribute_value_type="value"} <= ignoring(attribute_value_type) smartctl_device_attribute{attribute_value_type="thresh"}) and ignoring(attribute_value_type) (smartctl_device_attribute{attribute_value_type="thresh"} > 0)',
+            'for': '5m',
+            labels: {
+              severity: 'P2',
+            },
+            annotations: {
+              summary: 'Disk: SMART attribute below failure threshold',
+              description: 'The SMART attribute {{ $labels.attribute_name }} (id {{ $labels.attribute_id }}) on disk {{ $labels.device }} on node {{ $labels.instance }} has dropped to a normalized value of {{ $value }}, at or below the threshold the drive firmware uses to declare the attribute failing. Normal is for the value to stay well above its threshold. The drive itself is signalling imminent failure of this attribute (e.g., wear-leveling, reallocation, or a vendor-specific prefailure indicator).',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskattributefailing',
+            },
+          },
+          {
+            alert: 'SmartctlDiskScsiUncorrectedErrors',
+            expr: 'increase(smartctl_read_total_uncorrected_errors[24h]) > 0 or increase(smartctl_write_total_uncorrected_errors[24h]) > 0',
+            'for': '15m',
+            labels: {
+              severity: 'P3',
+            },
+            annotations: {
+              summary: 'Disk: SCSI/SAS uncorrected I/O errors',
+              description: 'The SCSI/SAS disk {{ $labels.device }} on node {{ $labels.instance }} accumulated {{ $value }} new uncorrected read/write errors in the last 24 hours. Normal is zero growth: any non-zero increase indicates the drive could not recover I/O via on-disk ECC, which means data loss or imminent failure.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskscsiuncorrectederrors',
+            },
+          },
+          {
+            alert: 'SmartctlDiskPendingSectorsGrowing',
+            expr: 'increase(smartctl_device_attribute{attribute_id="197",attribute_value_type="raw"}[24h]) > 0',
+            'for': '1h',
+            labels: {
+              severity: 'P3',
+            },
+            annotations: {
+              summary: 'Disk: pending sector count growing',
+              description: 'The SATA disk {{ $labels.device }} on node {{ $labels.instance }} added {{ $value }} sectors awaiting reallocation in the last 24 hours (Current_Pending_Sector, attribute 197). Normal is zero growth: a stable non-zero count is harmless (those sectors will be remapped on next write), but ongoing growth indicates active media degradation.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskpendingsectorsgrowing',
+            },
+          },
+          {
+            alert: 'SmartctlDiskUncorrectableSectorsGrowing',
+            expr: 'increase(smartctl_device_attribute{attribute_id="198",attribute_value_type="raw"}[24h]) > 0',
+            'for': '1h',
+            labels: {
+              severity: 'P3',
+            },
+            annotations: {
+              summary: 'Disk: uncorrectable sector count growing',
+              description: 'The SATA disk {{ $labels.device }} on node {{ $labels.instance }} added {{ $value }} offline-uncorrectable sectors in the last 24 hours (Offline_Uncorrectable, attribute 198). Normal is zero growth: a stable non-zero count is harmless, but ongoing growth indicates confirmed unrecoverable data loss in newly affected LBAs.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskuncorrectablesectorsgrowing',
+            },
+          },
+          {
+            alert: 'SmartctlDiskMediaErrorsGrowing',
+            expr: 'increase(smartctl_device_media_errors[24h]) > 0',
+            'for': '15m',
+            labels: {
+              severity: 'P3',
+            },
+            annotations: {
+              summary: 'Disk: NVMe media errors increasing',
+              description: 'The NVMe disk {{ $labels.device }} on node {{ $labels.instance }} accumulated {{ $value }} new media errors in the last 24 hours (smartctl_device_media_errors). Normal is zero growth over time. New errors indicate active uncorrectable ECC failures or LBA tag mismatches.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskmediaerrorsgrowing',
+            },
+          },
+          {
+            alert: 'SmartctlDiskWearoutWarning',
+            expr: 'smartctl_device_percentage_used > 75',
+            'for': '1h',
+            labels: {
+              severity: 'P4',
+            },
+            annotations: {
+              summary: 'Disk: NVMe wear level elevated',
+              description: 'The NVMe disk {{ $labels.device }} on node {{ $labels.instance }} reports {{ $value }}% of its rated endurance used (smartctl_device_percentage_used), exceeding the 75% threshold. Plan replacement during the next maintenance window. Normal operating range is below 75%. (NVMe-only; SATA drives are covered by SmartctlDiskAttributeFailing.)',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskwearoutwarning',
+            },
+          },
+          {
+            alert: 'SmartctlDiskScsiGrownDefectsGrowing',
+            expr: 'increase(smartctl_scsi_grown_defect_list[24h]) > 0',
+            'for': '1h',
+            labels: {
+              severity: 'P4',
+            },
+            annotations: {
+              summary: 'Disk: SCSI/SAS grown defect list growing',
+              description: 'The SCSI/SAS disk {{ $labels.device }} on node {{ $labels.instance }} added {{ $value }} entries to its grown defect list in the last 24 hours. Normal is zero growth: a stable non-zero count is harmless, but ongoing growth means the drive is actively reallocating bad blocks.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskscsigrowndefectsgrowing',
+            },
+          },
+          {
+            alert: 'SmartctlDiskTemperatureHigh',
+            expr: 'smartctl_device_temperature{temperature_type="current"} > 65',
+            'for': '1h',
+            labels: {
+              severity: 'P4',
+            },
+            annotations: {
+              summary: 'Disk: temperature sustained high',
+              description: 'The disk {{ $labels.device }} on node {{ $labels.instance }} has run at {{ $value }}°C for over an hour, exceeding the 65°C threshold. Normal operating temperature is below 50°C for HDDs and below 60°C for SSDs. Check chassis cooling and airflow.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldisktemperaturehigh',
+            },
+          },
+          {
+            alert: 'SmartctlDiskReallocatedSectorsGrowing',
+            expr: 'increase(smartctl_device_attribute{attribute_id="5",attribute_value_type="raw"}[24h]) > 0',
+            'for': '1h',
+            labels: {
+              severity: 'P4',
+            },
+            annotations: {
+              summary: 'Disk: reallocated sector count growing',
+              description: 'The SATA disk {{ $labels.device }} on node {{ $labels.instance }} reallocated {{ $value }} additional sectors in the last 24 hours (Reallocated_Sector_Ct, attribute 5). Normal is zero growth: a stable non-zero count is harmless, but ongoing reallocation indicates active media degradation.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskreallocatedsectorsgrowing',
+            },
+          },
+          {
+            alert: 'SmartctlDiskSelfTestFailed',
+            expr: 'smartctl_device_self_test_log_error_count > 0',
+            'for': '1h',
+            labels: {
+              severity: 'P4',
+            },
+            annotations: {
+              summary: 'Disk: SATA SMART self-test reported errors',
+              description: 'The SATA disk {{ $labels.device }} on node {{ $labels.instance }} has {{ $value }} entries in its SMART self-test error log (self_test_log_type={{ $labels.self_test_log_type }}). Normal is 0. Even one failed self-test indicates the drive could not complete an internal integrity check. (SATA-only; the upstream exporter does not surface NVMe self-test results.)',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskselftestfailed',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -1083,6 +1083,435 @@ tests:
               description: "CoreDNS has disappeared from Prometheus target discovery for more than 15 minutes. This could indicate a crashed CoreDNS pod or a misconfigured scrape target."
               runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#corednsdown"
 
+  # SmartctlDiskUnhealthy - should NOT fire when SMART status is healthy
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_smart_status{device="/dev/sda",instance="192.0.2.10"}'
+        values: '1x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: SmartctlDiskUnhealthy
+        exp_alerts: []
+
+  # SmartctlDiskUnhealthy - should fire when SMART status is 0
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_smart_status{device="/dev/sda",instance="192.0.2.10"}'
+        values: '0x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: SmartctlDiskUnhealthy
+        exp_alerts:
+          - exp_labels:
+              severity: P2
+              device: /dev/sda
+              instance: 192.0.2.10
+            exp_annotations:
+              summary: "Disk: SMART overall health check failed"
+              description: 'The SMART overall-health self-assessment for disk /dev/sda on node 192.0.2.10 is reporting failure (smartctl_device_smart_status=0). The drive firmware predicts imminent failure. Normal value is 1.'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskunhealthy"
+
+  # SmartctlDiskCriticalWarning - should NOT fire when bitfield is 0
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_critical_warning{device="/dev/nvme0",instance="192.0.2.10"}'
+        values: '0x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: SmartctlDiskCriticalWarning
+        exp_alerts: []
+
+  # SmartctlDiskCriticalWarning - should fire when bitfield is set
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_critical_warning{device="/dev/nvme0",instance="192.0.2.10"}'
+        values: '4x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: SmartctlDiskCriticalWarning
+        exp_alerts:
+          - exp_labels:
+              severity: P2
+              device: /dev/nvme0
+              instance: 192.0.2.10
+            exp_annotations:
+              summary: "Disk: NVMe critical warning bit set"
+              description: 'The NVMe critical_warning bitfield for disk /dev/nvme0 on node 192.0.2.10 is 4 (normal is 0). Bits indicate available spare below threshold, temperature above critical, NVM subsystem reliability degraded, media in read-only mode, or volatile memory backup failed.'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskcriticalwarning"
+
+  # SmartctlDiskAvailableSpareLow - should NOT fire when spare is above threshold
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_available_spare{device="/dev/nvme0",instance="192.0.2.10"}'
+        values: '90x10'
+      - series: 'smartctl_device_available_spare_threshold{device="/dev/nvme0",instance="192.0.2.10"}'
+        values: '10x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: SmartctlDiskAvailableSpareLow
+        exp_alerts: []
+
+  # SmartctlDiskAvailableSpareLow - should fire when spare drops below threshold
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_available_spare{device="/dev/nvme0",instance="192.0.2.10"}'
+        values: '5x10'
+      - series: 'smartctl_device_available_spare_threshold{device="/dev/nvme0",instance="192.0.2.10"}'
+        values: '10x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: SmartctlDiskAvailableSpareLow
+        exp_alerts:
+          - exp_labels:
+              severity: P2
+              device: /dev/nvme0
+              instance: 192.0.2.10
+            exp_annotations:
+              summary: "Disk: NVMe available spare below manufacturer threshold"
+              description: 'The NVMe available spare on disk /dev/nvme0 on node 192.0.2.10 is 5%, which is below the manufacturer-defined threshold. The drive has nearly exhausted its reserve blocks; failure is imminent. Normal is well above the threshold (typically 100% on a healthy drive).'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskavailablesparelow"
+
+  # SmartctlDiskWearoutCritical - should NOT fire when wear is below 90%
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_percentage_used{device="/dev/sda",instance="192.0.2.10"}'
+        values: '85x20'
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: SmartctlDiskWearoutCritical
+        exp_alerts: []
+
+  # SmartctlDiskWearoutCritical - should fire when wear exceeds 90%
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_percentage_used{device="/dev/sda",instance="192.0.2.10"}'
+        values: '95x20'
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: SmartctlDiskWearoutCritical
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+              device: /dev/sda
+              instance: 192.0.2.10
+            exp_annotations:
+              summary: "Disk: NVMe wear level critical"
+              description: 'The NVMe disk /dev/sda on node 192.0.2.10 reports 95% of its rated endurance used (smartctl_device_percentage_used), exceeding the 90% threshold. Plan immediate replacement. Normal operating range is below 75%. (NVMe-only; SATA drives are covered by SmartctlDiskAttributeFailing.)'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskwearoutcritical"
+
+  # SmartctlDiskPendingSectorsGrowing - should NOT fire when count is stable (no growth)
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_attribute{device="/dev/sda",instance="192.0.2.10",attribute_id="197",attribute_name="Current_Pending_Sector",attribute_value_type="raw"}'
+        values: '4x1500'
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: SmartctlDiskPendingSectorsGrowing
+        exp_alerts: []
+
+  # SmartctlDiskPendingSectorsGrowing - should fire when count grows over 24h
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_attribute{device="/dev/sda",instance="192.0.2.10",attribute_id="197",attribute_name="Current_Pending_Sector",attribute_value_type="raw"}'
+        values: '0+1x1500'
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: SmartctlDiskPendingSectorsGrowing
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+              device: /dev/sda
+              instance: 192.0.2.10
+              attribute_id: "197"
+              attribute_name: Current_Pending_Sector
+              attribute_value_type: raw
+            exp_annotations:
+              summary: "Disk: pending sector count growing"
+              description: 'The SATA disk /dev/sda on node 192.0.2.10 added 1440 sectors awaiting reallocation in the last 24 hours (Current_Pending_Sector, attribute 197). Normal is zero growth: a stable non-zero count is harmless (those sectors will be remapped on next write), but ongoing growth indicates active media degradation.'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskpendingsectorsgrowing"
+
+  # SmartctlDiskUncorrectableSectorsGrowing - should NOT fire when count is stable (no growth)
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_attribute{device="/dev/sda",instance="192.0.2.10",attribute_id="198",attribute_name="Offline_Uncorrectable",attribute_value_type="raw"}'
+        values: '2x1500'
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: SmartctlDiskUncorrectableSectorsGrowing
+        exp_alerts: []
+
+  # SmartctlDiskUncorrectableSectorsGrowing - should fire when count grows over 24h
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_attribute{device="/dev/sda",instance="192.0.2.10",attribute_id="198",attribute_name="Offline_Uncorrectable",attribute_value_type="raw"}'
+        values: '0+1x1500'
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: SmartctlDiskUncorrectableSectorsGrowing
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+              device: /dev/sda
+              instance: 192.0.2.10
+              attribute_id: "198"
+              attribute_name: Offline_Uncorrectable
+              attribute_value_type: raw
+            exp_annotations:
+              summary: "Disk: uncorrectable sector count growing"
+              description: 'The SATA disk /dev/sda on node 192.0.2.10 added 1440 offline-uncorrectable sectors in the last 24 hours (Offline_Uncorrectable, attribute 198). Normal is zero growth: a stable non-zero count is harmless, but ongoing growth indicates confirmed unrecoverable data loss in newly affected LBAs.'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskuncorrectablesectorsgrowing"
+
+  # SmartctlDiskMediaErrorsGrowing - should NOT fire when count is stable (no growth)
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_media_errors{device="/dev/nvme0",instance="192.0.2.10"}'
+        values: '5x1500'
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: SmartctlDiskMediaErrorsGrowing
+        exp_alerts: []
+
+  # SmartctlDiskMediaErrorsGrowing - should fire when count grows over 24h
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_media_errors{device="/dev/nvme0",instance="192.0.2.10"}'
+        values: '0+1x1500'
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: SmartctlDiskMediaErrorsGrowing
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+              device: /dev/nvme0
+              instance: 192.0.2.10
+            exp_annotations:
+              summary: "Disk: NVMe media errors increasing"
+              description: 'The NVMe disk /dev/nvme0 on node 192.0.2.10 accumulated 1440 new media errors in the last 24 hours (smartctl_device_media_errors). Normal is zero growth over time. New errors indicate active uncorrectable ECC failures or LBA tag mismatches.'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskmediaerrorsgrowing"
+
+  # SmartctlDiskWearoutWarning - should NOT fire when wear is below 75%
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_percentage_used{device="/dev/sda",instance="192.0.2.10"}'
+        values: '70x80'
+    alert_rule_test:
+      - eval_time: 1h5m
+        alertname: SmartctlDiskWearoutWarning
+        exp_alerts: []
+
+  # SmartctlDiskWearoutWarning - should fire when wear exceeds 75%
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_percentage_used{device="/dev/sda",instance="192.0.2.10"}'
+        values: '80x80'
+    alert_rule_test:
+      - eval_time: 1h5m
+        alertname: SmartctlDiskWearoutWarning
+        exp_alerts:
+          - exp_labels:
+              severity: P4
+              device: /dev/sda
+              instance: 192.0.2.10
+            exp_annotations:
+              summary: "Disk: NVMe wear level elevated"
+              description: 'The NVMe disk /dev/sda on node 192.0.2.10 reports 80% of its rated endurance used (smartctl_device_percentage_used), exceeding the 75% threshold. Plan replacement during the next maintenance window. Normal operating range is below 75%. (NVMe-only; SATA drives are covered by SmartctlDiskAttributeFailing.)'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskwearoutwarning"
+
+  # SmartctlDiskTemperatureHigh - should NOT fire when temperature is normal
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_temperature{device="/dev/sda",instance="192.0.2.10",temperature_type="current"}'
+        values: '45x80'
+    alert_rule_test:
+      - eval_time: 1h5m
+        alertname: SmartctlDiskTemperatureHigh
+        exp_alerts: []
+
+  # SmartctlDiskTemperatureHigh - should fire when temperature exceeds 65°C
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_temperature{device="/dev/sda",instance="192.0.2.10",temperature_type="current"}'
+        values: '70x80'
+    alert_rule_test:
+      - eval_time: 1h5m
+        alertname: SmartctlDiskTemperatureHigh
+        exp_alerts:
+          - exp_labels:
+              severity: P4
+              device: /dev/sda
+              instance: 192.0.2.10
+              temperature_type: current
+            exp_annotations:
+              summary: "Disk: temperature sustained high"
+              description: 'The disk /dev/sda on node 192.0.2.10 has run at 70°C for over an hour, exceeding the 65°C threshold. Normal operating temperature is below 50°C for HDDs and below 60°C for SSDs. Check chassis cooling and airflow.'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldisktemperaturehigh"
+
+  # SmartctlDiskReallocatedSectorsGrowing - should NOT fire when count is stable
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_attribute{device="/dev/sda",instance="192.0.2.10",attribute_id="5",attribute_name="Reallocated_Sector_Ct",attribute_value_type="raw"}'
+        values: '12x1500'
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: SmartctlDiskReallocatedSectorsGrowing
+        exp_alerts: []
+
+  # SmartctlDiskReallocatedSectorsGrowing - should fire when count grows over 24h
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_attribute{device="/dev/sda",instance="192.0.2.10",attribute_id="5",attribute_name="Reallocated_Sector_Ct",attribute_value_type="raw"}'
+        values: '0+1x1500'
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: SmartctlDiskReallocatedSectorsGrowing
+        exp_alerts:
+          - exp_labels:
+              severity: P4
+              device: /dev/sda
+              instance: 192.0.2.10
+              attribute_id: "5"
+              attribute_name: Reallocated_Sector_Ct
+              attribute_value_type: raw
+            exp_annotations:
+              summary: "Disk: reallocated sector count growing"
+              description: 'The SATA disk /dev/sda on node 192.0.2.10 reallocated 1440 additional sectors in the last 24 hours (Reallocated_Sector_Ct, attribute 5). Normal is zero growth: a stable non-zero count is harmless, but ongoing reallocation indicates active media degradation.'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskreallocatedsectorsgrowing"
+
+  # SmartctlDiskSelfTestFailed - should NOT fire when error count is 0
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_self_test_log_error_count{device="/dev/sda",instance="192.0.2.10",self_test_log_type="standard"}'
+        values: '0x80'
+    alert_rule_test:
+      - eval_time: 1h5m
+        alertname: SmartctlDiskSelfTestFailed
+        exp_alerts: []
+
+  # SmartctlDiskSelfTestFailed - should fire when error count > 0
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_self_test_log_error_count{device="/dev/sda",instance="192.0.2.10",self_test_log_type="standard"}'
+        values: '1x80'
+    alert_rule_test:
+      - eval_time: 1h5m
+        alertname: SmartctlDiskSelfTestFailed
+        exp_alerts:
+          - exp_labels:
+              severity: P4
+              device: /dev/sda
+              instance: 192.0.2.10
+              self_test_log_type: standard
+            exp_annotations:
+              summary: "Disk: SATA SMART self-test reported errors"
+              description: 'The SATA disk /dev/sda on node 192.0.2.10 has 1 entries in its SMART self-test error log (self_test_log_type=standard). Normal is 0. Even one failed self-test indicates the drive could not complete an internal integrity check. (SATA-only; the upstream exporter does not surface NVMe self-test results.)'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskselftestfailed"
+
+  # SmartctlDiskAttributeFailing - should NOT fire when value is above thresh
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_attribute{device="/dev/sda",instance="192.0.2.10",attribute_id="5",attribute_name="Reallocated_Sector_Ct",attribute_value_type="value"}'
+        values: '100x20'
+      - series: 'smartctl_device_attribute{device="/dev/sda",instance="192.0.2.10",attribute_id="5",attribute_name="Reallocated_Sector_Ct",attribute_value_type="thresh"}'
+        values: '10x20'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: SmartctlDiskAttributeFailing
+        exp_alerts: []
+
+  # SmartctlDiskAttributeFailing - should NOT fire when thresh is 0 (informational attribute)
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_attribute{device="/dev/sda",instance="192.0.2.10",attribute_id="194",attribute_name="Temperature_Celsius",attribute_value_type="value"}'
+        values: '0x20'
+      - series: 'smartctl_device_attribute{device="/dev/sda",instance="192.0.2.10",attribute_id="194",attribute_name="Temperature_Celsius",attribute_value_type="thresh"}'
+        values: '0x20'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: SmartctlDiskAttributeFailing
+        exp_alerts: []
+
+  # SmartctlDiskAttributeFailing - should fire when value drops to/below thresh
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_device_attribute{device="/dev/sda",instance="192.0.2.10",attribute_id="233",attribute_name="Media_Wearout_Indicator",attribute_value_type="value"}'
+        values: '8x20'
+      - series: 'smartctl_device_attribute{device="/dev/sda",instance="192.0.2.10",attribute_id="233",attribute_name="Media_Wearout_Indicator",attribute_value_type="thresh"}'
+        values: '10x20'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: SmartctlDiskAttributeFailing
+        exp_alerts:
+          - exp_labels:
+              severity: P2
+              device: /dev/sda
+              instance: 192.0.2.10
+              attribute_id: "233"
+              attribute_name: Media_Wearout_Indicator
+            exp_annotations:
+              summary: "Disk: SMART attribute below failure threshold"
+              description: 'The SMART attribute Media_Wearout_Indicator (id 233) on disk /dev/sda on node 192.0.2.10 has dropped to a normalized value of 8, at or below the threshold the drive firmware uses to declare the attribute failing. Normal is for the value to stay well above its threshold. The drive itself is signalling imminent failure of this attribute (e.g., wear-leveling, reallocation, or a vendor-specific prefailure indicator).'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskattributefailing"
+
+  # SmartctlDiskScsiUncorrectedErrors - should NOT fire when error counters are flat
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_read_total_uncorrected_errors{device="/dev/sdb",instance="192.0.2.10"}'
+        values: '0x1500'
+      - series: 'smartctl_write_total_uncorrected_errors{device="/dev/sdb",instance="192.0.2.10"}'
+        values: '0x1500'
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: SmartctlDiskScsiUncorrectedErrors
+        exp_alerts: []
+
+  # SmartctlDiskScsiUncorrectedErrors - should fire when read errors grow
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_read_total_uncorrected_errors{device="/dev/sdb",instance="192.0.2.10"}'
+        values: '0+1x1500'
+      - series: 'smartctl_write_total_uncorrected_errors{device="/dev/sdb",instance="192.0.2.10"}'
+        values: '0x1500'
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: SmartctlDiskScsiUncorrectedErrors
+        exp_alerts:
+          - exp_labels:
+              severity: P3
+              device: /dev/sdb
+              instance: 192.0.2.10
+            exp_annotations:
+              summary: "Disk: SCSI/SAS uncorrected I/O errors"
+              description: 'The SCSI/SAS disk /dev/sdb on node 192.0.2.10 accumulated 1440 new uncorrected read/write errors in the last 24 hours. Normal is zero growth: any non-zero increase indicates the drive could not recover I/O via on-disk ECC, which means data loss or imminent failure.'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskscsiuncorrectederrors"
+
+  # SmartctlDiskScsiGrownDefectsGrowing - should NOT fire when count is stable
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_scsi_grown_defect_list{device="/dev/sdb",instance="192.0.2.10"}'
+        values: '7x1500'
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: SmartctlDiskScsiGrownDefectsGrowing
+        exp_alerts: []
+
+  # SmartctlDiskScsiGrownDefectsGrowing - should fire when count grows over 24h
+  - interval: 1m
+    input_series:
+      - series: 'smartctl_scsi_grown_defect_list{device="/dev/sdb",instance="192.0.2.10"}'
+        values: '0+1x1500'
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: SmartctlDiskScsiGrownDefectsGrowing
+        exp_alerts:
+          - exp_labels:
+              severity: P4
+              device: /dev/sdb
+              instance: 192.0.2.10
+            exp_annotations:
+              summary: "Disk: SCSI/SAS grown defect list growing"
+              description: 'The SCSI/SAS disk /dev/sdb on node 192.0.2.10 added 1440 entries to its grown defect list in the last 24 hours. Normal is zero growth: a stable non-zero count is harmless, but ongoing growth means the drive is actively reallocating bad blocks.'
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#smartctldiskscsigrowndefectsgrowing"
+
   # GeneveTransmitErrors - should NOT fire when error rate is below threshold
   - interval: 1m
     input_series:

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -69,6 +69,48 @@ _kube_prometheus_stack_helm_values:
             - alertname = "CoreDNSModerateErrorBudgetBurn"
           target_matchers:
             - alertname = "CoreDNSLowErrorBudgetBurn"
+        - source_matchers:
+            - alertname = "SmartctlDiskUnhealthy"
+          target_matchers:
+            - alertname =~ "SmartctlDisk(CriticalWarning|AvailableSpareLow|WearoutCritical|WearoutWarning|PendingSectorsGrowing|UncorrectableSectorsGrowing|MediaErrorsGrowing|ReallocatedSectorsGrowing|TemperatureHigh|SelfTestFailed|AttributeFailing|ScsiUncorrectedErrors|ScsiGrownDefectsGrowing)"
+          equal:
+            - instance
+            - device
+        - source_matchers:
+            - alertname = "SmartctlDiskAvailableSpareLow"
+          target_matchers:
+            - alertname =~ "SmartctlDisk(CriticalWarning|WearoutCritical|WearoutWarning)"
+          equal:
+            - instance
+            - device
+        - source_matchers:
+            - alertname = "SmartctlDiskMediaErrorsGrowing"
+          target_matchers:
+            - alertname = "SmartctlDiskCriticalWarning"
+          equal:
+            - instance
+            - device
+        - source_matchers:
+            - alertname = "SmartctlDiskTemperatureHigh"
+          target_matchers:
+            - alertname = "SmartctlDiskCriticalWarning"
+          equal:
+            - instance
+            - device
+        - source_matchers:
+            - alertname = "SmartctlDiskAttributeFailing"
+          target_matchers:
+            - alertname =~ "SmartctlDisk(PendingSectorsGrowing|UncorrectableSectorsGrowing|ReallocatedSectorsGrowing)"
+          equal:
+            - instance
+            - device
+        - source_matchers:
+            - alertname = "SmartctlDiskWearoutCritical"
+          target_matchers:
+            - alertname = "SmartctlDiskWearoutWarning"
+          equal:
+            - instance
+            - device
       route:
         group_by:
           - alertname

--- a/roles/smartctl_exporter/README.md
+++ b/roles/smartctl_exporter/README.md
@@ -1,0 +1,20 @@
+# `smartctl_exporter`
+
+Deploys the `prometheus-smartctl-exporter` Helm chart as a DaemonSet on
+bare-metal nodes to expose disk SMART metrics for Prometheus scraping.
+
+## Role variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `smartctl_exporter_helm_release_name` | `prometheus-smartctl-exporter` | Helm release name |
+| `smartctl_exporter_helm_release_namespace` | `monitoring` | Namespace to deploy into |
+| `smartctl_exporter_helm_values` | `{}` | Extra Helm values to merge |
+
+To exclude specific devices from monitoring:
+
+```yaml
+smartctl_exporter_helm_values:
+  config:
+    device_exclude: /dev/sr.*
+```

--- a/roles/smartctl_exporter/defaults/main.yml
+++ b/roles/smartctl_exporter/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+smartctl_exporter_helm_release_name: prometheus-smartctl-exporter
+smartctl_exporter_helm_chart_path: "../../charts/prometheus-smartctl-exporter/"
+smartctl_exporter_helm_chart_ref: /usr/local/src/prometheus-smartctl-exporter
+
+smartctl_exporter_helm_release_namespace: monitoring
+smartctl_exporter_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
+smartctl_exporter_helm_values: {}

--- a/roles/smartctl_exporter/meta/main.yml
+++ b/roles/smartctl_exporter/meta/main.yml
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+galaxy_info:
+  author: VEXXHOST, Inc.
+  description: Ansible role for smartctl exporter
+  license: Apache-2.0
+  min_ansible_version: 5.5.0
+  standalone: false
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+
+dependencies:
+  - role: defaults
+  - role: vexxhost.kubernetes.upload_helm_chart
+    vars:
+      upload_helm_chart_src: "{{ smartctl_exporter_helm_chart_path }}"
+      upload_helm_chart_dest: "{{ smartctl_exporter_helm_chart_ref }}"

--- a/roles/smartctl_exporter/tasks/main.yml
+++ b/roles/smartctl_exporter/tasks/main.yml
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Deploy Helm chart
+  run_once: true
+  kubernetes.core.helm:
+    name: "{{ smartctl_exporter_helm_release_name }}"
+    chart_ref: "{{ smartctl_exporter_helm_chart_ref }}"
+    release_namespace: "{{ smartctl_exporter_helm_release_namespace }}"
+    create_namespace: true
+    kubeconfig: "{{ smartctl_exporter_helm_kubeconfig }}"
+    values: "{{ _smartctl_exporter_helm_values | combine(smartctl_exporter_helm_values, recursive=True) }}"

--- a/roles/smartctl_exporter/vars/main.yml
+++ b/roles/smartctl_exporter/vars/main.yml
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+_smartctl_exporter_helm_values:
+  image:
+    repository: "{{ atmosphere_images['prometheus_smartctl_exporter'] | vexxhost.kubernetes.docker_image('name') }}"
+    tag: "{{ atmosphere_images['prometheus_smartctl_exporter'] | vexxhost.kubernetes.docker_image('tag') }}"
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: feature.node.kubernetes.io/cpu-cpuid.HYPERVISOR
+                operator: NotIn
+                values:
+                  - "true"
+  serviceMonitor:
+    enabled: true
+    extraLabels:
+      release: kube-prometheus-stack
+    interval: 60s
+    relabelings:
+      - sourceLabels:
+          - __meta_kubernetes_pod_node_name
+        targetLabel: instance
+      - action: labeldrop
+        regex: ^(container|namespace|pod|node|service)$


### PR DESCRIPTION
# Description
Backport of #3772 to `stable/2023.1`.

# Validation
- `PRE_COMMIT_HOME=/tmp/pre-commit-cache nix develop --command pre-commit run --from-ref HEAD~1 --to-ref HEAD`
- Changed-file hooks passed; ansible-lint stops on existing repo-wide `galaxy[no-changelog]` at `galaxy.yml:1`.