### PR TITLE
Update Neutron server URLs to use openstack.svc.cluster.local

### DIFF
--- a/releasenotes/notes/update-neutron-policy-02161e0eb01b7c95.yaml
+++ b/releasenotes/notes/update-neutron-policy-02161e0eb01b7c95.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    To solve this issue, the suffix openstack.svc.cluster.local gets added. This also makes the query more performant (it does not use the DNS domain search).

--- a/roles/neutron/vars/main.yml
+++ b/roles/neutron/vars/main.yml
@@ -161,9 +161,9 @@ __neutron_ovn_helm_values:
 __neutron_policy_server_helm_values:
   conf:
     policy:
-      delete_port: "((rule:admin_only) or (rule:service_api) or role:member and rule:network_owner or role:member and project_id:%(project_id)s) and http://neutron-server:9697/port-delete"
-      update_port:mac_address: "((rule:admin_only) or (rule:service_api) or role:manager and project_id:%(project_id)s) and http://neutron-server:9697/port-update"
-      update_port:fixed_ips: "((rule:admin_only) or (rule:service_api) or role:manager and project_id:%(project_id)s or role:member and rule:network_owner) and http://neutron-server:9697/port-update"
-      update_port:allowed_address_pairs: "((rule:admin_only) or (role:member and rule:network_owner) or role:manager and project_id:%(project_id)s) or (role:member and project_id:%(project_id)s and http://neutron-server:9697/address-pair )"
+      delete_port: "((rule:admin_only) or (rule:service_api) or role:member and rule:network_owner or role:member and project_id:%(project_id)s) and http://neutron-server.openstack.svc.cluster.local:9697/port-delete"
+      update_port:mac_address: "((rule:admin_only) or (rule:service_api) or role:manager and project_id:%(project_id)s) and http://neutron-server.openstack.svc.cluster.local:9697/port-update"
+      update_port:fixed_ips: "((rule:admin_only) or (rule:service_api) or role:manager and project_id:%(project_id)s or role:member and rule:network_owner) and http://neutron-server.openstack.svc.cluster.local:9697/port-update"
+      update_port:allowed_address_pairs: "((rule:admin_only) or (role:member and rule:network_owner) or role:manager and project_id:%(project_id)s) or (role:member and project_id:%(project_id)s and http://neutron-server.openstack.svc.cluster.local:9697/address-pair )"
       update_port:allowed_address_pairs:ip_address: "((rule:admin_only) or (role:member and rule:network_owner) or role:manager and project_id:%(project_id)s) or (role:member and project_id:%(project_id)s)"
       update_port:allowed_address_pairs:mac_address: "((rule:admin_only) or (role:member and rule:network_owner) or role:manager and project_id:%(project_id)s) or (role:member and project_id:%(project_id)s)"


### PR DESCRIPTION
In our current setup we use a Windows DNS as upstream DNS server. When a non-existing TLD gets asked, a ServFail returns.

To solve this issue, the suffix openstack.svc.cluster.local gets added. This also makes the query more performant (it does not use the DNS domain search).