### PR TITLE
fix(kube_prometheus_stack): reduce Ceph packet error alert noise

### DIFF
--- a/releasenotes/notes/reduce-ceph-packet-error-alert-noise-996a9d911244f31d.yaml
+++ b/releasenotes/notes/reduce-ceph-packet-error-alert-noise-996a9d911244f31d.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    The ``CephNodeNetworkPacketErrors`` alert now excludes tunnel
+    interfaces that match ``genev_sys_*`` and waits 5 minutes before
+    firing. This reduces noisy alerts on OVN hosts while the dedicated
+    ``GeneveTransmitErrors`` alert continues to cover overlay tunnel
+    devices.

--- a/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
@@ -73,7 +73,38 @@ local mixins = {
   },
   ceph: (import 'vendor/github.com/ceph/ceph/monitoring/ceph-mixin/mixin.libsonnet') + {
     prometheusAlerts+:: {
-      groups+: [
+      groups: [
+        if group.name == 'nodes' then group {
+          rules: [
+            if rule.alert == 'CephNodeNetworkPacketErrors' then rule {
+              'for': '5m',
+              expr: |||
+                (
+                  (
+                    (
+                      rate(node_network_receive_errs_total{device!="lo"}[1m]) +
+                      rate(node_network_transmit_errs_total{device!="lo"}[1m])
+                    ) / (
+                      rate(node_network_receive_packets_total{device!="lo"}[1m]) +
+                      rate(node_network_transmit_packets_total{device!="lo"}[1m])
+                    ) >= 0.0001
+                  ) or (
+                    (
+                      rate(node_network_receive_errs_total{device!="lo"}[1m]) +
+                      rate(node_network_transmit_errs_total{device!="lo"}[1m])
+                    ) >= 10
+                  )
+                ) unless on(instance, device) node_ethtool_info{driver="geneve"}
+              |||,
+              annotations+: {
+                description: 'Node {{ $labels.instance }} experiences sustained packet errors > 0.01% or > 10 packets/s on interface {{ $labels.device }}.',
+              },
+            } else rule
+            for rule in group.rules
+          ],
+        } else group
+        for group in super.groups
+      ] + [
         {
           name: 'cluster health detail',
           rules: [

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -1550,3 +1550,53 @@ tests:
               summary: "Geneve overlay: transmit failures may affect tenant traffic on a compute host"
               description: "192.0.2.10:9100 interface tenant-geneve0 has averaged 3.33 transmit errors per second over the last 5 minutes (threshold > 1.67/s, ~100/min). Normal behavior is zero sustained transmit errors on Geneve tunnel interfaces."
               runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#genevetransmiterrors"
+
+  # CephNodeNetworkPacketErrors - should wait 5m before alerting on a physical interface
+  - interval: 30s
+    input_series:
+      - series: 'node_network_receive_errs_total{job="node-exporter",instance="192.0.2.12:9100",device="eth0",cluster="mycluster"}'
+        values: '0+0x40'
+      - series: 'node_network_transmit_errs_total{job="node-exporter",instance="192.0.2.12:9100",device="eth0",cluster="mycluster"}'
+        values: '0+1x40'
+      - series: 'node_network_receive_packets_total{job="node-exporter",instance="192.0.2.12:9100",device="eth0",cluster="mycluster"}'
+        values: '0+1500x40'
+      - series: 'node_network_transmit_packets_total{job="node-exporter",instance="192.0.2.12:9100",device="eth0",cluster="mycluster"}'
+        values: '0+1500x40'
+      - series: 'node_ethtool_info{job="node-exporter",instance="192.0.2.12:9100",device="eth0",driver="mlx5_core"}'
+        values: '1x40'
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: CephNodeNetworkPacketErrors
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: CephNodeNetworkPacketErrors
+        exp_alerts:
+          - exp_labels:
+              cluster: mycluster
+              device: eth0
+              instance: 192.0.2.12:9100
+              job: node-exporter
+              oid: 1.3.6.1.4.1.50495.1.2.1.8.3
+              severity: P3
+              type: ceph_default
+            exp_annotations:
+              summary: "One or more NICs reports packet errors on cluster mycluster"
+              description: "Node 192.0.2.12:9100 experiences sustained packet errors > 0.01% or > 10 packets/s on interface eth0."
+
+  # CephNodeNetworkPacketErrors - should ignore Geneve tunnel interfaces that have a dedicated alert
+  - interval: 30s
+    input_series:
+      - series: 'node_network_receive_errs_total{job="node-exporter",instance="192.0.2.13:9100",device="genev_sys_6081",cluster="mycluster"}'
+        values: '0+0x40'
+      - series: 'node_network_transmit_errs_total{job="node-exporter",instance="192.0.2.13:9100",device="genev_sys_6081",cluster="mycluster"}'
+        values: '0+1x40'
+      - series: 'node_network_receive_packets_total{job="node-exporter",instance="192.0.2.13:9100",device="genev_sys_6081",cluster="mycluster"}'
+        values: '0+1500x40'
+      - series: 'node_network_transmit_packets_total{job="node-exporter",instance="192.0.2.13:9100",device="genev_sys_6081",cluster="mycluster"}'
+        values: '0+1500x40'
+      - series: 'node_ethtool_info{job="node-exporter",instance="192.0.2.13:9100",device="genev_sys_6081",driver="geneve"}'
+        values: '1x40'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: CephNodeNetworkPacketErrors
+        exp_alerts: []


### PR DESCRIPTION
CephNodeNetworkPacketErrors currently evaluates every non-loopback interface with no settling time. On OVN hosts that expose the kernel Geneve backing device through node-exporter, a single TX error on genev_sys_* can exceed the 0.01% ratio when the tunnel is only carrying a few dozen packets per second. That produces noisy pages even when the physical underlay is healthy.

Fix this in both rule sources by excluding interfaces reported by node_ethtool_info{driver="geneve"} and by requiring the alert to stay active for 5 minutes. This keeps the generic Ceph NIC alert focused on physical interfaces while the dedicated GeneveTransmitErrors alert continues to cover overlay tunnel devices.

Also add rule tests that verify a physical NIC waits 5 minutes before firing and that a sustained Geneve tunnel error does not trigger the Ceph alert.