### PR TITLE
feat(deploy): add role split parallelism

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -17,6 +17,7 @@ CRUSH
 CSI
 Cinder
 CoreDNS
+DAG
 DIMM
 DNS
 Dell

--- a/internal/deploy/completion.go
+++ b/internal/deploy/completion.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 VEXXHOST, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package deploy
+
+import (
+	"context"
+	"sync"
+)
+
+// completionTracker signals when named components finish deploying. Components
+// whose pre-role has an asymmetric dependency (see Component.PreRoleDependsOn)
+// use it to gate the pre-role while the main role runs eagerly.
+//
+// Signals are one-shot: MarkDone is idempotent; Wait returns immediately for
+// already-completed names.
+type completionTracker struct {
+	mu   sync.Mutex
+	done map[string]chan struct{}
+}
+
+// newCompletionTracker preallocates channels for every component name so that
+// Wait can be called before MarkDone without a race.
+func newCompletionTracker(names []string) *completionTracker {
+	m := make(map[string]chan struct{}, len(names))
+	for _, n := range names {
+		m[n] = make(chan struct{})
+	}
+	return &completionTracker{done: m}
+}
+
+// MarkDone signals that the component with the given name has finished.
+// Safe to call multiple times; only the first call closes the channel.
+func (t *completionTracker) MarkDone(name string) {
+	t.mu.Lock()
+	ch, ok := t.done[name]
+	t.mu.Unlock()
+	if !ok {
+		return
+	}
+	select {
+	case <-ch:
+	default:
+		close(ch)
+	}
+}
+
+// Wait blocks until every named component is done or the context is cancelled.
+// Unknown names are ignored so the caller does not need to pre-validate them.
+func (t *completionTracker) Wait(ctx context.Context, names []string) error {
+	for _, n := range names {
+		t.mu.Lock()
+		ch, ok := t.done[n]
+		t.mu.Unlock()
+		if !ok {
+			continue
+		}
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}

--- a/internal/deploy/completion_test.go
+++ b/internal/deploy/completion_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 VEXXHOST, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCompletionTracker_WaitBlocksUntilDone(t *testing.T) {
+	tr := newCompletionTracker([]string{"a", "b"})
+
+	var waited atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := tr.Wait(context.Background(), []string{"a"}); err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return
+		}
+		waited.Store(true)
+	}()
+
+	// Give the goroutine a chance to block on the channel.
+	time.Sleep(20 * time.Millisecond)
+	if waited.Load() {
+		t.Fatal("Wait returned before MarkDone was called")
+	}
+
+	tr.MarkDone("a")
+	<-done
+	if !waited.Load() {
+		t.Fatal("Wait did not return after MarkDone")
+	}
+}
+
+func TestCompletionTracker_MarkDoneIdempotent(t *testing.T) {
+	tr := newCompletionTracker([]string{"a"})
+	tr.MarkDone("a")
+	tr.MarkDone("a") // must not panic on double close
+	if err := tr.Wait(context.Background(), []string{"a"}); err != nil {
+		t.Fatalf("Wait on already-done name returned error: %v", err)
+	}
+}
+
+func TestCompletionTracker_UnknownNameIgnored(t *testing.T) {
+	tr := newCompletionTracker([]string{"a"})
+	if err := tr.Wait(context.Background(), []string{"unknown"}); err != nil {
+		t.Fatalf("Wait on unknown name should be a no-op, got: %v", err)
+	}
+}
+
+func TestCompletionTracker_ContextCancellation(t *testing.T) {
+	tr := newCompletionTracker([]string{"a"})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := tr.Wait(ctx, []string{"a"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+}

--- a/internal/deploy/component.go
+++ b/internal/deploy/component.go
@@ -50,6 +50,14 @@ type Component struct {
 	// OpenStack resources, downloading images) overlaps with the Helm install.
 	// Both must complete before the component is considered done.
 	PreRoleName string
+	// PreRoleDependsOn lists component Names that must complete before the
+	// pre-role may start. When empty, the pre-role starts as soon as the
+	// component's own DependsOn are satisfied (the current behaviour). When
+	// set, the main role still starts eagerly while the pre-role waits.
+	// This enables asymmetric gating — e.g. keystone's Keycloak realm
+	// creation (pre-role) waits for keycloak while the keystone Helm install
+	// (main role) runs in parallel with keycloak startup.
+	PreRoleDependsOn []string
 }
 
 // EffectiveTag returns the Ansible tag for this component.
@@ -127,6 +135,9 @@ var Components = []Component{
 		RoleName:  "ingress_nginx",
 		Hosts:     "controllers",
 		DependsOn: []string{"kubernetes"},
+		// Helm install talks to apiserver; counts toward k8s-api cap to
+		// prevent Wave 2 fan-out from overloading a single-node apiserver.
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:      "rabbitmq-cluster-operator",
@@ -134,6 +145,7 @@ var Components = []Component{
 		RoleName:  "rabbitmq_cluster_operator",
 		Hosts:     "controllers",
 		DependsOn: []string{"cert-manager"},
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:      "percona-xtradb-cluster-operator",
@@ -141,6 +153,7 @@ var Components = []Component{
 		RoleName:  "percona_xtradb_cluster_operator",
 		Hosts:     "controllers",
 		DependsOn: []string{"cert-manager"},
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:      "percona-xtradb-cluster",
@@ -148,6 +161,7 @@ var Components = []Component{
 		RoleName:  "percona_xtradb_cluster",
 		Hosts:     "controllers",
 		DependsOn: []string{"percona-xtradb-cluster-operator", "csi"},
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:      "valkey",
@@ -155,6 +169,7 @@ var Components = []Component{
 		RoleName:  "valkey",
 		Hosts:     "controllers",
 		DependsOn: []string{"kubernetes", "csi", "cluster-issuer"},
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:      "keycloak",
@@ -162,14 +177,14 @@ var Components = []Component{
 		RoleName:  "keycloak",
 		Hosts:     "controllers",
 		DependsOn: []string{"percona-xtradb-cluster", "ingress-nginx"},
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:      "keepalived",
 		Type:      RoleType,
 		RoleName:  "keepalived",
 		Hosts:     "controllers",
-		// memcached creates the openstack namespace that keepalived uses.
-		DependsOn: []string{"memcached"},
+		DependsOn: []string{"kubernetes"},
 	},
 
 	// Monitoring (RoleType, Hosts: "controllers[0]")
@@ -179,6 +194,7 @@ var Components = []Component{
 		RoleName:  "node_feature_discovery",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"kubernetes"},
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:      "kube-prometheus-stack",
@@ -186,6 +202,7 @@ var Components = []Component{
 		RoleName:  "kube_prometheus_stack",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"kubernetes", "csi", "cluster-issuer", "keycloak"},
+		Resources: []string{"k8s-api", "keycloak-admin"},
 	},
 	{
 		Name:      "loki",
@@ -193,6 +210,7 @@ var Components = []Component{
 		RoleName:  "loki",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"kubernetes", "csi"},
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:      "vector",
@@ -200,6 +218,7 @@ var Components = []Component{
 		RoleName:  "vector",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"loki"},
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:      "goldpinger",
@@ -207,6 +226,7 @@ var Components = []Component{
 		RoleName:  "goldpinger",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"kubernetes"},
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:      "ipmi-exporter",
@@ -214,6 +234,7 @@ var Components = []Component{
 		RoleName:  "ipmi_exporter",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"kube-prometheus-stack"},
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:      "prometheus-pushgateway",
@@ -221,6 +242,7 @@ var Components = []Component{
 		RoleName:  "prometheus_pushgateway",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"kube-prometheus-stack"},
+		Resources: []string{"k8s-api"},
 	},
 
 	// OS Configuration (RoleType, Hosts: "controllers:computes")
@@ -254,18 +276,34 @@ var Components = []Component{
 
 	// OpenStack (RoleType, Hosts: "controllers[0]")
 	{
+		// Pre-pull all known Atmosphere container images on every node
+		// so later component Helm installs do not stall in
+		// ImagePulling. Best-effort: failures are non-fatal because
+		// the kubelet falls back to on-demand pulls.
+		Name:        "image-warmup",
+		Type:        RoleType,
+		RoleName:    "image_warmup",
+		Hosts:       "controllers:computes",
+		DependsOn:   []string{"kubernetes"},
+		GatherFacts: boolPtr(false),
+	},
+	{
 		Name:      "memcached",
 		Type:      RoleType,
 		RoleName:  "memcached",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"kubernetes"},
+		Resources: []string{"k8s-api"},
 	},
 	{
-		Name:      "keystone",
-		Type:      RoleType,
-		RoleName:  "keystone",
-		Hosts:     "controllers[0]",
-		DependsOn: []string{"keycloak", "ingress-nginx", "rabbitmq-cluster-operator", "percona-xtradb-cluster", "memcached"},
+		Name:             "keystone",
+		Type:             RoleType,
+		RoleName:         "keystone",
+		PreRoleName:      "keystone_pre",
+		Hosts:            "controllers[0]",
+		DependsOn:        []string{"ingress-nginx", "rabbitmq-cluster-operator", "percona-xtradb-cluster", "memcached"},
+		PreRoleDependsOn: []string{"keycloak"},
+		Resources:        []string{"k8s-api", "keycloak-admin"},
 	},
 	{
 		Name:      "barbican",
@@ -273,6 +311,7 @@ var Components = []Component{
 		RoleName:  "barbican",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"keystone"},
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:        "rook-ceph",
@@ -281,14 +320,16 @@ var Components = []Component{
 		Hosts:       "controllers[0]",
 		DependsOn:   []string{"kubernetes"},
 		Environment: cephEnvironment,
+		Resources:   []string{"k8s-api"},
 	},
 	{
 		Name:        "rook-ceph-cluster",
 		Type:        RoleType,
 		RoleName:    "rook_ceph_cluster",
 		Hosts:       "controllers[0]",
-		DependsOn:   []string{"rook-ceph", "ceph", "barbican"},
+		DependsOn:   []string{"rook-ceph", "ceph", "keystone"},
 		Environment: cephEnvironment,
+		Resources:   []string{"k8s-api"},
 	},
 	{
 		Name:        "ceph-provisioners",
@@ -297,6 +338,7 @@ var Components = []Component{
 		Hosts:       "controllers[0]",
 		DependsOn:   []string{"ceph", "kubernetes"},
 		Environment: cephEnvironment,
+		Resources:   []string{"k8s-api"},
 	},
 	{
 		Name:      "glance",
@@ -304,6 +346,17 @@ var Components = []Component{
 		RoleName:  "glance",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"keystone"},
+		Resources: []string{"k8s-api"},
+	},
+	{
+		// Image uploads run as a separate component so they do not block
+		// downstream services (Nova, Magnum, etc.) which only need the
+		// Glance API to be deployed.
+		Name:      "glance-images",
+		Type:      RoleType,
+		RoleName:  "glance_images",
+		Hosts:     "controllers[0]",
+		DependsOn: []string{"glance"},
 	},
 	{
 		Name:      "staffeln",
@@ -319,6 +372,7 @@ var Components = []Component{
 		RoleName:  "cinder",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"keystone", "ceph-provisioners"},
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:      "placement",
@@ -326,6 +380,7 @@ var Components = []Component{
 		RoleName:  "placement",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"keystone"},
+		Resources: []string{"k8s-api"},
 	},
 
 	// SDN (RoleType, Hosts: "controllers:computes", GatherFacts: false)
@@ -377,13 +432,24 @@ var Components = []Component{
 		RoleName:  "nova",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"placement", "glance", "libvirt"},
+		Resources: []string{"k8s-api"},
 	},
 	{
-		Name:      "neutron",
-		Type:      RoleType,
-		RoleName:  "neutron",
-		Hosts:     "controllers[0]",
-		DependsOn: []string{"keystone", "ovn", "coredns"},
+		// The pre-role does the Helm install (heavy, ~5 min) and only
+		// requires keystone/OVN/coredns. The main role's only remaining
+		// work is the post-install "Create networks" task, which hits
+		// neutron-server's AZ check that needs Nova compute to have
+		// registered the default availability zone "nova". Splitting
+		// the role lets the install overlap with Nova while the cheap
+		// network creation continues to wait on Nova.
+		Name:             "neutron",
+		Type:             RoleType,
+		RoleName:         "neutron",
+		PreRoleName:      "neutron_pre",
+		Hosts:            "controllers[0]",
+		DependsOn:        []string{"nova"},
+		PreRoleDependsOn: []string{"keystone", "ovn", "coredns"},
+		Resources:        []string{"k8s-api"},
 	},
 	{
 		Name:      "heat",
@@ -391,30 +457,33 @@ var Components = []Component{
 		RoleName:  "heat",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"keystone"},
+		Resources: []string{"k8s-api"},
 	},
 	{
-		Name:      "octavia",
-		Type:      RoleType,
-		RoleName:  "octavia",
-		Hosts:     "controllers[0]",
-		DependsOn: []string{"keystone", "nova", "neutron"},
+		Name:        "octavia",
+		Type:        RoleType,
+		RoleName:    "octavia",
+		PreRoleName: "octavia_pre",
+		Hosts:       "controllers[0]",
+		DependsOn:   []string{"keystone", "nova", "neutron"},
+		Resources:   []string{"k8s-api"},
 	},
 	{
-		Name:      "magnum",
-		Type:      RoleType,
-		RoleName:  "magnum",
-		Hosts:     "controllers[0]",
-		DependsOn: []string{"octavia", "barbican", "heat"},
+		Name:        "magnum",
+		Type:        RoleType,
+		RoleName:    "magnum",
+		PreRoleName: "magnum_pre",
+		Hosts:       "controllers[0]",
+		DependsOn:   []string{"keystone", "glance"},
+		Resources:   []string{"k8s-api"},
 	},
 	{
 		Name:      "manila",
 		Type:      RoleType,
 		RoleName:  "manila",
 		Hosts:     "controllers[0]",
-		// The Manila role uses the combined openstack.cloud.quota module,
-		// which reads Octavia load-balancer quotas before updating compute,
-		// volume, and network limits.
-		DependsOn: []string{"keystone", "nova", "neutron", "cinder", "octavia"},
+		DependsOn: []string{"keystone", "nova", "neutron", "cinder"},
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:      "horizon",
@@ -422,6 +491,7 @@ var Components = []Component{
 		RoleName:  "horizon",
 		Hosts:     "controllers[0]",
 		DependsOn: []string{"keystone"},
+		Resources: []string{"k8s-api"},
 	},
 	{
 		Name:      "openstack-exporter",

--- a/internal/deploy/deployer.go
+++ b/internal/deploy/deployer.go
@@ -44,9 +44,13 @@ func configureSubprocess(cmd *exec.Cmd) {
 	cmd.WaitDelay = subprocessCancelGracePeriod
 }
 
-// Deployer deploys a single component.
+// Deployer deploys a single component. When preGate is non-nil, it gates the
+// pre-role: the pre-role goroutine waits for preGate to return nil (typically
+// after PreRoleDependsOn components complete) before running. The main role
+// always starts immediately. For components without a pre-role, preGate is
+// ignored.
 type Deployer interface {
-	Deploy(ctx context.Context, component Component) error
+	Deploy(ctx context.Context, component Component, preGate func(context.Context) error) error
 }
 
 // AnsibleDeployer deploys components by spawning ansible-playbook subprocesses.
@@ -57,7 +61,7 @@ type AnsibleDeployer struct {
 	Output io.Writer
 }
 
-func (a *AnsibleDeployer) Deploy(ctx context.Context, component Component) error {
+func (a *AnsibleDeployer) Deploy(ctx context.Context, component Component, preGate func(context.Context) error) error {
 	if component.PreRoleName == "" {
 		return a.runRole(ctx, component, component.RoleName)
 	}
@@ -65,6 +69,11 @@ func (a *AnsibleDeployer) Deploy(ctx context.Context, component Component) error
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
+		if preGate != nil {
+			if err := preGate(ctx); err != nil {
+				return err
+			}
+		}
 		return a.runRole(ctx, component, component.PreRoleName)
 	})
 

--- a/internal/deploy/deployer_test.go
+++ b/internal/deploy/deployer_test.go
@@ -6,6 +6,7 @@ package deploy
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -26,7 +27,7 @@ type deployEvent struct {
 	endedAt   time.Time
 }
 
-func (d *trackingDeployer) Deploy(ctx context.Context, component Component) error {
+func (d *trackingDeployer) Deploy(ctx context.Context, component Component, preGate func(context.Context) error) error {
 	// Mirror only the PreRoleName branching needed by this test helper;
 	// this doesn't exercise AnsibleDeployer internals.
 	if component.PreRoleName == "" {
@@ -40,6 +41,11 @@ func (d *trackingDeployer) Deploy(ctx context.Context, component Component) erro
 
 	go func() {
 		defer wg.Done()
+		if preGate != nil {
+			if err := preGate(ctx); err != nil {
+				return
+			}
+		}
 		d.recordRole(component.Name, component.PreRoleName)
 	}()
 
@@ -134,7 +140,7 @@ func TestDeploy_PreRoleRunsInParallel(t *testing.T) {
 		Hosts:       "controllers[0]",
 	}
 
-	deployer.Deploy(context.Background(), component)
+	deployer.Deploy(context.Background(), component, nil)
 
 	if len(deployer.events) != 2 {
 		t.Fatalf("expected 2 deploy events, got %d", len(deployer.events))
@@ -175,7 +181,7 @@ func TestDeploy_NoPreRoleRunsSingle(t *testing.T) {
 		Hosts:    "controllers[0]",
 	}
 
-	deployer.Deploy(context.Background(), component)
+	deployer.Deploy(context.Background(), component, nil)
 
 	if len(deployer.events) != 1 {
 		t.Fatalf("expected 1 deploy event, got %d", len(deployer.events))
@@ -205,4 +211,30 @@ func TestRenderPlaybook_WithEnvironmentAndPreRole(t *testing.T) {
 	if !strings.Contains(mainPlaybook, "_pre_role_active: true") {
 		t.Error("main playbook should include _pre_role_active")
 	}
+}
+
+func TestComponentRegistry_PreRoleComponents(t *testing.T) {
+preRoleComponents := []string{}
+for _, c := range Components {
+if c.PreRoleName != "" {
+preRoleComponents = append(preRoleComponents, fmt.Sprintf("%s (pre: %s)", c.Name, c.PreRoleName))
+}
+}
+
+if len(preRoleComponents) == 0 {
+t.Fatal("expected at least one component with PreRoleName")
+}
+
+// Verify known components have pre-roles
+found := map[string]bool{}
+for _, c := range Components {
+found[c.Name] = c.PreRoleName != ""
+}
+
+if !found["octavia"] {
+t.Error("octavia should have a pre-role")
+}
+if !found["magnum"] {
+t.Error("magnum should have a pre-role")
+}
 }

--- a/internal/deploy/orchestrator.go
+++ b/internal/deploy/orchestrator.go
@@ -136,7 +136,8 @@ func (o *Orchestrator) deployFullDAG(ctx context.Context, output io.Writer) erro
 		return fmt.Errorf("building dependency graph: %w", err)
 	}
 
-	rc := NewResourceCoordinator(Components)
+	rc := NewResourceCoordinator(Components, nil)
+	tracker := newCompletionTracker(allComponentNames(Components))
 
 	fmt.Fprintln(output, "==> Starting parallel deployment")
 	return g.Run(ctx, o.Concurrency, func(ctx context.Context, id string, comp Component) error {
@@ -148,9 +149,14 @@ func (o *Orchestrator) deployFullDAG(ctx context.Context, output io.Writer) erro
 		}
 		defer release()
 
-		if err := o.Deployer.Deploy(ctx, comp); err != nil {
+		preGate := buildPreGate(comp, tracker)
+		if err := o.Deployer.Deploy(ctx, comp, preGate); err != nil {
 			return fmt.Errorf("component %s failed: %w", id, err)
 		}
+		// Only mark done on success; on failure, downstream pre-roles
+		// must not be unblocked because the dependency is not actually
+		// ready. errgroup cancellation will tear them down promptly.
+		tracker.MarkDone(id)
 		fmt.Fprintf(output, "==> [%s] Deployment complete\n", id)
 		return nil
 	})
@@ -228,7 +234,14 @@ func (o *Orchestrator) deployMultipleTags(ctx context.Context, tags []string, ou
 		return fmt.Errorf("extracting subgraph: %w", err)
 	}
 
-	rc := NewResourceCoordinator(Components)
+	rc := NewResourceCoordinator(Components, nil)
+	// Only allocate tracker channels for components actually in the
+	// subgraph. Components outside the subgraph are treated as
+	// already-complete by completionTracker.Wait (it skips unknown
+	// names), matching the semantic that --tags assumes everything
+	// not selected is already deployed. Without this, a pre-role
+	// gated on an out-of-subgraph component would block forever.
+	tracker := newCompletionTracker(componentNames)
 
 	fmt.Fprintln(output, "==> Starting parallel deployment (subgraph)")
 	return subGraph.Run(ctx, o.Concurrency, func(ctx context.Context, id string, comp Component) error {
@@ -240,10 +253,35 @@ func (o *Orchestrator) deployMultipleTags(ctx context.Context, tags []string, ou
 		}
 		defer release()
 
-		if err := o.Deployer.Deploy(ctx, comp); err != nil {
+		preGate := buildPreGate(comp, tracker)
+		if err := o.Deployer.Deploy(ctx, comp, preGate); err != nil {
 			return fmt.Errorf("component %s failed: %w", id, err)
 		}
+		// Only mark done on success; see comment in deployFullGraph.
+		tracker.MarkDone(id)
 		fmt.Fprintf(output, "==> [%s] Deployment complete\n", id)
 		return nil
 	})
+}
+
+// allComponentNames extracts the Name field from each component for
+// preallocating the completion tracker.
+func allComponentNames(comps []Component) []string {
+	names := make([]string, 0, len(comps))
+	for _, c := range comps {
+		names = append(names, c.Name)
+	}
+	return names
+}
+
+// buildPreGate returns a preGate closure for the deployer, or nil when the
+// component has no asymmetric pre-role dependency.
+func buildPreGate(comp Component, tracker *completionTracker) func(context.Context) error {
+	if comp.PreRoleName == "" || len(comp.PreRoleDependsOn) == 0 {
+		return nil
+	}
+	deps := comp.PreRoleDependsOn
+	return func(ctx context.Context) error {
+		return tracker.Wait(ctx, deps)
+	}
 }

--- a/internal/deploy/orchestrator_subgraph_pregate_test.go
+++ b/internal/deploy/orchestrator_subgraph_pregate_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 VEXXHOST, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+)
+
+// gateAwareDeployer invokes preGate (mirroring AnsibleDeployer behavior),
+// unlike the simpler mocks in orchestrator_test.go that drop it. This is
+// what surfaces the multi-tag pre-role-dependency hang.
+type gateAwareDeployer struct{}
+
+func (g *gateAwareDeployer) Deploy(ctx context.Context, c Component, preGate func(context.Context) error) error {
+	if preGate != nil {
+		if err := preGate(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TestDeployMultipleTags_PreRoleDependencyOutsideSubgraph guards against the
+// regression where a selected component's PreRoleDependsOn pointed at a
+// component outside the user-selected --tags subgraph and caused the pre-role
+// goroutine to block forever. With the fix, out-of-subgraph names are
+// treated as already-complete, matching --tags semantics.
+func TestDeployMultipleTags_PreRoleDependencyOutsideSubgraph(t *testing.T) {
+	o := &Orchestrator{
+		Deployer:  &gateAwareDeployer{},
+		Inventory: "/dev/null",
+		Output:    io.Discard,
+		Preflight: func(_ context.Context, _ io.Writer) error { return nil },
+	}
+
+	// neutron has PreRoleDependsOn=[keystone, ovn, coredns]; none of
+	// these are in --tags neutron,nova. Before the fix, neutron's
+	// pre-role goroutine waited on those channels forever.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := o.Deploy(ctx, []string{"neutron", "nova"})
+	if err != nil {
+		t.Fatalf("Deploy returned error (likely a hang regression): %v", err)
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatal("context deadline exceeded - subgraph deployment hung")
+	}
+}
+
+// TestDeployMultipleTags_KeystoneSubgraph covers the keystone variant of
+// the C1 hang (PreRoleDependsOn=[keycloak]).
+//
+// The orchestrator only routes through deployMultipleTags — and therefore
+// only exercises the buggy pre-role gating path — when **two or more**
+// distinct tags are selected. A single tag falls into the Mode 2
+// pass-through path, which shells out to a real ansible-playbook and
+// ignores o.Deployer entirely, making it unusable for unit testing.
+//
+// We pair keystone with barbican (which DependsOn=[keystone]) so the
+// subgraph contains keystone+barbican but NOT keycloak, reproducing
+// the original hang condition.
+func TestDeployMultipleTags_KeystoneSubgraph(t *testing.T) {
+	o := &Orchestrator{
+		Deployer:  &gateAwareDeployer{},
+		Inventory: "/dev/null",
+		Output:    io.Discard,
+		Preflight: func(_ context.Context, _ io.Writer) error { return nil },
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := o.Deploy(ctx, []string{"keystone", "barbican"}); err != nil {
+		t.Fatalf("Deploy returned error: %v", err)
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatal("context deadline exceeded - subgraph deployment hung")
+	}
+}
+
+// failingDeployer fails for a named target, succeeds otherwise. It also
+// invokes preGate so we can observe whether MarkDone was triggered after
+// a failure (which would unblock the gated downstream pre-role).
+type failingDeployer struct {
+	failOn   string
+	preGated chan string
+}
+
+func (f *failingDeployer) Deploy(ctx context.Context, c Component, preGate func(context.Context) error) error {
+	if preGate != nil {
+		if err := preGate(ctx); err != nil {
+			return err
+		}
+		select {
+		case f.preGated <- c.Name:
+		default:
+		}
+	}
+	if c.Name == f.failOn {
+		return errors.New("synthetic failure")
+	}
+	return nil
+}
+
+// TestDeployFailure_DoesNotMarkDone confirms that a failed component does
+// not mark itself done and therefore does not unblock downstream pre-role
+// gates. The test runs the keystone -> neutron pre-role chain (well: only
+// the part observable in the in-subgraph case) and asserts that when
+// keystone fails, the run aborts with the failure rather than silently
+// proceeding.
+func TestDeployFailure_DoesNotMarkDone(t *testing.T) {
+	o := &Orchestrator{
+		Deployer: &failingDeployer{
+			failOn:   "keycloak",
+			preGated: make(chan string, 8),
+		},
+		Inventory: "/dev/null",
+		Output:    io.Discard,
+		Preflight: func(_ context.Context, _ io.Writer) error { return nil },
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := o.Deploy(ctx, []string{"keycloak", "keystone"})
+	if err == nil {
+		t.Fatal("expected failure from keycloak to propagate, got nil")
+	}
+}

--- a/internal/deploy/orchestrator_test.go
+++ b/internal/deploy/orchestrator_test.go
@@ -21,7 +21,7 @@ type mockDeployer struct {
 	deployed []string
 }
 
-func (m *mockDeployer) Deploy(_ context.Context, component Component) error {
+func (m *mockDeployer) Deploy(_ context.Context, component Component, _ func(context.Context) error) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.deployed = append(m.deployed, component.Name)
@@ -132,4 +132,60 @@ func TestOrchestrator_MultipleTags_UnknownTag(t *testing.T) {
 	if len(mock.deployed) != 0 {
 		t.Errorf("expected no deployments on error, got %d", len(mock.deployed))
 	}
+}
+
+// preGateRecorder captures whether preGate was invoked and what it returned
+// for each component deployed, allowing tests to assert pre-role gating.
+type preGateRecorder struct {
+mu      sync.Mutex
+gates   map[string]bool // component name -> gate was invoked
+gateErr map[string]error
+}
+
+func newPreGateRecorder() *preGateRecorder {
+return &preGateRecorder{
+gates:   map[string]bool{},
+gateErr: map[string]error{},
+}
+}
+
+func (p *preGateRecorder) Deploy(ctx context.Context, component Component, preGate func(context.Context) error) error {
+if preGate != nil {
+err := preGate(ctx)
+p.mu.Lock()
+p.gates[component.Name] = true
+p.gateErr[component.Name] = err
+p.mu.Unlock()
+if err != nil {
+return err
+}
+} else {
+p.mu.Lock()
+p.gates[component.Name] = false
+p.mu.Unlock()
+}
+return nil
+}
+
+func TestOrchestrator_BuildPreGate(t *testing.T) {
+tracker := newCompletionTracker([]string{"x", "y"})
+
+withPre := Component{
+Name:             "withpre",
+PreRoleName:      "withpre_pre",
+PreRoleDependsOn: []string{"x"},
+}
+if gate := buildPreGate(withPre, tracker); gate == nil {
+t.Fatal("expected non-nil gate for component with PreRoleDependsOn")
+}
+
+noPreDeps := Component{Name: "n1", PreRoleName: "n1_pre"}
+if gate := buildPreGate(noPreDeps, tracker); gate != nil {
+t.Errorf("expected nil gate when PreRoleDependsOn is empty")
+}
+
+noPreRole := Component{Name: "n2", PreRoleDependsOn: []string{"x"}}
+if gate := buildPreGate(noPreRole, tracker); gate != nil {
+t.Errorf("expected nil gate when PreRoleName is empty")
+}
 }

--- a/internal/deploy/resource.go
+++ b/internal/deploy/resource.go
@@ -9,16 +9,42 @@ import (
 )
 
 // ResourceCoordinator manages named semaphores to serialize components that
-// share a resource (e.g., "apt" for package management). Components in the
-// same DAG wave that declare the same resource run one at a time, while
-// components without shared resources remain fully parallel.
+// share a resource (e.g., "apt" for package management) or cap the parallel
+// fan-out to a shared backend (e.g., "k8s-api"). Components declaring the
+// same resource respect its concurrency cap; components without shared
+// resources remain fully parallel.
 type ResourceCoordinator struct {
 	semas map[string]chan struct{}
 }
 
+// defaultResourceConcurrency returns the default cap for a resource when the
+// caller does not override it. Historically every resource was a mutex
+// (cap=1); newer resources may be backends we merely want to rate-limit.
+var defaultResourceConcurrency = map[string]int{
+	// apt: package manager. Must be serialized per host, but we also
+	// serialize globally today since components touching apt span all hosts.
+	"apt": 1,
+	// k8s-api: the Kubernetes apiserver. Cap limits how many Helm/Kubernetes
+	// operations run concurrently across heavy OpenStack components, smoothing
+	// apiserver load during wave fan-out without serializing fully.
+	"k8s-api": 6,
+	// keycloak-admin: the Keycloak admin HTTP endpoint. The community.general
+	// keycloak_* modules rebuild auth state per call; concurrent realm/client
+	// creates race and fail. Serialize globally (cap=1).
+	"keycloak-admin": 1,
+	// containerd: the vexxhost.containers.containerd role calls
+	// systemctl daemon-reload + enable on containerd.service. Two
+	// concurrent enable calls race on dbus and intermittently fail
+	// with "Message recipient disconnected from message bus without
+	// replying". Serialize globally (cap=1) so any pair of
+	// components touching the role can't collide on systemd.
+	"containerd": 1,
+}
+
 // NewResourceCoordinator builds semaphores for every resource declared across
-// the given components. Each resource defaults to a concurrency of 1 (mutex).
-func NewResourceCoordinator(components []Component) *ResourceCoordinator {
+// the given components. Each resource's capacity is looked up in overrides,
+// falling back to defaultResourceConcurrency, and finally to 1 (mutex).
+func NewResourceCoordinator(components []Component, overrides map[string]int) *ResourceCoordinator {
 	resources := make(map[string]bool)
 	for _, c := range components {
 		for _, r := range c.Resources {
@@ -28,10 +54,21 @@ func NewResourceCoordinator(components []Component) *ResourceCoordinator {
 
 	semas := make(map[string]chan struct{}, len(resources))
 	for r := range resources {
-		semas[r] = make(chan struct{}, 1)
+		cap := resourceCapacity(r, overrides)
+		semas[r] = make(chan struct{}, cap)
 	}
 
 	return &ResourceCoordinator{semas: semas}
+}
+
+func resourceCapacity(name string, overrides map[string]int) int {
+	if v, ok := overrides[name]; ok && v > 0 {
+		return v
+	}
+	if v, ok := defaultResourceConcurrency[name]; ok && v > 0 {
+		return v
+	}
+	return 1
 }
 
 // Acquire blocks until all resources required by the component are available

--- a/internal/deploy/resource_concurrency_test.go
+++ b/internal/deploy/resource_concurrency_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 VEXXHOST, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package deploy
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestResourceCoordinator_CustomConcurrency(t *testing.T) {
+	components := []Component{
+		{Name: "a", Resources: []string{"k8s-api"}},
+		{Name: "b", Resources: []string{"k8s-api"}},
+		{Name: "c", Resources: []string{"k8s-api"}},
+		{Name: "d", Resources: []string{"k8s-api"}},
+	}
+
+	rc := NewResourceCoordinator(components, map[string]int{"k8s-api": 2})
+	ctx := context.Background()
+
+	var concurrent int64
+	var maxConcurrent int64
+	var wg sync.WaitGroup
+
+	for _, comp := range components {
+		wg.Add(1)
+		go func(c Component) {
+			defer wg.Done()
+			release, err := rc.Acquire(ctx, c)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			defer release()
+
+			cur := atomic.AddInt64(&concurrent, 1)
+			for {
+				old := atomic.LoadInt64(&maxConcurrent)
+				if cur <= old || atomic.CompareAndSwapInt64(&maxConcurrent, old, cur) {
+					break
+				}
+			}
+			time.Sleep(20 * time.Millisecond)
+			atomic.AddInt64(&concurrent, -1)
+		}(comp)
+	}
+
+	wg.Wait()
+
+	if maxConcurrent != 2 {
+		t.Errorf("expected max concurrency of 2 for k8s-api override, got %d", maxConcurrent)
+	}
+}
+
+func TestResourceCoordinator_DefaultK8sApiCap(t *testing.T) {
+	// Without an override, k8s-api should use defaultResourceConcurrency (6).
+	// Verify the semaphore's buffered capacity matches.
+	components := []Component{{Name: "a", Resources: []string{"k8s-api"}}}
+	rc := NewResourceCoordinator(components, nil)
+
+	if got := cap(rc.semas["k8s-api"]); got != 6 {
+		t.Errorf("expected default k8s-api cap of 6, got %d", got)
+	}
+}

--- a/internal/deploy/resource_test.go
+++ b/internal/deploy/resource_test.go
@@ -18,7 +18,7 @@ func TestResourceCoordinator_Serializes(t *testing.T) {
 		{Name: "c"},
 	}
 
-	rc := NewResourceCoordinator(components)
+	rc := NewResourceCoordinator(components, nil)
 	ctx := context.Background()
 
 	var concurrent int64
@@ -62,7 +62,7 @@ func TestResourceCoordinator_NoResource(t *testing.T) {
 		{Name: "b"},
 	}
 
-	rc := NewResourceCoordinator(components)
+	rc := NewResourceCoordinator(components, nil)
 	ctx := context.Background()
 
 	release, err := rc.Acquire(ctx, components[0])
@@ -83,7 +83,7 @@ func TestResourceCoordinator_DifferentResources(t *testing.T) {
 		{Name: "b", Resources: []string{"helm"}},
 	}
 
-	rc := NewResourceCoordinator(components)
+	rc := NewResourceCoordinator(components, nil)
 	ctx := context.Background()
 
 	var concurrent int64
@@ -127,7 +127,7 @@ func TestResourceCoordinator_ContextCancellation(t *testing.T) {
 		{Name: "b", Resources: []string{"apt"}},
 	}
 
-	rc := NewResourceCoordinator(components)
+	rc := NewResourceCoordinator(components, nil)
 	ctx := context.Background()
 
 	// Acquire the resource with component a

--- a/playbooks/image_warmup.yml
+++ b/playbooks/image_warmup.yml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- hosts: "{{ target | default('controllers:computes') }}"
+  become: true
+  gather_facts: false
+  tags:
+    - image-warmup
+  roles:
+    - role: vexxhost.atmosphere.image_warmup

--- a/playbooks/openstack.yml
+++ b/playbooks/openstack.yml
@@ -53,6 +53,10 @@
       tags:
         - glance
 
+    - role: glance_images
+      tags:
+        - glance-images
+
     - role: staffeln
       when: atmosphere_staffeln_enabled | default(true)
       tags:
@@ -137,11 +141,23 @@
       tags:
         - heat
 
-    - role: octavia
+    - role: octavia_pre
       tags:
         - octavia
 
+    - role: octavia
+      vars:
+        _pre_role_active: true
+      tags:
+        - octavia
+
+    - role: magnum_pre
+      tags:
+        - magnum
+
     - role: magnum
+      vars:
+        _pre_role_active: true
       tags:
         - magnum
 

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -18,6 +18,9 @@
 - name: Install Kubernetes
   import_playbook: vexxhost.atmosphere.kubernetes
 
+- name: Pre-pull container images
+  ansible.builtin.import_playbook: vexxhost.atmosphere.image_warmup
+
 - name: Install CSI
   import_playbook: vexxhost.atmosphere.csi
 

--- a/releasenotes/notes/dag-edge-removal-phase1-439694be3dac4d84.yaml
+++ b/releasenotes/notes/dag-edge-removal-phase1-439694be3dac4d84.yaml
@@ -1,0 +1,17 @@
+---
+features:
+  - |
+    The parallel deployment orchestrator now runs Magnum in parallel with
+    Barbican and Heat instead of after them. An audit showed that these
+    dependencies were configuration-only references and don't require the
+    dependent service to run at install time. Magnum retains install-time
+    dependencies on Keystone and Glance because it creates identity
+    resources and uploads cluster images during deployment.
+  - |
+    The Rook Ceph cluster role now depends on Keystone directly rather than
+    on Barbican. The previous Barbican dependency was mis-declared: the
+    role only creates an identity user and catalog service in Keystone. A
+    new readiness check on the ``keystone-api`` Deployment runs before the
+    OpenStack API calls, and the role now creates both the ``service``
+    domain and the ``service`` project itself so it no longer relies on
+    another chart's ks-user job to create them first.

--- a/releasenotes/notes/deploy-perf-tier1-d8f993d67122d060.yaml
+++ b/releasenotes/notes/deploy-perf-tier1-d8f993d67122d060.yaml
@@ -1,0 +1,32 @@
+---
+features:
+  - |
+    Added ``PreRoleDependsOn`` to the parallel deploy orchestrator so a
+    component's pre-role can wait for different dependencies than the main
+    role. This lets the Keycloak realm setup gate the pre-role while
+    the Keystone Helm install runs in parallel with Keycloak startup.
+  - |
+    Split Keystone's Keycloak realm and OpenID configuration into a new
+    ``keystone_pre`` role. Under the parallel orchestrator this runs
+    concurrently with the Keystone Helm install.
+  - |
+    Extended the ``ResourceCoordinator`` in the parallel deploy
+    orchestrator with per-resource concurrency caps. A new ``k8s-api``
+    resource (default cap ``6``) smooths the load on the Kubernetes API
+    server during wave fan-out without serializing OpenStack components.
+  - |
+    Added a dedicated semaphore (cap ``1``) for the Keycloak admin HTTP
+    endpoint. The orchestrator now serializes ``keystone`` and
+    ``kube-prometheus-stack`` whenever they create realms or clients, so
+    concurrent admin calls on the same Keycloak no longer race and fail.
+  - |
+    Moved Neutron's Helm install into a separate pre-role under the
+    parallel orchestrator. The install now overlaps with Nova; only the
+    post-install network creation, which hits an availability zone
+    check on the Neutron API, still waits on Nova.
+  - |
+    Split Glance image uploads into a separate component. Downstream
+    services that depend on Glance (Nova, Magnum, and others) now
+    wait only for the Glance API; image downloads continue in
+    parallel off the critical path.
+upgrade: []

--- a/releasenotes/notes/deploy-perf-tier2-613c7bac4183c8bd.yaml
+++ b/releasenotes/notes/deploy-perf-tier2-613c7bac4183c8bd.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Added the ``image_warmup`` role and component, which pre-pulls every
+    image listed in ``_atmosphere_images`` on every Kubernetes node once
+    the cluster reports READY. Subsequent component Helm installs
+    schedule pods that find their images already cached, eliminating
+    most ``ImagePulling`` waits from the critical path. Failures are
+    non-fatal: the ``kubelet`` falls back to on-demand pulls.
+upgrade: []

--- a/roles/cluster_issuer/handlers/main.yml
+++ b/roles/cluster_issuer/handlers/main.yml
@@ -17,6 +17,10 @@
   ansible.builtin.package:
     name: openssl-perl
     state: present
+  register: _install_openssl_perl
+  retries: 5
+  delay: 10
+  until: _install_openssl_perl is not failed
   listen: Update CA certificates on host
 
 - name: Update CA certificates

--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -35,19 +35,3 @@
     openstack_helm_ingress_service_port: 9292
     openstack_helm_ingress_annotations: "{{ _glance_ingress_annotations | combine(glance_ingress_annotations) }}"
     openstack_helm_ingress_class_name: "{{ glance_ingress_class_name }}"
-
-- name: Create images
-  ansible.builtin.include_role:
-    name: atmosphere.common.glance_image
-  loop: "{{ glance_images }}"
-  vars:
-    glance_image_name: "{{ item.name }}"
-    glance_image_url: "{{ item.url }}"
-    glance_image_min_disk: "{{ item.min_disk | default(omit) }}"
-    glance_image_min_ram: "{{ item.min_ram | default(omit) }}"
-    glance_image_container_format: "{{ item.container_format | default(omit) }}"
-    glance_image_disk_format: "{{ item.disk_format | default(omit) }}"
-    glance_image_properties: "{{ item.properties | default({}) }}"
-    glance_image_kernel: "{{ item.kernel | default(omit) }}"
-    glance_image_ramdisk: "{{ item.ramdisk | default(omit) }}"
-    glance_image_is_public: "{{ item.is_public | default(omit) }}"

--- a/roles/glance_images/README.md
+++ b/roles/glance_images/README.md
@@ -1,0 +1,6 @@
+# `glance_images` role
+
+Uploads Glance images defined in `glance_images` (see `glance` role
+defaults). Split out from the main `glance` role so that downstream
+services (Nova, Magnum, etc.) only wait for the Glance API to be
+deployed and not for image downloads to finish.

--- a/roles/glance_images/defaults/main.yml
+++ b/roles/glance_images/defaults/main.yml
@@ -1,0 +1,1 @@
+../../glance/defaults/main.yml

--- a/roles/glance_images/meta/main.yml
+++ b/roles/glance_images/meta/main.yml
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+galaxy_info:
+  author: VEXXHOST, Inc.
+  description: >-
+    Uploads Glance images. Runs as a separate component so that downstream
+    services (Nova, Magnum, etc.) only have to wait for the Glance API to
+    be installed (the `glance` component) and not for image downloads to
+    finish.
+  license: Apache-2.0
+  min_ansible_version: 5.5.0
+  standalone: false
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+
+dependencies:
+  - role: defaults
+  - role: openstack_helm_endpoints
+    vars:
+      openstack_helm_endpoints_chart: glance
+      openstack_helm_endpoints_skip_cluster_creation: true
+  - role: openstacksdk

--- a/roles/glance_images/tasks/main.yml
+++ b/roles/glance_images/tasks/main.yml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Create images
+  ansible.builtin.include_role:
+    name: glance_image
+  loop: "{{ glance_images }}"
+  vars:
+    glance_image_name: "{{ item.name }}"
+    glance_image_url: "{{ item.url }}"
+    glance_image_min_disk: "{{ item.min_disk | default(omit) }}"
+    glance_image_min_ram: "{{ item.min_ram | default(omit) }}"
+    glance_image_container_format: "{{ item.container_format | default(omit) }}"
+    glance_image_disk_format: "{{ item.disk_format | default(omit) }}"
+    glance_image_properties: "{{ item.properties | default(omit) }}"
+    glance_image_kernel: "{{ item.kernel | default(omit) }}"
+    glance_image_ramdisk: "{{ item.ramdisk | default(omit) }}"
+    glance_image_is_public: "{{ item.is_public | default(omit) }}"

--- a/roles/image_warmup/README.md
+++ b/roles/image_warmup/README.md
@@ -1,0 +1,11 @@
+# `image_warmup`
+
+This role pre-pulls every container image listed in `_atmosphere_images`
+on every Kubernetes node using `crictl`. Running it once the cluster is
+ready ensures that subsequent component Helm installs schedule pods
+whose images are already cached, removing most `ImagePulling` waits
+from the deploy critical path.
+
+Pulls run with bounded concurrency and any failure is logged but
+non-fatal so that on-demand pulls can still satisfy missing images
+later.

--- a/roles/image_warmup/defaults/main.yml
+++ b/roles/image_warmup/defaults/main.yml
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Path to the containerd CRI socket used for `crictl pull`.
+#
+# image_warmup_containerd_socket: unix:///run/containerd/containerd.sock
+image_warmup_containerd_socket: unix:///run/containerd/containerd.sock
+
+# Per-image pull timeout in seconds for `crictl pull`. The kubelet will pull
+# on demand if warmup is slower, so this is purely a guard against runaway
+# stuck pulls.
+#
+# image_warmup_pull_timeout: 600
+image_warmup_pull_timeout: 600
+
+# Maximum number of parallel pulls per host. Containerd handles its own
+# layer-level deduplication, but capping concurrency avoids saturating the
+# image registry from every node at once.
+#
+# image_warmup_concurrency: 4
+image_warmup_concurrency: 4
+
+# Optional explicit list of image references to pre-pull. When empty
+# (default), the role pulls every value from `_atmosphere_images`.
+#
+# image_warmup_images:
+#   - quay.io/ceph/ceph:v18.2.7
+image_warmup_images: []

--- a/roles/image_warmup/meta/main.yml
+++ b/roles/image_warmup/meta/main.yml
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+galaxy_info:
+  author: VEXXHOST, Inc.
+  description: >-
+    Pre-pulls all known Atmosphere container images on every node so that
+    later component Helm installs do not stall in ImagePulling. Best-effort:
+    failures are non-fatal because the kubelet will pull on demand if the
+    warmup did not complete in time.
+  license: Apache-2.0
+  min_ansible_version: 5.5.0
+
+dependencies:
+  - role: defaults

--- a/roles/image_warmup/tasks/main.yml
+++ b/roles/image_warmup/tasks/main.yml
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Resolve image list
+  ansible.builtin.set_fact:
+    _image_warmup_targets: >-
+      {{
+        (image_warmup_images
+         if (image_warmup_images | length) > 0
+         else (_atmosphere_images | dict2items | map(attribute='value') | list))
+        | unique
+      }}
+
+- name: Check for crictl
+  ansible.builtin.command:
+    cmd: which crictl
+  register: _image_warmup_crictl
+  changed_when: false
+  failed_when: false
+
+- name: Pre-pull container images
+  when: _image_warmup_crictl.rc == 0
+  ansible.builtin.command:
+    cmd: >-
+      crictl --runtime-endpoint {{ image_warmup_containerd_socket }}
+      --timeout {{ image_warmup_pull_timeout }}s
+      pull {{ item }}
+  loop: "{{ _image_warmup_targets }}"
+  loop_control:
+    label: "{{ item }}"
+  register: _image_warmup_pull
+  changed_when: false
+  failed_when: false
+  throttle: "{{ image_warmup_concurrency }}"
+
+- name: Report unreachable images
+  when:
+    - _image_warmup_crictl.rc == 0
+    - _image_warmup_pull.results is defined
+    - item.rc != 0
+  ansible.builtin.debug:
+    msg: >-
+      Warmup pull failed for {{ item.item }} (rc={{ item.rc }}); kubelet
+      will pull on demand.
+  loop: "{{ _image_warmup_pull.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item | default('') }}"

--- a/roles/iscsi/tasks/main.yml
+++ b/roles/iscsi/tasks/main.yml
@@ -4,6 +4,10 @@
   ansible.builtin.package:
     name: "{{ 'iscsi-initiator-utils' if ansible_os_family == 'RedHat' else 'open-iscsi' }}"
     state: present
+  register: _install_iscsi
+  retries: 5
+  delay: 10
+  until: _install_iscsi is not failed
 
 - name: Ensure iscsid is started
   ansible.builtin.service:

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -19,6 +19,11 @@
     state: present
     definition:
       - apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: openstack
+
+      - apiVersion: v1
         kind: Secret
         metadata:
           name: keepalived-etc

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -16,6 +16,7 @@
   no_log: true
   run_once: true
   changed_when: false
+  when: not (_pre_role_active | default(false))
   community.general.keycloak_realm:
     # Keycloak settings
     auth_keycloak_url: "{{ item.keycloak_server_url }}"
@@ -42,6 +43,7 @@
     label: "{{ item.name }}"
 
 - name: Setup Keycloak Authentication Required Actions (MFA)
+  when: not (_pre_role_active | default(false))
   community.general.keycloak_authentication_required_actions:
     # Keycloak settings
     auth_keycloak_url: "{{ item.keycloak_server_url }}"
@@ -65,12 +67,14 @@
 
 - name: Create ConfigMap with all OpenID connect configurations
   run_once: true
+  when: not (_pre_role_active | default(false))
   kubernetes.core.k8s:
     template: configmap-openid-metadata.yml.j2
 
 - name: Create Keycloak clients
   no_log: true
   run_once: true
+  when: not (_pre_role_active | default(false))
   community.general.keycloak_client:
     # Keycloak settings
     auth_keycloak_url: "{{ item.keycloak_server_url }}"
@@ -97,6 +101,7 @@
 - name: Assign realm-management roles to service account
   no_log: true
   run_once: true
+  when: not (_pre_role_active | default(false))
   community.general.keycloak_user_rolemapping:
     # Keycloak settings
     auth_keycloak_url: "{{ item.keycloak_server_url }}"
@@ -114,6 +119,18 @@
   loop: "{{ keystone_domains }}"
   loop_control:
     label: "{{ item.name }}"
+
+- name: Wait for OpenID metadata ConfigMap
+  run_once: true
+  when: _pre_role_active | default(false)
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: keystone-openid-metadata
+    namespace: "{{ keystone_helm_release_namespace }}"
+    wait: true
+    wait_sleep: 2
+    wait_timeout: 600
 
 - name: Deploy Helm chart
   run_once: true

--- a/roles/keystone_pre/README.md
+++ b/roles/keystone_pre/README.md
@@ -1,0 +1,7 @@
+# `keystone_pre`
+
+This role performs the Keycloak-side setup required by Keystone — realm
+creation, MFA configuration, OpenID Connect client registration, and the
+OpenID metadata ConfigMap. It runs in parallel with the main `keystone`
+role so the Keystone Helm install does not have to wait for Keycloak to
+finish starting up.

--- a/roles/keystone_pre/defaults/main.yml
+++ b/roles/keystone_pre/defaults/main.yml
@@ -1,0 +1,1 @@
+../../keystone/defaults/main.yml

--- a/roles/keystone_pre/meta/main.yml
+++ b/roles/keystone_pre/meta/main.yml
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+galaxy_info:
+  author: VEXXHOST, Inc.
+  description: >-
+    Pre-tasks for Keystone that configure Keycloak realms, MFA, OIDC
+    clients, and the OpenID metadata ConfigMap. Runs in parallel with the
+    main `keystone` role under the parallel deploy orchestrator.
+  license: Apache-2.0
+  min_ansible_version: 5.5.0
+  standalone: false
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+
+dependencies:
+  - role: defaults
+  - role: openstack_helm_endpoints
+    vars:
+      openstack_helm_endpoints_chart: keystone
+      openstack_helm_endpoints_skip_cluster_creation: true

--- a/roles/keystone_pre/tasks/main.yml
+++ b/roles/keystone_pre/tasks/main.yml
@@ -1,0 +1,105 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Create Keycloak realms
+  no_log: true
+  run_once: true
+  changed_when: false
+  community.general.keycloak_realm:
+    # Keycloak settings
+    auth_keycloak_url: "{{ item.keycloak_server_url }}"
+    auth_realm: "{{ item.keycloak_user_realm_name }}"
+    auth_client_id: "{{ item.keycloak_admin_client_id }}"
+    auth_username: "{{ item.keycloak_admin_user }}"
+    auth_password: "{{ item.keycloak_admin_password }}"
+    validate_certs: "{{ cluster_issuer_type != 'self-signed' }}"
+    # Realm settings
+    id: "{{ item.keycloak_realm }}"
+    realm: "{{ item.keycloak_realm }}"
+    display_name: "{{ item.label }}"
+    enabled: true
+    password_policy: "{{ item.keycloak_password_policy | default(keystone_keycloak_realm_default_password_policy | default(omit)) }}"
+    brute_force_protected: "{{ item.keycloak_brute_force_protected | default(keystone_keycloak_realm_default_brute_force_protected | default(omit)) }}"
+    failure_factor: "{{ item.keycloak_brute_force_failure_factor | default(keystone_keycloak_realm_default_brute_force_failure_factor | default(omit)) }}"
+    wait_increment_seconds: "{{ item.keycloak_brute_force_wait_increment_seconds | default(keystone_keycloak_realm_default_brute_force_wait_increment_seconds | default(omit)) }}"
+    max_failure_wait_seconds: "{{ item.keycloak_brute_force_max_failure_wait_seconds | default(keystone_keycloak_realm_default_brute_force_max_failure_wait_seconds | default(omit)) }}"
+    max_delta_time_seconds: "{{ item.keycloak_brute_force_max_delta_time_seconds | default(keystone_keycloak_realm_default_brute_force_max_delta_time_seconds | default(omit)) }}"
+    minimum_quick_login_wait_seconds: "{{ item.keycloak_minimum_quick_login_wait_seconds | default(keystone_keycloak_realm_default_minimum_quick_login_wait_seconds | default(omit)) }}"
+    quick_login_check_milli_seconds: "{{ item.keycloak_quick_login_check_milli_seconds | default(keystone_keycloak_realm_default_quick_login_check_milli_seconds | default(omit)) }}"
+  loop: "{{ keystone_domains }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Setup Keycloak Authentication Required Actions (MFA)
+  community.general.keycloak_authentication_required_actions:
+    # Keycloak settings
+    auth_keycloak_url: "{{ item.keycloak_server_url }}"
+    auth_realm: "{{ item.keycloak_user_realm_name }}"
+    auth_client_id: "{{ item.keycloak_admin_client_id }}"
+    auth_username: "{{ item.keycloak_admin_user }}"
+    auth_password: "{{ item.keycloak_admin_password }}"
+    validate_certs: "{{ cluster_issuer_type != 'self-signed' }}"
+    # Realm settings
+    realm: "{{ item.name }}"
+    required_actions:
+      - alias: "CONFIGURE_TOTP"
+        name: "Configure OTP"
+        providerId: "CONFIGURE_TOTP"
+        defaultAction: "{{ item.keycloak_totp_default_action | default(keystone_keycloak_realm_default_totp_default_action | default(omit)) }}"
+        enabled: true
+    state: present
+  loop: "{{ keystone_domains }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Create ConfigMap with all OpenID connect configurations
+  run_once: true
+  kubernetes.core.k8s:
+    template: configmap-openid-metadata.yml.j2
+
+- name: Create Keycloak clients
+  no_log: true
+  run_once: true
+  community.general.keycloak_client:
+    # Keycloak settings
+    auth_keycloak_url: "{{ item.keycloak_server_url }}"
+    auth_realm: "{{ item.keycloak_user_realm_name }}"
+    auth_client_id: "{{ item.keycloak_admin_client_id }}"
+    auth_username: "{{ item.keycloak_admin_user }}"
+    auth_password: "{{ item.keycloak_admin_password }}"
+    validate_certs: "{{ cluster_issuer_type != 'self-signed' }}"
+    # Realm settings
+    realm: "{{ item.keycloak_realm }}"
+    client_id: "{{ item.keycloak_client_id }}"
+    secret: "{{ item.keycloak_client_secret }}"
+    client_authenticator_type: client-secret
+    public_client: false
+    service_accounts_enabled: true
+    direct_access_grants_enabled: false
+    redirect_uris:
+      - "{{ keystone_oidc_redirect_uri }}"
+      - "https://{{ openstack_helm_endpoints_horizon_api_host }}/auth/logout/"
+  loop: "{{ keystone_domains }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Assign realm-management roles to service account
+  no_log: true
+  run_once: true
+  community.general.keycloak_user_rolemapping:
+    # Keycloak settings
+    auth_keycloak_url: "{{ item.keycloak_server_url }}"
+    auth_realm: "{{ item.keycloak_user_realm_name }}"
+    auth_client_id: "{{ item.keycloak_admin_client_id }}"
+    auth_username: "{{ item.keycloak_admin_user }}"
+    auth_password: "{{ item.keycloak_admin_password }}"
+    validate_certs: "{{ cluster_issuer_type != 'self-signed' }}"
+    # Role mapping settings
+    realm: "{{ item.keycloak_realm }}"
+    service_account_user_client_id: "{{ item.keycloak_client_id }}"
+    client_id: realm-management
+    roles:
+      - name: view-users
+  loop: "{{ keystone_domains }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/roles/keystone_pre/templates/configmap-openid-metadata.yml.j2
+++ b/roles/keystone_pre/templates/configmap-openid-metadata.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: v1
+metadata:
+  name: keystone-openid-metadata
+  namespace: "{{ keystone_helm_release_namespace }}"
+  labels:
+    application: keystone
+kind: ConfigMap
+data:
+{% for domain in keystone_domains %}
+  {{ domain.name }}-oidc-client: '{"client_id":"{{ domain.keycloak_client_id }}","client_secret":"{{ domain.keycloak_client_secret }}","response_type":"id_token"}'
+  {{ domain.name }}-oidc-conf: '{"scope":"{{ domain.keycloak_scopes }}"}'
+  {{ domain.name }}-oidc-provider: '{{ lookup('url', domain.keycloak_server_url ~ "/realms/" ~ domain.keycloak_realm ~ "/.well-known/openid-configuration", validate_certs=keystone_oidc_ssl_validate_server) }}'
+{% endfor %}

--- a/roles/magnum/tasks/main.yml
+++ b/roles/magnum/tasks/main.yml
@@ -218,3 +218,4 @@
     glance_image_disk_format: "{{ magnum_image_disk_format }}"
     glance_image_properties:
       os_distro: "{{ item.distro }}"
+  when: not (_pre_role_active | default(false))

--- a/roles/magnum_pre/README.md
+++ b/roles/magnum_pre/README.md
@@ -1,0 +1,5 @@
+# `magnum_pre`
+
+This role uploads Glance images for Magnum. It runs in parallel with the
+main `magnum` role during deployment to overlap image downloads with the
+Helm install.

--- a/roles/magnum_pre/defaults/main.yml
+++ b/roles/magnum_pre/defaults/main.yml
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Container format for Magnum images.
+#
+# magnum_image_container_format: bare
+magnum_image_container_format: bare
+
+# Disk format for Magnum images.
+#
+# magnum_image_disk_format: raw
+magnum_image_disk_format: raw
+
+# List of images to upload for Magnum.
+#
+# magnum_images: "{{ _magnum_images }}"
+magnum_images: "{{ _magnum_images }}"

--- a/roles/magnum_pre/meta/main.yml
+++ b/roles/magnum_pre/meta/main.yml
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+galaxy_info:
+  author: VEXXHOST, Inc.
+  description: >-
+    Pre-tasks for Magnum that run in parallel with the main Helm deploy.
+    Handles Glance image uploads which are independent of the Magnum service.
+  license: Apache-2.0
+  min_ansible_version: 5.5.0
+
+dependencies:
+  - role: defaults
+  - role: openstack_helm_endpoints
+    vars:
+      openstack_helm_endpoints_chart: magnum
+      openstack_helm_endpoints_skip_cluster_creation: true
+  - role: openstacksdk

--- a/roles/magnum_pre/tasks/main.yml
+++ b/roles/magnum_pre/tasks/main.yml
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Upload images
+  ansible.builtin.include_role:
+    name: glance_image
+  loop: "{{ magnum_images }}"
+  vars:
+    glance_image_name: "{{ item.name }}"
+    glance_image_url: "{{ item.url }}"
+    glance_image_container_format: "{{ magnum_image_container_format }}"
+    glance_image_disk_format: "{{ magnum_image_disk_format }}"
+    glance_image_properties:
+      os_distro: "{{ item.distro }}"

--- a/roles/magnum_pre/vars/main.yml
+++ b/roles/magnum_pre/vars/main.yml
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+_magnum_images:
+  - name: ubuntu-2204-kube-v1.32.10
+    url: https://github.com/vexxhost/capo-image-elements/releases/download/2025.12-3/ubuntu-22.04-v1.32.10.qcow2
+    distro: ubuntu
+  - name: ubuntu-2204-kube-v1.33.7
+    url: https://github.com/vexxhost/capo-image-elements/releases/download/2025.12-3/ubuntu-22.04-v1.33.7.qcow2
+    distro: ubuntu
+  - name: ubuntu-2204-kube-v1.34.3
+    url: https://github.com/vexxhost/capo-image-elements/releases/download/2025.12-3/ubuntu-22.04-v1.34.3.qcow2
+    distro: ubuntu

--- a/roles/manila/tasks/main.yml
+++ b/roles/manila/tasks/main.yml
@@ -40,15 +40,39 @@
     openstack_helm_ingress_annotations: "{{ manila_ingress_annotations }}"
     openstack_helm_ingress_class_name: "{{ manila_ingress_class_name }}"
 
-- name: Update service tenant quotas
-  openstack.cloud.quota:
-    cloud: atmosphere
-    # NOTE(okozachenko): It uses project name instead of id.
-    name: service
-    instances: -1
-    cores: -1
-    ram: -1
-    volumes: -1
-    gigabytes: -1
-    security_group: -1
-    security_group_rule: -1
+- name: Update service tenant compute quotas
+  ansible.builtin.command:
+    cmd: >-
+      openstack quota set
+      --instances -1
+      --cores -1
+      --ram -1
+      service
+  environment:
+    OS_CLOUD: atmosphere
+  register: _manila_compute_quota_set
+  changed_when: _manila_compute_quota_set.rc == 0
+
+- name: Update service tenant volume quotas
+  ansible.builtin.command:
+    cmd: >-
+      openstack quota set
+      --volumes -1
+      --gigabytes -1
+      service
+  environment:
+    OS_CLOUD: atmosphere
+  register: _manila_volume_quota_set
+  changed_when: _manila_volume_quota_set.rc == 0
+
+- name: Update service tenant network quotas
+  ansible.builtin.command:
+    cmd: >-
+      openstack quota set
+      --secgroups -1
+      --secgroup-rules -1
+      service
+  environment:
+    OS_CLOUD: atmosphere
+  register: _manila_network_quota_set
+  changed_when: _manila_network_quota_set.rc == 0

--- a/roles/multipathd/tasks/main.yml
+++ b/roles/multipathd/tasks/main.yml
@@ -25,6 +25,10 @@
   ansible.builtin.package:
     name: "{{ 'multipath-tools' if ansible_os_family == 'Debian' else 'device-mapper-multipath' }}"
     state: latest # noqa: package-latest
+  register: _install_multipathd
+  retries: 5
+  delay: 10
+  until: _install_multipathd is not failed
   notify:
     - Restart "multipathd"
 

--- a/roles/neutron/meta/main.yml
+++ b/roles/neutron/meta/main.yml
@@ -32,9 +32,11 @@ dependencies:
   - role: defaults
   - role: openstacksdk
   - role: openstack_helm_endpoints
+    when: not (_pre_role_active | default(false))
     vars:
       openstack_helm_endpoints_chart: neutron
   - role: vexxhost.kubernetes.upload_helm_chart
+    when: not (_pre_role_active | default(false))
     vars:
       upload_helm_chart_src: "{{ neutron_helm_chart_path }}"
       upload_helm_chart_dest: "{{ neutron_helm_chart_ref }}"

--- a/roles/neutron/tasks/main.yml
+++ b/roles/neutron/tasks/main.yml
@@ -32,49 +32,52 @@
           )
         }}
 
-- name: Set external_dns_driver
-  ansible.builtin.set_fact:
-    _neutron_external_dns_driver: "designate"
-  when: neutron_designate_integration_enabled | bool
+- name: Deploy Neutron chart
+  when: not (_pre_role_active | default(false))
+  block:
+    - name: Set external_dns_driver
+      ansible.builtin.set_fact:
+        _neutron_external_dns_driver: "designate"
+      when: neutron_designate_integration_enabled | bool
 
-- name: Generate Helm values
-  ansible.builtin.set_fact:
-    _neutron_helm_values: "{{ __neutron_helm_values }}"
+    - name: Generate Helm values
+      ansible.builtin.set_fact:
+        _neutron_helm_values: "{{ __neutron_helm_values }}"
 
-- name: Append Helm values
-  when: atmosphere_network_backend == 'ovn'
-  ansible.builtin.set_fact:
-    _neutron_helm_values: "{{ _neutron_helm_values | combine(__neutron_ovn_helm_values, recursive=True) }}"
+    - name: Append Helm values
+      when: atmosphere_network_backend == 'ovn'
+      ansible.builtin.set_fact:
+        _neutron_helm_values: "{{ _neutron_helm_values | combine(__neutron_ovn_helm_values, recursive=True) }}"
 
-- name: Append Helm values (neutron_policy_server)
-  when: neutron_policy_server_integration_enabled | bool
-  ansible.builtin.set_fact:
-    _neutron_helm_values: "{{ _neutron_helm_values | combine(__neutron_policy_server_helm_values, recursive=True) }}"
+    - name: Append Helm values (neutron_policy_server)
+      when: neutron_policy_server_integration_enabled | bool
+      ansible.builtin.set_fact:
+        _neutron_helm_values: "{{ _neutron_helm_values | combine(__neutron_policy_server_helm_values, recursive=True) }}"
 
-- name: Append Helm values (mount neutron genericswitch keys)
-  when: neutron_genericswitch_keys | length > 0
-  ansible.builtin.set_fact:
-    _neutron_helm_values: "{{ _neutron_helm_values | combine(__neutron_generic_switch_keys_helm_values, recursive=True) }}"
+    - name: Append Helm values (mount neutron genericswitch keys)
+      when: neutron_genericswitch_keys | length > 0
+      ansible.builtin.set_fact:
+        _neutron_helm_values: "{{ _neutron_helm_values | combine(__neutron_generic_switch_keys_helm_values, recursive=True) }}"
 
-- name: Deploy Helm chart
-  run_once: true
-  kubernetes.core.helm:
-    name: "{{ neutron_helm_release_name }}"
-    chart_ref: "{{ neutron_helm_chart_ref }}"
-    release_namespace: "{{ neutron_helm_release_namespace }}"
-    create_namespace: true
-    kubeconfig: "{{ neutron_helm_kubeconfig }}"
-    values: "{{ _neutron_helm_values | combine(neutron_helm_values, recursive=True) }}"
+    - name: Deploy Helm chart
+      run_once: true
+      kubernetes.core.helm:
+        name: "{{ neutron_helm_release_name }}"
+        chart_ref: "{{ neutron_helm_chart_ref }}"
+        release_namespace: "{{ neutron_helm_release_namespace }}"
+        create_namespace: true
+        kubeconfig: "{{ neutron_helm_kubeconfig }}"
+        values: "{{ _neutron_helm_values | combine(neutron_helm_values, recursive=True) }}"
 
-- name: Create Ingress
-  ansible.builtin.include_role:
-    name: openstack_helm_ingress
-  vars:
-    openstack_helm_ingress_endpoint: network
-    openstack_helm_ingress_service_name: neutron-server
-    openstack_helm_ingress_service_port: 9696
-    openstack_helm_ingress_annotations: "{{ neutron_ingress_annotations }}"
-    openstack_helm_ingress_class_name: "{{ neutron_ingress_class_name }}"
+    - name: Create Ingress
+      ansible.builtin.include_role:
+        name: openstack_helm_ingress
+      vars:
+        openstack_helm_ingress_endpoint: network
+        openstack_helm_ingress_service_name: neutron-server
+        openstack_helm_ingress_service_port: 9696
+        openstack_helm_ingress_annotations: "{{ neutron_ingress_annotations }}"
+        openstack_helm_ingress_class_name: "{{ neutron_ingress_class_name }}"
 
 - name: Create networks
   when: neutron_networks | length > 0
@@ -107,7 +110,7 @@
       loop: "{{ neutron_networks }}"
       # NOTE(mnaser): This often fails since the SSL certificates are not
       #               ready yet. We need to wait for them to be ready.
-      retries: 60
+      retries: 120
       delay: 5
       register: _result
       until: _result is not failed
@@ -134,7 +137,7 @@
         - subnets
       # NOTE(mnaser): This often fails since the SSL certificates are not
       #               ready yet. We need to wait for them to be ready.
-      retries: 60
+      retries: 120
       delay: 5
       register: _result
       until: _result is not failed

--- a/roles/neutron_pre/README.md
+++ b/roles/neutron_pre/README.md
@@ -1,0 +1,8 @@
+# `neutron_pre`
+
+This role installs the Neutron Helm chart and creates the network
+ingress. Under the parallel deploy orchestrator it runs in parallel with
+the main `neutron` role so the heavy Helm install does not block on
+Nova. Only the post-install "Create networks" task (which hits the
+neutron-server AZ check that requires the `nova` availability zone)
+remains gated on Nova in the main `neutron` role.

--- a/roles/neutron_pre/defaults/main.yml
+++ b/roles/neutron_pre/defaults/main.yml
@@ -1,0 +1,1 @@
+../../neutron/defaults/main.yml

--- a/roles/neutron_pre/meta/main.yml
+++ b/roles/neutron_pre/meta/main.yml
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+galaxy_info:
+  author: VEXXHOST, Inc.
+  description: >-
+    Pre-tasks for Neutron that install the Helm chart and create the
+    network ingress. Runs in parallel with the main `neutron` role under
+    the parallel deploy orchestrator so that the heavy Helm install does
+    not have to wait for Nova to come up; only the post-install network
+    creation (which hits the AZ check) waits on Nova.
+  license: Apache-2.0
+  min_ansible_version: 5.5.0
+  standalone: false
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+
+dependencies:
+  - role: defaults
+  - role: openstack_helm_endpoints
+    vars:
+      openstack_helm_endpoints_chart: neutron
+      openstack_helm_endpoints_skip_cluster_creation: true
+  - role: vexxhost.kubernetes.upload_helm_chart
+    vars:
+      upload_helm_chart_src: "{{ neutron_helm_chart_path }}"
+      upload_helm_chart_dest: "{{ neutron_helm_chart_ref }}"

--- a/roles/neutron_pre/tasks/main.yml
+++ b/roles/neutron_pre/tasks/main.yml
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Configure OpenStack-Helm endpoints
+  ansible.builtin.include_role:
+    name: openstack_helm_endpoints
+  vars:
+    openstack_helm_endpoints_chart: neutron
+
+- name: Set external_dns_driver
+  ansible.builtin.set_fact:
+    _neutron_external_dns_driver: "designate"
+  when: neutron_designate_integration_enabled | bool
+
+- name: Generate Helm values
+  ansible.builtin.set_fact:
+    _neutron_helm_values: "{{ __neutron_helm_values }}"
+
+- name: Append Helm values
+  when: atmosphere_network_backend == 'ovn'
+  ansible.builtin.set_fact:
+    _neutron_helm_values: "{{ _neutron_helm_values | combine(__neutron_ovn_helm_values, recursive=True) }}"
+
+- name: Append Helm values (neutron_policy_server)
+  when: neutron_policy_server_integration_enabled | bool
+  ansible.builtin.set_fact:
+    _neutron_helm_values: "{{ _neutron_helm_values | combine(__neutron_policy_server_helm_values, recursive=True) }}"
+
+- name: Deploy Helm chart
+  run_once: true
+  kubernetes.core.helm:
+    name: "{{ neutron_helm_release_name }}"
+    chart_ref: "{{ neutron_helm_chart_ref }}"
+    release_namespace: "{{ neutron_helm_release_namespace }}"
+    create_namespace: true
+    kubeconfig: "{{ neutron_helm_kubeconfig }}"
+    values: "{{ _neutron_helm_values | combine(neutron_helm_values, recursive=True) }}"
+
+- name: Create Ingress
+  ansible.builtin.include_role:
+    name: openstack_helm_ingress
+  vars:
+    openstack_helm_ingress_endpoint: network
+    openstack_helm_ingress_service_name: neutron-server
+    openstack_helm_ingress_service_port: 9696
+    openstack_helm_ingress_annotations: "{{ neutron_ingress_annotations }}"
+    openstack_helm_ingress_class_name: "{{ neutron_ingress_class_name }}"

--- a/roles/neutron_pre/vars/main.yml
+++ b/roles/neutron_pre/vars/main.yml
@@ -1,0 +1,1 @@
+../../neutron/vars/main.yml

--- a/roles/octavia/tasks/main.yml
+++ b/roles/octavia/tasks/main.yml
@@ -17,6 +17,7 @@
     file: generate_resources.yml
 
 - name: Create CAs & Issuers
+  when: not (_pre_role_active | default(false))
   kubernetes.core.k8s:
     state: present
     definition:
@@ -56,6 +57,7 @@
     - octavia-server
 
 - name: Create certificate for Octavia clients
+  when: not (_pre_role_active | default(false))
   kubernetes.core.k8s:
     state: present
     definition:
@@ -84,6 +86,7 @@
       size: {{ octavia_tls_client_private_key_size }}
 
 - name: Create admin compute quotaset
+  when: not (_pre_role_active | default(false))
   openstack.cloud.quota:
     cloud: atmosphere
     # NOTE(okozachenko): It uses project name instead of id.
@@ -95,6 +98,26 @@
     gigabytes: -1
     security_group: -1
     security_group_rule: -1
+
+- name: Wait for Octavia client certificate secret
+  # The Certificate resources above are issued asynchronously by cert-manager.
+  # When the pre-role runs in parallel with the main role, the Helm install
+  # below mounts these secrets and will stall pods in ContainerCreating if
+  # they are not present yet. Wait explicitly so the deploy is deterministic
+  # in both sequential and parallel modes.
+  run_once: true
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ item }}"
+    namespace: "{{ octavia_helm_release_namespace }}"
+    wait: true
+    wait_sleep: 2
+    wait_timeout: 600
+  loop:
+    - octavia-client-certs
+    - octavia-server-ca
+    - octavia-client-ca
 
 - name: Deploy Helm chart
   run_once: true

--- a/roles/octavia_pre/README.md
+++ b/roles/octavia_pre/README.md
@@ -1,0 +1,5 @@
+# `octavia_pre`
+
+This role creates cert-manager CAs, certificates, and admin quotas for
+Octavia. It runs in parallel with the main `octavia` role during
+deployment.

--- a/roles/octavia_pre/defaults/main.yml
+++ b/roles/octavia_pre/defaults/main.yml
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Common name for the Octavia server TLS certificate.
+#
+# octavia_tls_server_common_name: octavia-server
+octavia_tls_server_common_name: octavia-server
+
+# Private key algorithm for the Octavia server TLS certificate.
+#
+# octavia_tls_server_private_key_algorithm: ECDSA
+octavia_tls_server_private_key_algorithm: ECDSA
+
+# Private key size for the Octavia server TLS certificate.
+#
+# octavia_tls_server_private_key_size: 256
+octavia_tls_server_private_key_size: 256
+
+# Common name for the Octavia client TLS certificate.
+#
+# octavia_tls_client_common_name: octavia-client
+octavia_tls_client_common_name: octavia-client
+
+# Private key algorithm for the Octavia client TLS certificate.
+#
+# octavia_tls_client_private_key_algorithm: ECDSA
+octavia_tls_client_private_key_algorithm: ECDSA
+
+# Private key size for the Octavia client TLS certificate.
+#
+# octavia_tls_client_private_key_size: 256
+octavia_tls_client_private_key_size: 256

--- a/roles/octavia_pre/meta/main.yml
+++ b/roles/octavia_pre/meta/main.yml
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+galaxy_info:
+  author: VEXXHOST, Inc.
+  description: >-
+    Pre-tasks for Octavia that run in parallel with the main role.
+    Handles cert-manager CAs, certificates, and admin quotas.
+  license: Apache-2.0
+  min_ansible_version: 5.5.0
+
+dependencies:
+  - role: defaults
+  - role: openstack_helm_endpoints
+    vars:
+      openstack_helm_endpoints_chart: octavia
+      openstack_helm_endpoints_skip_cluster_creation: true
+  - role: openstacksdk
+  - role: openstack_cli

--- a/roles/octavia_pre/tasks/main.yml
+++ b/roles/octavia_pre/tasks/main.yml
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Create CAs & Issuers
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      - apiVersion: cert-manager.io/v1
+        kind: Certificate
+        metadata:
+          name: "{{ item }}-ca"
+          namespace: openstack
+        spec:
+          isCA: true
+          commonName: "{{ octavia_tls_server_common_name if item == 'octavia-server' else octavia_tls_client_common_name }}"
+          secretName: "{{ item }}-ca"
+          duration: 87600h0m0s
+          renewBefore: 720h0m0s
+          privateKey: "{{ private_key | from_yaml }}"
+          issuerRef:
+            name: self-signed
+            kind: ClusterIssuer
+            group: cert-manager.io
+
+      - apiVersion: cert-manager.io/v1
+        kind: Issuer
+        metadata:
+          name: "{{ item }}"
+          namespace: openstack
+        spec:
+          ca:
+            secretName: "{{ item }}-ca"
+  vars:
+    # NOTE(mnaser): Unfortunately, Ansible renders all variables as strings so
+    #               we do this workaround to make sure the size is an integer.
+    private_key: |
+      algorithm: "{{ octavia_tls_server_private_key_algorithm if item == 'octavia-server' else octavia_tls_client_private_key_algorithm }}"
+      size: {{ octavia_tls_server_private_key_size if item == 'octavia-server' else octavia_tls_client_private_key_size }}
+  loop:
+    - octavia-client
+    - octavia-server
+
+- name: Create certificate for Octavia clients
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: cert-manager.io/v1
+      kind: Certificate
+      metadata:
+        name: octavia-client-certs
+        namespace: openstack
+      spec:
+        commonName: "{{ octavia_tls_client_common_name }}"
+        secretName: octavia-client-certs
+        additionalOutputFormats:
+          - type: CombinedPEM
+        duration: 87600h0m0s
+        renewBefore: 720h0m0s
+        privateKey: "{{ private_key | from_yaml }}"
+        issuerRef:
+          name: octavia-client
+          kind: Issuer
+          group: cert-manager.io
+  vars:
+    # NOTE(mnaser): Unfortunately, Ansible renders all variables as strings so
+    #               we do this workaround to make sure the size is an integer.
+    private_key: |
+      algorithm: "{{ octavia_tls_client_private_key_algorithm }}"
+      size: {{ octavia_tls_client_private_key_size }}
+
+- name: Create admin compute quotaset
+  openstack.cloud.quota:
+    cloud: atmosphere
+    # NOTE(okozachenko): It uses project name instead of id.
+    name: admin
+    instances: -1
+    cores: -1
+    ram: -1
+    volumes: -1
+    gigabytes: -1
+    security_group: -1
+    security_group_rule: -1

--- a/roles/openstack_cli/tasks/main.yml
+++ b/roles/openstack_cli/tasks/main.yml
@@ -16,12 +16,20 @@
   ansible.builtin.package:
     name: "{{ openstack_cli_packages }}"
     state: absent
+  register: _uninstall_osc
+  retries: 5
+  delay: 10
+  until: _uninstall_osc is not failed
   when: ansible_facts['os_family'] in ['Debian']
 
 - name: Uninstall Ubuntu Cloud Archive keyring
   ansible.builtin.apt:
     name: ubuntu-cloud-keyring
     state: absent
+  register: _uninstall_uca_keyring
+  retries: 5
+  delay: 10
+  until: _uninstall_uca_keyring is not failed
   when: ansible_facts['os_family'] in ['Debian']
 
 - name: Remove Ubuntu Cloud Archive repository
@@ -29,6 +37,10 @@
     filename: ubuntu-cloud-archive
     repo: "{{ openstack_cli_cloud_archive_repo }}"
     state: absent
+  register: _remove_uca_repo
+  retries: 5
+  delay: 10
+  until: _remove_uca_repo is not failed
   when: ansible_facts['os_family'] in ['Debian']
 
 - name: Generate OpenStack-Helm endpoints

--- a/roles/openstack_helm_endpoints/tasks/main.yml
+++ b/roles/openstack_helm_endpoints/tasks/main.yml
@@ -19,70 +19,78 @@
   when:
     - openstack_helm_endpoints_chart is defined
 
-# NOTE(mnaser): Since we manage one-RabbitMQ per service, we create the RabbitMQ
-#               cluster here and then append the necessary values to be used
-#               inside the `oslo_messaging` section.
-- name: Configure "oslo.messaging"
-  when:
-    - '"oslo_messaging" in openstack_helm_endpoints_list'
+# NOTE: When invoked from a pre-role that only needs this role's defaults
+#       loaded (for example, so openstacksdk can render clouds.yaml), skip
+#       everything that touches Kubernetes resources or depends on them.
+#       This avoids racing with the main role on RabbitmqCluster/DB secret
+#       creation when pre-roles run in parallel with their main role.
+- name: Configure endpoints and operator-managed resources
+  when: not (openstack_helm_endpoints_skip_cluster_creation | default(false))
   block:
-    - name: Create RabbitMQ cluster
-      ansible.builtin.include_role:
-        name: rabbitmq
-      vars:
-        rabbitmq_cluster_name: "{{ openstack_helm_endpoints_chart }}"
-        rabbitmq_spec: "{{ lookup('vars', openstack_helm_endpoints_chart ~ '_rabbitmq_spec', default={}) }}"
+    # NOTE(mnaser): Since we manage one-RabbitMQ per service, we create the RabbitMQ
+    #               cluster here and then append the necessary values to be used
+    #               inside the `oslo_messaging` section.
+    - name: Configure "oslo.messaging"
+      when:
+        - '"oslo_messaging" in openstack_helm_endpoints_list'
+      block:
+        - name: Create RabbitMQ cluster
+          ansible.builtin.include_role:
+            name: rabbitmq
+          vars:
+            rabbitmq_cluster_name: "{{ openstack_helm_endpoints_chart }}"
+            rabbitmq_spec: "{{ lookup('vars', openstack_helm_endpoints_chart ~ '_rabbitmq_spec', default={}) }}"
 
-    - name: Grab RabbitMQ cluster secret
-      kubernetes.core.k8s_info:
-        api_version: v1
-        kind: Secret
-        name: "rabbitmq-{{ openstack_helm_endpoints_chart }}-default-user"
-        namespace: openstack
-      register: _openstack_helm_endpoints_rabbitmq_cluster_secret
+        - name: Grab RabbitMQ cluster secret
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Secret
+            name: "rabbitmq-{{ openstack_helm_endpoints_chart }}-default-user"
+            namespace: openstack
+          register: _openstack_helm_endpoints_rabbitmq_cluster_secret
 
-    - name: Cache fact with RabbitMQ cluster credentials
+        - name: Cache fact with RabbitMQ cluster credentials
+          ansible.builtin.set_fact:
+            _openstack_helm_endpoints_rabbitmq_cluster_username: |-
+              {{ _openstack_helm_endpoints_rabbitmq_cluster_secret.resources[0]['data']['username'] | b64decode }}
+            _openstack_helm_endpoints_rabbitmq_cluster_password: |-
+              {{ _openstack_helm_endpoints_rabbitmq_cluster_secret.resources[0]['data']['password'] | b64decode }}
+
+    # NOTE(mnaser): Since we deploy the database using the operator and we let it
+    #               generate the root password, we look it up if the fact has not
+    #               been cached from a previous run.
+    - name: Configure "oslo.db"
+      when:
+        - '"oslo_db" in openstack_helm_endpoints_list'
+        - openstack_helm_endpoints_mariadb_admin_password is not defined
+      block:
+        - name: Grab Percona XtraDB cluster secret
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Secret
+            name: percona-xtradb
+            namespace: openstack
+          register: _openstack_helm_endpoints_oslo_db_secret
+
+        - name: Cache fact with Percona XtraDB password
+          ansible.builtin.set_fact:
+            openstack_helm_endpoints_mariadb_admin_password: "{{ _openstack_helm_endpoints_oslo_db_secret.resources[0]['data']['root'] | b64decode }}"
+
+    - name: Reset value for OpenStack_Helm endpoints
       ansible.builtin.set_fact:
-        _openstack_helm_endpoints_rabbitmq_cluster_username: |-
-          {{ _openstack_helm_endpoints_rabbitmq_cluster_secret.resources[0]['data']['username'] | b64decode }}
-        _openstack_helm_endpoints_rabbitmq_cluster_password: |-
-          {{ _openstack_helm_endpoints_rabbitmq_cluster_secret.resources[0]['data']['password'] | b64decode }}
+        openstack_helm_endpoints: "{{ openstack_helm_endpoints_config }}"
 
-# NOTE(mnaser): Since we deploy the database using the operator and we let it
-#               generate the root password, we look it up if the fact has not
-#               been cached from a previous run.
-- name: Configure "oslo.db"
-  when:
-    - '"oslo_db" in openstack_helm_endpoints_list'
-    - openstack_helm_endpoints_mariadb_admin_password is not defined
-  block:
-    - name: Grab Percona XtraDB cluster secret
-      kubernetes.core.k8s_info:
-        api_version: v1
-        kind: Secret
-        name: percona-xtradb
-        namespace: openstack
-      register: _openstack_helm_endpoints_oslo_db_secret
-
-    - name: Cache fact with Percona XtraDB password
+    - name: Generate OpenStack-Helm endpoints
       ansible.builtin.set_fact:
-        openstack_helm_endpoints_mariadb_admin_password: "{{ _openstack_helm_endpoints_oslo_db_secret.resources[0]['data']['root'] | b64decode }}"
+        openstack_helm_endpoints: |
+          {{ openstack_helm_endpoints | combine(lookup('vars', '_openstack_helm_endpoints_' + service), recursive=True) }}
+      loop: "{{ openstack_helm_endpoints_list }}"
+      loop_control:
+        loop_var: service
 
-- name: Reset value for OpenStack_Helm endpoints
-  ansible.builtin.set_fact:
-    openstack_helm_endpoints: "{{ openstack_helm_endpoints_config }}"
-
-- name: Generate OpenStack-Helm endpoints
-  ansible.builtin.set_fact:
-    openstack_helm_endpoints: |
-      {{ openstack_helm_endpoints | combine(lookup('vars', '_openstack_helm_endpoints_' + service), recursive=True) }}
-  loop: "{{ openstack_helm_endpoints_list }}"
-  loop_control:
-    loop_var: service
-
-# NOTE(mnaser): Since we use `openstack_helm_endpoints_list` to ensure that we
-#               have a common entry for endpoints and stay DRY, we need to
-#               reset the fact so it works for follow-up requests.
-- name: Clean-up facts
-  ansible.builtin.set_fact:
-    openstack_helm_endpoints_list:
+    # NOTE(mnaser): Since we use `openstack_helm_endpoints_list` to ensure that we
+    #               have a common entry for endpoints and stay DRY, we need to
+    #               reset the fact so it works for follow-up requests.
+    - name: Clean-up facts
+      ansible.builtin.set_fact:
+        openstack_helm_endpoints_list:

--- a/roles/reboot/tasks/main.yml
+++ b/roles/reboot/tasks/main.yml
@@ -15,6 +15,10 @@
 - name: Install package for "community.general.pids"
   ansible.builtin.package:
     name: python3-psutil
+  register: _install_psutil
+  retries: 5
+  delay: 10
+  until: _install_psutil is not failed
 
 # NOTE(mnaser): These are all processes that we do not currently have a way to
 #               safely evacuate *yet*.  We should remove these as we add ways

--- a/roles/rook_ceph_cluster/tasks/main.yml
+++ b/roles/rook_ceph_cluster/tasks/main.yml
@@ -108,12 +108,56 @@
     kubeconfig: "{{ rook_ceph_cluster_helm_kubeconfig }}"
     values: "{{ _rook_ceph_cluster_helm_values | combine(rook_ceph_cluster_helm_values, recursive=True) }}"
 
+# When the parallel orchestrator schedules rook-ceph-cluster shortly after
+# keystone's Helm release is reported complete, the keystone-api pods can
+# still be completing their rolling update. Wait explicitly so the
+# subsequent openstack.cloud.* calls do not race keystone readiness.
+- name: Wait for keystone API to be Available
+  run_once: true
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: keystone-api
+    namespace: openstack
+    wait: true
+    wait_sleep: 5
+    wait_timeout: 600
+    wait_condition:
+      type: Available
+      status: "True"
+
+# The "service" domain is normally created on-demand by the first
+# openstack-helm service chart's ks-user job.  When rook-ceph-cluster
+# runs in parallel with those charts, the domain might not yet exist,
+# so create it idempotently here.
+- name: Ensure "service" domain exists
+  run_once: true
+  openstack.cloud.identity_domain:
+    cloud: atmosphere
+    name: service
+    description: Service Domain
+  register: _rook_ceph_cluster_service_domain
+  until: _rook_ceph_cluster_service_domain is not failed
+  retries: 60
+  delay: 5
+
 - name: Create OpenStack user
   openstack.cloud.identity_user:
     cloud: atmosphere
     name: "{{ openstack_helm_endpoints.identity.auth.rgw.username }}"
     password: "{{ openstack_helm_endpoints.identity.auth.rgw.password }}"
     domain: service
+
+# The "service" project in the "service" domain is likewise created by
+# the first openstack-helm ks-user job.  Create it here so rook-ceph-cluster
+# doesn't depend on another chart having run first.
+- name: Ensure "service" project exists
+  run_once: true
+  openstack.cloud.project:
+    cloud: atmosphere
+    name: service
+    domain: service
+    description: Service Project
 
 # NOTE(mnaser): https://storyboard.openstack.org/#!/story/2010579
 - name: Grant access to "service" project


### PR DESCRIPTION
## Summary
- Move role-facing parallel deployment changes out of PR #3818 into this stacked PR.
- Add pre-role splits for Keystone, Neutron, Magnum, and Octavia, plus Glance image upload and image warmup components.
- Keep related resource caps, role fixes, and pre-role gating tests together with the role split work.

## Tests
- `go test ./internal/deploy ./pkg/dag`
- `git diff --check origin/main..work/pr3818-core-split`
- `git diff --check work/pr3818-core-split..feat/parallel-deploy-role-splits`
