### PR TITLE
fix(loki): preserve default alert rules with custom files

### DIFF
--- a/releasenotes/notes/loki-custom-alert-rule-files-cfb0961dab14ea5d.yaml
+++ b/releasenotes/notes/loki-custom-alert-rule-files-cfb0961dab14ea5d.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Atmosphere now keeps the default Loki alert rules when operators add
+    custom files through ``loki_alert_rule_files``. Give each custom ruleset
+    its own unique filename. Set each file value to a string that contains
+    the YAML rules. Reusing an existing filename replaces that file instead
+    of merging it.

--- a/roles/loki/defaults/main.yml
+++ b/roles/loki/defaults/main.yml
@@ -19,3 +19,4 @@ loki_helm_chart_ref: /usr/local/src/loki
 loki_helm_release_namespace: monitoring
 loki_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
 loki_helm_values: {}
+loki_alert_rule_files: {}

--- a/roles/loki/tasks/main.yml
+++ b/roles/loki/tasks/main.yml
@@ -12,6 +12,28 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Generate Loki alert rule files
+  ansible.builtin.set_fact:
+    _loki_alert_rule_files: "{{ _loki_default_alert_rule_files | combine(loki_alert_rule_files, recursive=True) }}"
+
+- name: Ensure Loki namespace exists
+  run_once: true
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ loki_helm_kubeconfig }}"
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ loki_helm_release_namespace }}"
+
+- name: Create Loki alert rules ConfigMap
+  run_once: true
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ loki_helm_kubeconfig }}"
+    definition: "{{ _loki_alert_rules_configmap | combine({'data': _loki_alert_rule_files}, recursive=True) }}"
+
 - name: Deploy Helm chart
   run_once: true
   kubernetes.core.helm:

--- a/roles/loki/vars/main.yml
+++ b/roles/loki/vars/main.yml
@@ -95,21 +95,26 @@ _loki_helm_values:
       openstack-control-plane: enabled
   lokiCanary:
     enabled: false
-  extraObjects:
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: loki-alerting-rules
-        labels:
-          loki_rule: "atmosphere"
-      data:
-        loki-alerting-rules.yaml: |-
-          groups:
-            - name: additional-loki-rules
-              rules:
-                - alert: NovaCellNotResponding
-                  expr: 'count_over_time({pod_label_component="compute"} |= "not responding and hence is being omitted from the results" [1m]) > 0'
-                  labels:
-                    severity: critical
-                  annotations:
-                    summary: Nova Cell is not responding. It can cause port deletion in CAPI.
+
+_loki_alert_rules_configmap:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: loki-alerting-rules
+    namespace: "{{ loki_helm_release_namespace }}"
+    annotations:
+      helm.sh/resource-policy: keep
+    labels:
+      loki_rule: "atmosphere"
+
+_loki_default_alert_rule_files:
+  loki-alerting-rules.yaml: |-
+    groups:
+      - name: additional-loki-rules
+        rules:
+          - alert: NovaCellNotResponding
+            expr: 'count_over_time({pod_label_component="compute"} |= "not responding and hence is being omitted from the results" [1m]) > 0'
+            labels:
+              severity: critical
+            annotations:
+              summary: Nova Cell is not responding. It can cause port deletion in CAPI.

--- a/roles/loki/vars_test.go
+++ b/roles/loki/vars_test.go
@@ -1,0 +1,65 @@
+package loki
+
+import (
+	_ "embed"
+	"os"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	//go:embed vars/main.yml
+	varsFile []byte
+	vars     Vars
+)
+
+type Vars struct {
+	AlertRulesConfigMap   map[string]any    `yaml:"_loki_alert_rules_configmap"`
+	DefaultAlertRuleFiles map[string]string `yaml:"_loki_default_alert_rule_files"`
+}
+
+func TestMain(m *testing.M) {
+	t := &testing.T{}
+	err := yaml.UnmarshalWithOptions(varsFile, &vars)
+	require.NoError(t, err)
+
+	code := m.Run()
+	os.Exit(code)
+}
+
+func TestDefaultAlertRuleFiles(t *testing.T) {
+	defaultRules, ok := vars.DefaultAlertRuleFiles["loki-alerting-rules.yaml"]
+	require.True(t, ok)
+	assert.Contains(t, defaultRules, "NovaCellNotResponding")
+}
+
+func TestAlertRulesConfigMapKeepAnnotation(t *testing.T) {
+	metadata, ok := vars.AlertRulesConfigMap["metadata"].(map[string]any)
+	require.True(t, ok)
+
+	annotations, ok := metadata["annotations"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "keep", annotations["helm.sh/resource-policy"])
+}
+
+func TestCustomAlertRuleFilesMerge(t *testing.T) {
+	customRuleFiles := map[string]string{
+		"julian-rules.yaml": "groups:\n  - name: julian-rules\n",
+	}
+
+	mergedRuleFiles := make(map[string]string, len(vars.DefaultAlertRuleFiles)+len(customRuleFiles))
+	for name, contents := range vars.DefaultAlertRuleFiles {
+		mergedRuleFiles[name] = contents
+	}
+	for name, contents := range customRuleFiles {
+		mergedRuleFiles[name] = contents
+	}
+
+	assert.Contains(t, mergedRuleFiles, "loki-alerting-rules.yaml")
+	assert.Contains(t, mergedRuleFiles, "julian-rules.yaml")
+	assert.Contains(t, mergedRuleFiles["loki-alerting-rules.yaml"], "NovaCellNotResponding")
+	assert.Contains(t, mergedRuleFiles["julian-rules.yaml"], "julian-rules")
+}


### PR DESCRIPTION
## Summary
- preserve the default Loki alert rules when custom rule files are provided
- add `loki_alert_rule_files` as the supported way to append extra Loki rule files
- add a Loki role test and a release note for the new rule file behavior

## Testing
- `go test ./roles/loki -count=1`