### PR TITLE
feat(monitoring): run ceph exporter as daemonset

### DIFF
--- a/releasenotes/notes/ceph-exporter-monitoring-fallback-cc10d38474f13f08.yaml
+++ b/releasenotes/notes/ceph-exporter-monitoring-fallback-cc10d38474f13f08.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Added optional Prometheus scrape configuration for ``ceph-exporter``
+    targets in the kube-prometheus-stack role. The existing Ceph mgr
+    ServiceMonitor remains enabled by default so deployments can continue to
+    rely on mgr perf-counter collection while operators roll out the exporter.
+    Operators can enable the exporter scrape by populating
+    ``kube_prometheus_stack_ceph_exporter_http_sd_configs``.

--- a/releasenotes/notes/ceph-exporter-monitoring-fallback-cc10d38474f13f08.yaml
+++ b/releasenotes/notes/ceph-exporter-monitoring-fallback-cc10d38474f13f08.yaml
@@ -1,9 +1,11 @@
 ---
 features:
   - |
-    Added optional Prometheus scrape configuration for ``ceph-exporter``
-    targets in the kube-prometheus-stack role. The existing Ceph mgr
-    ServiceMonitor remains enabled by default so deployments can continue to
-    rely on mgr perf-counter collection while operators roll out the exporter.
-    Operators can enable the exporter scrape by populating
-    ``kube_prometheus_stack_ceph_exporter_http_sd_configs``.
+    Added a Kubernetes-native ``ceph-exporter`` DaemonSet in the
+    ``kube_prometheus_stack`` role. The exporter runs in the monitoring
+    namespace on nodes labeled ``ceph=enabled`` and is scraped through a
+    ServiceMonitor.
+
+    The existing Ceph mgr ServiceMonitor remains enabled so deployments can
+    continue to rely on mgr perf-counter collection while the exporter path is
+    being rolled out.

--- a/roles/kube_prometheus_stack/defaults/main.yml
+++ b/roles/kube_prometheus_stack/defaults/main.yml
@@ -30,7 +30,6 @@ kube_prometheus_stack_ceph_exporter_node_selector:
 kube_prometheus_stack_ceph_exporter_config_host_path: /etc/ceph
 kube_prometheus_stack_ceph_exporter_socket_host_path: "{{ '/var/run/ceph/' + ceph_fsid if ceph_fsid is defined else '/var/run/ceph' }}"
 kube_prometheus_stack_ceph_exporter_client_name: client.admin
-kube_prometheus_stack_ceph_exporter_port: 9926
 kube_prometheus_stack_ceph_exporter_scrape_interval: 15s
 kube_prometheus_stack_ceph_exporter_scrape_timeout: 10s
 kube_prometheus_stack_ceph_exporter_prio_limit: 5

--- a/roles/kube_prometheus_stack/defaults/main.yml
+++ b/roles/kube_prometheus_stack/defaults/main.yml
@@ -22,14 +22,26 @@ kube_prometheus_stack_helm_values: {}
 
 kube_prometheus_stack_prometheus_additional_scrape_configs: []
 
-# The Ceph mgr/prometheus ServiceMonitor remains enabled by default. Populate
-# this with cephadm service discovery endpoints to scrape ceph-exporter targets
-# in parallel, while keeping mgr perf-counter collection available as a fallback.
-kube_prometheus_stack_ceph_exporter_http_sd_configs: []
+kube_prometheus_stack_ceph_exporter_enabled: true
 kube_prometheus_stack_ceph_exporter_job_name: ceph-exporter
 kube_prometheus_stack_ceph_exporter_cluster_label: ceph
+kube_prometheus_stack_ceph_exporter_node_selector:
+  ceph: enabled
+kube_prometheus_stack_ceph_exporter_config_host_path: /etc/ceph
+kube_prometheus_stack_ceph_exporter_socket_host_path: "{{ '/var/run/ceph/' + ceph_fsid if ceph_fsid is defined else '/var/run/ceph' }}"
+kube_prometheus_stack_ceph_exporter_client_name: client.admin
+kube_prometheus_stack_ceph_exporter_port: 9926
 kube_prometheus_stack_ceph_exporter_scrape_interval: 15s
 kube_prometheus_stack_ceph_exporter_scrape_timeout: 10s
+kube_prometheus_stack_ceph_exporter_prio_limit: 5
+kube_prometheus_stack_ceph_exporter_stats_period: 5
+kube_prometheus_stack_ceph_exporter_resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    memory: 512Mi
+kube_prometheus_stack_ceph_exporter_tolerations: []
 
 kube_prometheus_stack_node_exporter_tls_template: "{{ _kube_prometheus_stack_tls_template }}"
 kube_prometheus_stack_node_exporter_config:

--- a/roles/kube_prometheus_stack/defaults/main.yml
+++ b/roles/kube_prometheus_stack/defaults/main.yml
@@ -20,6 +20,17 @@ kube_prometheus_stack_helm_release_namespace: monitoring
 kube_prometheus_stack_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
 kube_prometheus_stack_helm_values: {}
 
+kube_prometheus_stack_prometheus_additional_scrape_configs: []
+
+# The Ceph mgr/prometheus ServiceMonitor remains enabled by default. Populate
+# this with cephadm service discovery endpoints to scrape ceph-exporter targets
+# in parallel, while keeping mgr perf-counter collection available as a fallback.
+kube_prometheus_stack_ceph_exporter_http_sd_configs: []
+kube_prometheus_stack_ceph_exporter_job_name: ceph-exporter
+kube_prometheus_stack_ceph_exporter_cluster_label: ceph
+kube_prometheus_stack_ceph_exporter_scrape_interval: 15s
+kube_prometheus_stack_ceph_exporter_scrape_timeout: 10s
+
 kube_prometheus_stack_node_exporter_tls_template: "{{ _kube_prometheus_stack_tls_template }}"
 kube_prometheus_stack_node_exporter_config:
   tls_server_config:

--- a/roles/kube_prometheus_stack/tasks/main.yml
+++ b/roles/kube_prometheus_stack/tasks/main.yml
@@ -105,6 +105,94 @@
           healthcheck-client.crt: "{{ _etcd_healthcheck_client_crt.content }}"
           healthcheck-client.key: "{{ _etcd_healthcheck_client_key.content }}"
 
+- name: Deploy Ceph exporter
+  run_once: true
+  kubernetes.core.k8s:
+    state: "{{ kube_prometheus_stack_ceph_exporter_enabled | bool | ternary('present', 'absent') }}"
+    definition:
+      - apiVersion: apps/v1
+        kind: DaemonSet
+        metadata:
+          name: "{{ kube_prometheus_stack_ceph_exporter_job_name }}"
+          namespace: "{{ kube_prometheus_stack_helm_release_namespace }}"
+          labels:
+            application: "{{ kube_prometheus_stack_ceph_exporter_job_name }}"
+        spec:
+          selector:
+            matchLabels:
+              application: "{{ kube_prometheus_stack_ceph_exporter_job_name }}"
+          template:
+            metadata:
+              labels:
+                application: "{{ kube_prometheus_stack_ceph_exporter_job_name }}"
+            spec:
+              nodeSelector: "{{ kube_prometheus_stack_ceph_exporter_node_selector }}"
+              tolerations: "{{ kube_prometheus_stack_ceph_exporter_tolerations }}"
+              containers:
+                - name: ceph-exporter
+                  image: "{{ atmosphere_images['ceph'] | vexxhost.kubernetes.docker_image('ref') }}"
+                  command:
+                    - /usr/bin/ceph-exporter
+                  args:
+                    - -n
+                    - "{{ kube_prometheus_stack_ceph_exporter_client_name }}"
+                    - -d
+                    - --sock-dir=/var/run/ceph
+                    - --addrs=0.0.0.0
+                    - "--port={{ kube_prometheus_stack_ceph_exporter_port }}"
+                    - "--prio-limit={{ kube_prometheus_stack_ceph_exporter_prio_limit }}"
+                    - "--stats-period={{ kube_prometheus_stack_ceph_exporter_stats_period }}"
+                  ports:
+                    - name: metrics
+                      containerPort: "{{ kube_prometheus_stack_ceph_exporter_port | int }}"
+                  resources: "{{ kube_prometheus_stack_ceph_exporter_resources }}"
+                  securityContext:
+                    runAsUser: 0
+                    runAsGroup: 0
+                  readinessProbe:
+                    httpGet:
+                      path: /metrics
+                      port: metrics
+                    periodSeconds: 10
+                    timeoutSeconds: 5
+                  livenessProbe:
+                    httpGet:
+                      path: /metrics
+                      port: metrics
+                    periodSeconds: 30
+                    timeoutSeconds: 5
+                  volumeMounts:
+                    - name: ceph-config
+                      mountPath: /etc/ceph
+                      readOnly: true
+                    - name: ceph-sockets
+                      mountPath: /var/run/ceph
+              volumes:
+                - name: ceph-config
+                  hostPath:
+                    path: "{{ kube_prometheus_stack_ceph_exporter_config_host_path }}"
+                    type: Directory
+                - name: ceph-sockets
+                  hostPath:
+                    path: "{{ kube_prometheus_stack_ceph_exporter_socket_host_path }}"
+                    type: Directory
+
+      - apiVersion: v1
+        kind: Service
+        metadata:
+          name: "{{ kube_prometheus_stack_ceph_exporter_job_name }}"
+          namespace: "{{ kube_prometheus_stack_helm_release_namespace }}"
+          labels:
+            application: "{{ kube_prometheus_stack_ceph_exporter_job_name }}"
+        spec:
+          clusterIP: None
+          ports:
+            - name: metrics
+              port: "{{ kube_prometheus_stack_ceph_exporter_port | int }}"
+              targetPort: metrics
+          selector:
+            application: "{{ kube_prometheus_stack_ceph_exporter_job_name }}"
+
 - name: Generate client secret passwords
   run_once: true
   kubernetes.core.k8s:

--- a/roles/kube_prometheus_stack/tasks/main.yml
+++ b/roles/kube_prometheus_stack/tasks/main.yml
@@ -139,12 +139,12 @@
                     - -d
                     - --sock-dir=/var/run/ceph
                     - --addrs=0.0.0.0
-                    - "--port={{ kube_prometheus_stack_ceph_exporter_port }}"
+                    - --port=9926
                     - "--prio-limit={{ kube_prometheus_stack_ceph_exporter_prio_limit }}"
                     - "--stats-period={{ kube_prometheus_stack_ceph_exporter_stats_period }}"
                   ports:
                     - name: metrics
-                      containerPort: "{{ kube_prometheus_stack_ceph_exporter_port | int }}"
+                      containerPort: 9926
                   resources: "{{ kube_prometheus_stack_ceph_exporter_resources }}"
                   securityContext:
                     runAsUser: 0
@@ -188,7 +188,7 @@
           clusterIP: None
           ports:
             - name: metrics
-              port: "{{ kube_prometheus_stack_ceph_exporter_port | int }}"
+              port: 9926
               targetPort: metrics
           selector:
             application: "{{ kube_prometheus_stack_ceph_exporter_job_name }}"

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -1,15 +1,3 @@
-_kube_prometheus_stack_ceph_exporter_scrape_config:
-  job_name: "{{ kube_prometheus_stack_ceph_exporter_job_name }}"
-  honor_labels: true
-  scrape_interval: "{{ kube_prometheus_stack_ceph_exporter_scrape_interval }}"
-  scrape_timeout: "{{ kube_prometheus_stack_ceph_exporter_scrape_timeout }}"
-  http_sd_configs: "{{ kube_prometheus_stack_ceph_exporter_http_sd_configs }}"
-  relabel_configs:
-    - target_label: cluster
-      replacement: "{{ kube_prometheus_stack_ceph_exporter_cluster_label }}"
-
-_kube_prometheus_stack_ceph_exporter_scrape_configs: "{{ [_kube_prometheus_stack_ceph_exporter_scrape_config] if kube_prometheus_stack_ceph_exporter_http_sd_configs | length > 0 else [] }}"
-
 _kube_prometheus_stack_helm_values:
   defaultRules:
     rules:
@@ -490,7 +478,7 @@ _kube_prometheus_stack_helm_values:
       volumeMounts:
         - name: certs
           mountPath: /certs
-      additionalScrapeConfigs: "{{ kube_prometheus_stack_prometheus_additional_scrape_configs + _kube_prometheus_stack_ceph_exporter_scrape_configs }}"
+      additionalScrapeConfigs: "{{ kube_prometheus_stack_prometheus_additional_scrape_configs }}"
     additionalServiceMonitors:
       - name: goldpinger
         jobLabel: app.kubernetes.io/instance
@@ -517,6 +505,28 @@ _kube_prometheus_stack_helm_values:
                 regex: (.*)
                 replacement: ceph
                 targetLabel: cluster
+              - *relabeling_drop_all_kubernetes_labels
+      - name: "{{ kube_prometheus_stack_ceph_exporter_job_name }}"
+        jobLabel: application
+        namespaceSelector:
+          matchNames:
+            - "{{ kube_prometheus_stack_helm_release_namespace }}"
+        selector:
+          matchLabels:
+            application: "{{ kube_prometheus_stack_ceph_exporter_job_name }}"
+        endpoints:
+          - port: metrics
+            honorLabels: true
+            interval: "{{ kube_prometheus_stack_ceph_exporter_scrape_interval }}"
+            scrapeTimeout: "{{ kube_prometheus_stack_ceph_exporter_scrape_timeout }}"
+            relabelings:
+              - action: replace
+                regex: (.*)
+                replacement: "{{ kube_prometheus_stack_ceph_exporter_cluster_label }}"
+                targetLabel: cluster
+              - sourceLabels:
+                  - __meta_kubernetes_pod_node_name
+                targetLabel: instance
               - *relabeling_drop_all_kubernetes_labels
       - name: coredns
         jobLabel: app.kubernetes.io/name

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -1,3 +1,15 @@
+_kube_prometheus_stack_ceph_exporter_scrape_config:
+  job_name: "{{ kube_prometheus_stack_ceph_exporter_job_name }}"
+  honor_labels: true
+  scrape_interval: "{{ kube_prometheus_stack_ceph_exporter_scrape_interval }}"
+  scrape_timeout: "{{ kube_prometheus_stack_ceph_exporter_scrape_timeout }}"
+  http_sd_configs: "{{ kube_prometheus_stack_ceph_exporter_http_sd_configs }}"
+  relabel_configs:
+    - target_label: cluster
+      replacement: "{{ kube_prometheus_stack_ceph_exporter_cluster_label }}"
+
+_kube_prometheus_stack_ceph_exporter_scrape_configs: "{{ [_kube_prometheus_stack_ceph_exporter_scrape_config] if kube_prometheus_stack_ceph_exporter_http_sd_configs | length > 0 else [] }}"
+
 _kube_prometheus_stack_helm_values:
   defaultRules:
     rules:
@@ -478,6 +490,7 @@ _kube_prometheus_stack_helm_values:
       volumeMounts:
         - name: certs
           mountPath: /certs
+      additionalScrapeConfigs: "{{ kube_prometheus_stack_prometheus_additional_scrape_configs + _kube_prometheus_stack_ceph_exporter_scrape_configs }}"
     additionalServiceMonitors:
       - name: goldpinger
         jobLabel: app.kubernetes.io/instance

--- a/roles/kubernetes_node_labels/defaults/main.yml
+++ b/roles/kubernetes_node_labels/defaults/main.yml
@@ -24,4 +24,7 @@ kubernetes_node_labels: |
   {%   set _ = res.update({'openstack-compute-node': 'enabled'}) %}
   {%   set _ = res.update({'openvswitch': 'enabled'}) %}
   {% endif %}
+  {% if inventory_hostname in groups.get('cephs', []) %}
+  {%   set _ = res.update({'ceph': 'enabled'}) %}
+  {% endif %}
   {{ res }}


### PR DESCRIPTION
## Summary
- run ceph-exporter as an optional DaemonSet in the monitoring namespace, scheduled to Ceph nodes with the Kubernetes-native `ceph=enabled` node label
- scrape ceph-exporter through a ServiceMonitor and Kubernetes service discovery
- keep the existing Ceph mgr ServiceMonitor enabled as the perf-counter fallback for clusters that do not yet run ceph-exporter
- label Ceph inventory nodes through the kubernetes_node_labels role and document the monitoring change with Reno

## Validation
- git diff --check
- YAML parse for touched role files
- GOCACHE=/private/tmp/go-build-cache go test ./roles/kube_prometheus_stack -run "Test(CreateKeycloakRealmTask|AddClientRolesInIdTokenTask|CreateKeycloakClientsTask|CreateKeycloakRolesTask)"
- AIO test: temporary ceph-exporter DaemonSet scraped metrics successfully, including `ceph_osd_op_w_in_bytes`