### PR TITLE
fix(libvirt): use emptyDir for generated ceph config

### DIFF
--- a/charts/libvirt/templates/daemonset-libvirt.yaml
+++ b/charts/libvirt/templates/daemonset-libvirt.yaml
@@ -333,9 +333,6 @@ spec:
             {{- if .Values.conf.ceph.enabled }}
             - name: etcceph
               mountPath: /etc/ceph
-              {{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "10" ) }}
-              mountPropagation: Bidirectional
-              {{- end }}
             {{- if empty .Values.conf.ceph.cinder.keyring }}
             - name: ceph-keyring
               mountPath: /tmp/client-keyring
@@ -399,8 +396,7 @@ spec:
             defaultMode: 0444
         {{- if .Values.conf.ceph.enabled }}
         - name: etcceph
-          hostPath:
-            path: /var/lib/openstack-helm/compute/libvirt
+          emptyDir: {}
         - name: ceph-etc
           configMap:
             name: {{ .Values.ceph_client.configmap }}

--- a/charts/patches/libvirt/0003-use-emptydir-for-generated-etcceph.patch
+++ b/charts/patches/libvirt/0003-use-emptydir-for-generated-etcceph.patch
@@ -1,0 +1,24 @@
+diff --git a/libvirt/templates/daemonset-libvirt.yaml b/libvirt/templates/daemonset-libvirt.yaml
+index 7a537b403..c8c4d58ff 100644
+--- a/libvirt/templates/daemonset-libvirt.yaml
++++ b/libvirt/templates/daemonset-libvirt.yaml
+@@ -279,9 +279,6 @@ spec:
+             {{- if .Values.conf.ceph.enabled }}
+             - name: etcceph
+               mountPath: /etc/ceph
+-              {{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "10" ) }}
+-              mountPropagation: Bidirectional
+-              {{- end }}
+             {{- if empty .Values.conf.ceph.cinder.keyring }}
+             - name: ceph-keyring
+               mountPath: /tmp/client-keyring
+@@ -325,8 +322,7 @@ spec:
+             defaultMode: 0444
+         {{- if .Values.conf.ceph.enabled }}
+         - name: etcceph
+-          hostPath:
+-            path: /var/lib/openstack-helm/compute/libvirt
++          emptyDir: {}
+         - name: ceph-etc
+           configMap:
+             name: {{ .Values.ceph_client.configmap }}

--- a/releasenotes/notes/libvirt-emptydir-etcceph-f6f8c9c0d0e1a2b3.yaml
+++ b/releasenotes/notes/libvirt-emptydir-etcceph-f6f8c9c0d0e1a2b3.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Store generated ``/etc/ceph`` content for the libvirt pod in an
+    ``emptyDir`` volume instead of a ``hostPath``. This avoids propagating Ceph
+    configuration and keyring bind mounts into the host mount namespace during
+    libvirt pod restarts.


### PR DESCRIPTION
## Summary
- align the Atmosphere libvirt chart with merged upstream OpenStack-Helm change 992242
- store generated libvirt /etc/ceph content in an emptyDir instead of a hostPath
- remove bidirectional propagation from the /etc/ceph mount so Ceph config/keyring bind mounts stay inside the pod namespace

## Testing
- git diff --check --cached
- git apply --reverse --check --directory=charts charts/patches/libvirt/0003-use-emptydir-for-generated-etcceph.patch
- helm lint charts/libvirt
- vale releasenotes/notes/libvirt-emptydir-etcceph-f6f8c9c0d0e1a2b3.yaml
- HTTPS_PROXY=http://localhost:33128 HTTP_PROXY=http://localhost:33128 go test -run 'TestKubeconform/libvirt' ./charts
