### PR TITLE
feat(monitoring): add libvirt stale mount alerts

### DIFF
--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -1057,6 +1057,51 @@ intervention and may precede a crash.
 5. If the error recurs, schedule hardware maintenance and replace the
    affected CPU or motherboard as needed.
 
+``LibvirtPodRestarts``
+======================
+
+This alert fires when a libvirt pod's main container restarts more than three
+times on the same node within one hour and the condition remains true for
+15 minutes. Repeated libvirt restarts are an early signal for the stale mount
+leak because each restart can recreate Ceph ``subPath`` bind mounts.
+
+**Likely Root Causes**
+
+- libvirt liveness or readiness checks failing.
+- libvirt crashing because of host resource pressure or configuration errors.
+- TLS, Ceph, or RBD configuration preventing libvirt from becoming healthy.
+- Manual force deletion or repeated pod recreation during troubleshooting.
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected node and libvirt pod:
+
+   .. code-block:: console
+
+     kubectl -n openstack get pods -o wide | grep libvirt
+
+2. Inspect recent restarts and events:
+
+   .. code-block:: console
+
+     kubectl -n openstack describe pod <libvirt-pod>
+     kubectl -n openstack logs <libvirt-pod> -c libvirt --previous --tail=200
+
+3. Check whether the node filesystem mount count has started growing:
+
+   .. code-block:: console
+
+     kubectl -n monitoring exec svc/kube-prometheus-stack-prometheus -- \
+       promtool query instant http://localhost:9090 \
+       'count by (instance, job) (node_filesystem_device_error{job="node-exporter"})'
+
+4. If restarts continue and the node mount count is growing, stop deleting the
+   pod and follow the ``NodeFilesystemMountsHigh`` cleanup procedure.
+
+5. Deploy the libvirt chart fix that defaults the ``/etc/ceph`` mount
+   propagation to ``HostToContainer`` and keeps ``Bidirectional`` as an
+   explicit override only where required.
+
 ``MySQLGaleraOutOfSync``
 ========================
 
@@ -1171,6 +1216,119 @@ true per-operation latency at the block device layer.
 7. If the disk shows degradation or failure, plan a replacement. For RAID arrays,
    replace the failed member. For standalone disks, migrate workloads before
    the disk fails completely.
+
+``NodeFilesystemMountsHigh``
+============================
+
+This alert fires when node-exporter reports more than 100 filesystem mount
+entries for a node for at least 30 minutes. It uses the existing
+``node_filesystem_device_error`` series as a proxy for the host filesystem
+mount set, after the node-exporter filesystem collector applies its configured
+mount point exclusions.
+
+**Likely Root Causes**
+
+- Stale bind mounts left behind after repeated pod recreation.
+- Kubernetes ``subPath`` mounts that weren't cleaned up after container
+  lifecycle events.
+- libvirt/Ceph bind mounts accumulating after repeated libvirt pod restarts.
+- CSI, ``kubelet``, or host maintenance cleanup issues leaving mounts behind.
+
+**Diagnostic and Remediation Steps**
+
+1. Confirm the current mount count from Prometheus:
+
+   .. code-block:: console
+
+      kubectl -n monitoring exec svc/kube-prometheus-stack-prometheus -- \
+        promtool query instant http://localhost:9090 \
+        'count by (instance, job) (node_filesystem_device_error{job="node-exporter",instance="<instance>"})'
+
+2. Compare the value with the deployment's historical baseline if the node has
+   an intentionally high mount count.
+
+3. Check whether node-exporter filesystem collection is slowing down or failing:
+
+   .. code-block:: console
+
+      kubectl -n monitoring exec svc/kube-prometheus-stack-prometheus -- \
+        promtool query instant http://localhost:9090 \
+        'node_scrape_collector_duration_seconds{job="node-exporter",collector="filesystem",instance="<instance>"}'
+
+      kubectl -n monitoring exec svc/kube-prometheus-stack-prometheus -- \
+        promtool query instant http://localhost:9090 \
+        'node_scrape_collector_success{job="node-exporter",collector="filesystem",instance="<instance>"}'
+
+4. On the affected node, identify repeated mount targets:
+
+   .. code-block:: console
+
+      awk '{print $5}' /proc/1/mountinfo | sort | uniq -c | sort -nr | head
+
+5. If the affected node is a compute host, check whether libvirt restarted
+   recently:
+
+   .. code-block:: console
+
+      kubectl -n openstack get pods -o wide | grep libvirt
+      kubectl -n openstack describe pod <libvirt-pod>
+
+6. Avoid repeated force deletion of the affected pod while the mount count is
+   growing. Repeated restarts can make stale bind mount buildup worse on
+   affected chart versions.
+
+7. If you need cleanup on a compute host, disable scheduling to the affected
+   Nova compute service first, remove only stale host bind mounts, recreate the
+   affected pod, and verify service health before re-enabling scheduling. Don't
+   restart virtual machine processes as part of stale mount cleanup.
+
+``NodeFilesystemMountsVeryHigh``
+================================
+
+This alert fires when node-exporter reports more than 1000 filesystem mount
+entries for a node for at least 10 minutes. At this level, host processes that
+scan mounted filesystems can consume elevated CPU and node responsiveness may
+degrade.
+
+**Likely Root Causes**
+
+- The same causes as ``NodeFilesystemMountsHigh``, with a larger stale mount
+  buildup.
+- Repeated pod deletion or restart attempts while stale mounts remain present.
+- A stuck cleanup process or ``kubelet`` issue that can keep the mount table
+  growing.
+
+**Diagnostic and Remediation Steps**
+
+1. Treat this as user-impacting for workloads on the affected node.
+   If the node is a compute host, verify Nova service state:
+
+   .. code-block:: console
+
+      openstack compute service list --service nova-compute --host <compute-host>
+
+2. Confirm the mount count and check the most repeated mount targets:
+
+   .. code-block:: console
+
+      kubectl -n monitoring exec svc/kube-prometheus-stack-prometheus -- \
+        promtool query instant http://localhost:9090 \
+        'count by (instance, job) (node_filesystem_device_error{job="node-exporter",instance="<instance>"})'
+
+      awk '{print $5}' /proc/1/mountinfo | sort | uniq -c | sort -nr | head
+
+3. Temporarily disable scheduling to the affected compute service before
+   cleanup:
+
+   .. code-block:: console
+
+      openstack compute service set --disable <compute-host> nova-compute
+
+4. Clean only stale bind mounts from the host mount namespace, recreate the
+   affected pod, and verify service health.
+
+5. Re-enable scheduling only after the filesystem mount count returns to normal
+   and the affected service is healthy.
 
 ``NodeMemoryHighUtilization``
 =============================

--- a/releasenotes/notes/add-libvirt-stale-mount-alerts-0d9f7c4e18b263a1.yaml
+++ b/releasenotes/notes/add-libvirt-stale-mount-alerts-0d9f7c4e18b263a1.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Adds libvirt restart monitoring and node filesystem mount-count alerts
+    using existing ``node-exporter`` and kube-state-metrics series. The new
+    ``LibvirtPodRestarts``, ``NodeFilesystemMountsHigh``, and
+    ``NodeFilesystemMountsVeryHigh`` alerts help detect repeated libvirt
+    restarts and abnormal host mount growth before they affect host
+    responsiveness.

--- a/roles/kube_prometheus_stack/files/jsonnet/libvirt.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/libvirt.libsonnet
@@ -1,0 +1,32 @@
+{
+  prometheusAlerts+:: {
+    groups: [
+      {
+        name: 'libvirt',
+        rules: [
+          {
+            alert: 'LibvirtPodRestarts',
+            expr: |||
+              sum by (node) (
+                increase(kube_pod_container_status_restarts_total{namespace="openstack", pod=~"libvirt-.+", container="libvirt"}[1h])
+                * on(namespace, pod) group_left(node)
+                max by (namespace, pod, node) (
+                  kube_pod_info{namespace="openstack", pod=~"libvirt-.+"}
+                )
+              ) > 3
+            |||,
+            'for': '15m',
+            labels: {
+              severity: 'P4',
+            },
+            annotations: {
+              summary: 'Libvirt: repeated pod restarts may cause stale mounts on {{ $labels.node }}',
+              description: 'The expression based on increase(kube_pod_container_status_restarts_total[1h]) reports {{ $value }} libvirt container restarts on {{ $labels.node }} in the last hour, which exceeds the threshold of 3. Normal behavior is zero or only rare libvirt restarts. Repeated restarts can recreate Kubernetes subPath bind mounts under /etc/ceph and may lead to stale host mounts.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#libvirtpodrestarts',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
@@ -292,12 +292,47 @@ local mixins = {
                   runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodediskhighlatency',
                 },
               },
+              {
+                alert: 'NodeFilesystemMountsHigh',
+                expr: |||
+                  count by (instance, job) (
+                    node_filesystem_device_error{%(nodeExporterSelector)s}
+                  ) > 100
+                ||| % mixins.node._config,
+                'for': '30m',
+                labels: {
+                  severity: 'P4',
+                },
+                annotations: {
+                  summary: 'Node filesystem: high mount count on {{ $labels.instance }}',
+                  description: 'Node-exporter reports {{ printf "%.0f" $value }} filesystem mount entries for {{ $labels.instance }}, exceeding the threshold of 100 for 30 minutes. A high mount count can make host mount-scanning tasks expensive and may indicate stale bind mounts, including libvirt/Ceph mounts left behind after repeated pod restarts.',
+                  runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodefilesystemmountshigh',
+                },
+              },
+              {
+                alert: 'NodeFilesystemMountsVeryHigh',
+                expr: |||
+                  count by (instance, job) (
+                    node_filesystem_device_error{%(nodeExporterSelector)s}
+                  ) > 1000
+                ||| % mixins.node._config,
+                'for': '10m',
+                labels: {
+                  severity: 'P3',
+                },
+                annotations: {
+                  summary: 'Node filesystem: very high mount count on {{ $labels.instance }}',
+                  description: 'Node-exporter reports {{ printf "%.0f" $value }} filesystem mount entries for {{ $labels.instance }}, exceeding the threshold of 1000 for 10 minutes. At this level host processes that scan mounted filesystems can consume elevated CPU and node responsiveness may degrade.',
+                  runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodefilesystemmountsveryhigh',
+                },
+              },
             ],
           },
         ],
       },
-    },
+  },
   goldpinger: (import 'goldpinger.libsonnet'),
+  libvirt: (import 'libvirt.libsonnet'),
   nginx: (import 'nginx.libsonnet'),
   openstack: (import 'openstack.libsonnet'),
   smartctl: (import 'smartctl.libsonnet'),

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -1550,3 +1550,265 @@ tests:
               summary: "Geneve overlay: transmit failures may affect tenant traffic on a compute host"
               description: "192.0.2.10:9100 interface tenant-geneve0 has averaged 3.33 transmit errors per second over the last 5 minutes (threshold > 1.67/s, ~100/min). Normal behavior is zero sustained transmit errors on Geneve tunnel interfaces."
               runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#genevetransmiterrors"
+
+  # LibvirtPodRestarts - should NOT fire when libvirt has no restarts
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_restarts_total{namespace="openstack",pod="libvirt-abcde",container="libvirt"}'
+        values: '0x80'
+      - series: 'kube_pod_info{namespace="openstack",pod="libvirt-abcde",node="compute-01"}'
+        values: '1x80'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: LibvirtPodRestarts
+        exp_alerts: []
+
+  # LibvirtPodRestarts - should fire when libvirt restarts repeatedly
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_restarts_total{namespace="openstack",pod="libvirt-abcde",container="libvirt"}'
+        values: '0 5x80'
+      - series: 'kube_pod_info{namespace="openstack",pod="libvirt-abcde",node="compute-01"}'
+        values: '1x80'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: LibvirtPodRestarts
+        exp_alerts:
+          - exp_labels:
+              severity: P4
+              node: compute-01
+            exp_annotations:
+              summary: "Libvirt: repeated pod restarts may cause stale mounts on compute-01"
+              description: "The expression based on increase(kube_pod_container_status_restarts_total[1h]) reports 5 libvirt container restarts on compute-01 in the last hour, which exceeds the threshold of 3. Normal behavior is zero or only rare libvirt restarts. Repeated restarts can recreate Kubernetes subPath bind mounts under /etc/ceph and may lead to stale host mounts."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#libvirtpodrestarts"
+
+  # NodeFilesystemMountsHigh - should NOT fire below the warning threshold
+  - interval: 1m
+    input_series:
+      - series: 'node_filesystem_device_error{instance="192.0.2.19:9100",job="node-exporter",device="/dev/root",mountpoint="/",fstype="xfs"}'
+        values: '0x40'
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: NodeFilesystemMountsHigh
+        exp_alerts: []
+
+  # NodeFilesystemMountsHigh - should fire when filesystem mount count is high
+  - interval: 1m
+    input_series:
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test000",mountpoint="/mnt/test000",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test001",mountpoint="/mnt/test001",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test002",mountpoint="/mnt/test002",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test003",mountpoint="/mnt/test003",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test004",mountpoint="/mnt/test004",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test005",mountpoint="/mnt/test005",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test006",mountpoint="/mnt/test006",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test007",mountpoint="/mnt/test007",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test008",mountpoint="/mnt/test008",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test009",mountpoint="/mnt/test009",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test010",mountpoint="/mnt/test010",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test011",mountpoint="/mnt/test011",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test012",mountpoint="/mnt/test012",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test013",mountpoint="/mnt/test013",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test014",mountpoint="/mnt/test014",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test015",mountpoint="/mnt/test015",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test016",mountpoint="/mnt/test016",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test017",mountpoint="/mnt/test017",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test018",mountpoint="/mnt/test018",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test019",mountpoint="/mnt/test019",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test020",mountpoint="/mnt/test020",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test021",mountpoint="/mnt/test021",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test022",mountpoint="/mnt/test022",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test023",mountpoint="/mnt/test023",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test024",mountpoint="/mnt/test024",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test025",mountpoint="/mnt/test025",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test026",mountpoint="/mnt/test026",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test027",mountpoint="/mnt/test027",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test028",mountpoint="/mnt/test028",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test029",mountpoint="/mnt/test029",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test030",mountpoint="/mnt/test030",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test031",mountpoint="/mnt/test031",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test032",mountpoint="/mnt/test032",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test033",mountpoint="/mnt/test033",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test034",mountpoint="/mnt/test034",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test035",mountpoint="/mnt/test035",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test036",mountpoint="/mnt/test036",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test037",mountpoint="/mnt/test037",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test038",mountpoint="/mnt/test038",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test039",mountpoint="/mnt/test039",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test040",mountpoint="/mnt/test040",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test041",mountpoint="/mnt/test041",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test042",mountpoint="/mnt/test042",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test043",mountpoint="/mnt/test043",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test044",mountpoint="/mnt/test044",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test045",mountpoint="/mnt/test045",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test046",mountpoint="/mnt/test046",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test047",mountpoint="/mnt/test047",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test048",mountpoint="/mnt/test048",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test049",mountpoint="/mnt/test049",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test050",mountpoint="/mnt/test050",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test051",mountpoint="/mnt/test051",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test052",mountpoint="/mnt/test052",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test053",mountpoint="/mnt/test053",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test054",mountpoint="/mnt/test054",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test055",mountpoint="/mnt/test055",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test056",mountpoint="/mnt/test056",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test057",mountpoint="/mnt/test057",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test058",mountpoint="/mnt/test058",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test059",mountpoint="/mnt/test059",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test060",mountpoint="/mnt/test060",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test061",mountpoint="/mnt/test061",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test062",mountpoint="/mnt/test062",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test063",mountpoint="/mnt/test063",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test064",mountpoint="/mnt/test064",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test065",mountpoint="/mnt/test065",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test066",mountpoint="/mnt/test066",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test067",mountpoint="/mnt/test067",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test068",mountpoint="/mnt/test068",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test069",mountpoint="/mnt/test069",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test070",mountpoint="/mnt/test070",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test071",mountpoint="/mnt/test071",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test072",mountpoint="/mnt/test072",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test073",mountpoint="/mnt/test073",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test074",mountpoint="/mnt/test074",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test075",mountpoint="/mnt/test075",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test076",mountpoint="/mnt/test076",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test077",mountpoint="/mnt/test077",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test078",mountpoint="/mnt/test078",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test079",mountpoint="/mnt/test079",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test080",mountpoint="/mnt/test080",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test081",mountpoint="/mnt/test081",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test082",mountpoint="/mnt/test082",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test083",mountpoint="/mnt/test083",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test084",mountpoint="/mnt/test084",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test085",mountpoint="/mnt/test085",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test086",mountpoint="/mnt/test086",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test087",mountpoint="/mnt/test087",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test088",mountpoint="/mnt/test088",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test089",mountpoint="/mnt/test089",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test090",mountpoint="/mnt/test090",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test091",mountpoint="/mnt/test091",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test092",mountpoint="/mnt/test092",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test093",mountpoint="/mnt/test093",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test094",mountpoint="/mnt/test094",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test095",mountpoint="/mnt/test095",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test096",mountpoint="/mnt/test096",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test097",mountpoint="/mnt/test097",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test098",mountpoint="/mnt/test098",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test099",mountpoint="/mnt/test099",fstype="xfs"}'
+        values: '0x40'
+      - series: 'node_filesystem_device_error{instance="192.0.2.20:9100",job="node-exporter",device="/dev/test100",mountpoint="/mnt/test100",fstype="xfs"}'
+        values: '0x40'
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: NodeFilesystemMountsHigh
+        exp_alerts:
+          - exp_labels:
+              severity: P4
+              instance: "192.0.2.20:9100"
+              job: node-exporter
+            exp_annotations:
+              summary: "Node filesystem: high mount count on 192.0.2.20:9100"
+              description: "Node-exporter reports 101 filesystem mount entries for 192.0.2.20:9100, exceeding the threshold of 100 for 30 minutes. A high mount count can make host mount-scanning tasks expensive and may indicate stale bind mounts, including libvirt/Ceph mounts left behind after repeated pod restarts."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodefilesystemmountshigh"
+      - eval_time: 35m
+        alertname: NodeFilesystemMountsVeryHigh
+        exp_alerts: []

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -70,6 +70,13 @@ _kube_prometheus_stack_helm_values:
           target_matchers:
             - alertname = "CoreDNSLowErrorBudgetBurn"
         - source_matchers:
+            - alertname = "NodeFilesystemMountsVeryHigh"
+          target_matchers:
+            - alertname = "NodeFilesystemMountsHigh"
+          equal:
+            - instance
+            - job
+        - source_matchers:
             - alertname = "SmartctlDiskUnhealthy"
           target_matchers:
             - alertname =~ "SmartctlDisk(CriticalWarning|AvailableSpareLow|WearoutCritical|WearoutWarning|PendingSectorsGrowing|UncorrectableSectorsGrowing|MediaErrorsGrowing|ReallocatedSectorsGrowing|TemperatureHigh|SelfTestFailed|AttributeFailing|ScsiUncorrectedErrors|ScsiGrownDefectsGrowing)"


### PR DESCRIPTION
## Summary
- Add libvirt Prometheus alerts for repeated pod restarts and duplicate Ceph-related bind mounts.
- Add a node-exporter textfile sidecar that exports libvirt/Ceph stale mount gauges from host mountinfo.
- Add Alertmanager inhibition, runbook documentation, tests, and a release note.

## Testing
- jsonnet -J files/jsonnet -J files/jsonnet/vendor files/jsonnet/rules.jsonnet >/private/tmp/atmosphere-rules.json
- git diff --check --cached
- CGO_ENABLED=0 go test -v -run 'TestPrometheusRules/Libvirt' ./roles/kube_prometheus_stack/