### PR TITLE
fix(kube-prometheus-stack): ignore deleted master amphorae

### DIFF
--- a/releasenotes/notes/ignore-deleted-master-amphorae-alert-66df44c70fb66774.yaml
+++ b/releasenotes/notes/ignore-deleted-master-amphorae-alert-66df44c70fb66774.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix ``OctaviaLoadBalancerMultipleMaster`` monitoring rule to exclude
+    ``DELETED`` Amphora records. This prevents false positives after a
+    successful failover leaves the old master Amphora row in the Octavia
+    database with ``DELETED`` status.

--- a/releasenotes/notes/ignore-deleted-master-amphorae-alert-66df44c70fb66774.yaml
+++ b/releasenotes/notes/ignore-deleted-master-amphorae-alert-66df44c70fb66774.yaml
@@ -2,6 +2,6 @@
 fixes:
   - |
     Fix ``OctaviaLoadBalancerMultipleMaster`` monitoring rule to exclude
-    ``DELETED`` Amphora records. This prevents false positives after a
-    successful failover leaves the old master Amphora row in the Octavia
-    database with ``DELETED`` status.
+    ``DELETED`` Amphora records. This prevents false positives when Octavia
+    replaces the master Amphora and leaves the old row in the database with
+    ``DELETED`` status.

--- a/roles/kube_prometheus_stack/files/jsonnet/openstack.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/openstack.libsonnet
@@ -283,7 +283,7 @@
                 summary: 'Octavia load balancer has multiple MASTER Amphorae',
                 description: 'Load balancer with ID {{ $labels.loadbalancer_id }} has multiple MASTER Amphorae for more then 15 minutes.',
               },
-              expr: 'count by(loadbalancer_id) (openstack_loadbalancer_amphora_status{role="MASTER"}) > 1',
+              expr: 'count by(loadbalancer_id) (openstack_loadbalancer_amphora_status{role="MASTER",status!="DELETED"}) > 1',
               'for': '15m',
               labels: {
                 severity: 'P3',

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -389,6 +389,17 @@ tests:
 
   - interval: 1m
     input_series:
+      - series: 'openstack_loadbalancer_amphora_status{cert_expiration="2020-08-08T23:44:31Z",compute_id="667bb225-69aa-44b1-8908-694dc624c267",ha_ip="192.0.2.6",id="45f40289-0551-483a-b089-47214bc2a8a4",lb_network_ip="198.51.100.6",loadbalancer_id="882f2a9d-9d53-4bd0-b0e9-08e9d0de11f9",role="MASTER",status="READY"}'
+        values: '2x15'
+      - series: 'openstack_loadbalancer_amphora_status{cert_expiration="2020-08-08T23:44:30Z",compute_id="9cd0f9a2-fe12-42fc-a7e3-5b6fbbe20395",ha_ip="192.0.2.6",id="7f890893-ced0-46ed-8697-33415d070e5a",lb_network_ip="198.51.100.17",loadbalancer_id="882f2a9d-9d53-4bd0-b0e9-08e9d0de11f9",role="MASTER",status="DELETED"}'
+        values: '6x15'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: OctaviaLoadBalancerMultipleMaster
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
       - series: 'openstack_loadbalancer_amphora_status{cert_expiration="2020-08-08T23:44:31Z",compute_id="667bb225-69aa-44b1-8908-694dc624c267",ha_ip="10.0.0.6",id="45f40289-0551-483a-b089-47214bc2a8a4",lb_network_ip="192.168.0.6",loadbalancer_id="882f2a9d-9d53-4bd0-b0e9-08e9d0de11f9",role="MASTER",status="READY"}'
         values: '2x15'
       - series: 'openstack_loadbalancer_amphora_status{cert_expiration="2020-08-08T23:44:30Z",compute_id="9cd0f9a2-fe12-42fc-a7e3-5b6fbbe20395",ha_ip="10.0.0.6",id="7f890893-ced0-46ed-8697-33415d070e5a",lb_network_ip="192.168.0.17",loadbalancer_id="882f2a9d-9d53-4bd0-b0e9-08e9d0de11f9",role="BACKUP",status="ERROR"}'


### PR DESCRIPTION
## Summary

- exclude deleted amphora records from the Octavia multiple-master alert expression
- add a regression test so one active master plus one deleted old master does not fire
- add a release note for the monitoring fix
- keep the release note wording compatible with the current docs lint expectations

## Validation

- PASS: `CGO_ENABLED=0 go test -v -run 'TestPrometheusRules/OctaviaLoadBalancerMultipleMaster' ./roles/kube_prometheus_stack/`
- PASS: `git diff --check origin/main..HEAD`

## Rebase note

- Rebased onto current `main`.
- Dropped the old CI-only `vale` apt index refresh commit because current `main` no longer has that `vale` job in `.github/workflows/ci.yaml`.
