### PR TITLE
feat: add support for Ubuntu 24.04

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,3 +1,48 @@
+- nodeset:
+    name: atmosphere-ubuntu-noble-single-node
+    nodes:
+      - name: instance
+        label: ubuntu-noble
+    groups: &single_node_groups
+      - name: controllers
+        nodes:
+          - instance
+      - name: cephs
+        nodes:
+          - instance
+      - name: computes
+        nodes:
+          - instance
+
+- nodeset:
+    name: atmosphere-ubuntu-noble-single-node-16
+    nodes:
+      - name: instance
+        label: ubuntu-noble-16
+    groups: *single_node_groups
+
 - project:
-    templates:
-      - atmosphere-molecule-jobs
+    check:
+      jobs:
+        - atmosphere-molecule-aio-openvswitch:
+            nodeset: atmosphere-ubuntu-noble-single-node-16
+        - atmosphere-molecule-aio-ovn:
+            nodeset: atmosphere-ubuntu-noble-single-node-16
+        - atmosphere-molecule-csi-local-path-provisioner:
+            nodeset: atmosphere-ubuntu-noble-single-node
+        - atmosphere-molecule-csi-rbd:
+            nodeset: atmosphere-ubuntu-noble-single-node
+        - atmosphere-molecule-keycloak:
+            nodeset: atmosphere-ubuntu-noble-single-node
+    gate:
+      jobs:
+        - atmosphere-molecule-aio-openvswitch:
+            nodeset: atmosphere-ubuntu-noble-single-node-16
+        - atmosphere-molecule-aio-ovn:
+            nodeset: atmosphere-ubuntu-noble-single-node-16
+        - atmosphere-molecule-csi-local-path-provisioner:
+            nodeset: atmosphere-ubuntu-noble-single-node
+        - atmosphere-molecule-csi-rbd:
+            nodeset: atmosphere-ubuntu-noble-single-node
+        - atmosphere-molecule-keycloak:
+            nodeset: atmosphere-ubuntu-noble-single-node

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -32,6 +32,8 @@
             nodeset: atmosphere-ubuntu-noble-single-node
         - atmosphere-molecule-csi-rbd:
             nodeset: atmosphere-ubuntu-noble-single-node
+            vars:
+              ceph_version: 18.2.7
         - atmosphere-molecule-keycloak:
             nodeset: atmosphere-ubuntu-noble-single-node
     gate:
@@ -44,5 +46,7 @@
             nodeset: atmosphere-ubuntu-noble-single-node
         - atmosphere-molecule-csi-rbd:
             nodeset: atmosphere-ubuntu-noble-single-node
+            vars:
+              ceph_version: 18.2.7
         - atmosphere-molecule-keycloak:
             nodeset: atmosphere-ubuntu-noble-single-node

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ description: Simple & easy private cloud platform featuring VMs, Kubernetes & ba
 license:
   - GPL-3.0-or-later
 dependencies:
-  ansible.netcommon: 1.2.0
+  ansible.netcommon: 8.5.0
   ansible.posix: 1.6.0
   ansible.utils: ">=2.9.0"
   community.crypto: 2.2.3

--- a/molecule/aio/prepare.yml
+++ b/molecule/aio/prepare.yml
@@ -22,7 +22,7 @@
         state: present
 
     - name: Purge "snapd" package
-      when: ansible_distribution | lower == 'ubuntu'
+      when: ansible_facts['distribution'] | lower == 'ubuntu'
       ansible.builtin.apt:
         name: snapd
         state: absent
@@ -32,7 +32,7 @@
   ansible.builtin.import_playbook: vexxhost.atmosphere.generate_workspace
   vars:
     workspace_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
-    domain_name: "{{ ansible_default_ipv4['address'].replace('.', '-') }}.nip.io"
+    domain_name: "{{ ansible_facts['default_ipv4']['address'].replace('.', '-') }}.nip.io"
 
 - name: Setup networking
   hosts: all

--- a/molecule/default/group_vars/all/molecule.yml
+++ b/molecule/default/group_vars/all/molecule.yml
@@ -10,6 +10,8 @@ glance_images:
     container_format: bare
     is_public: true
 
+magnum_images: "{{ _magnum_images[-1:] }}"
+
 atmosphere_network_backend: "{{ lookup('env', 'ATMOSPHERE_NETWORK_BACKEND') | default('openvswitch', True) }}"
 ovn_helm_values:
   conf:

--- a/plugins/filter/storage.py
+++ b/plugins/filter/storage.py
@@ -557,9 +557,27 @@ class StorageConfig(_StrictBase):
     )
 
 
+def _deep_unwrap(obj: Any) -> Any:
+    """Recursively unwrap Ansible lazy templating wrappers into plain types."""
+    cls_name = obj.__class__.__name__
+    if cls_name == "_LazyValue":
+        for attr in ("_value", "value"):
+            if hasattr(obj, attr):
+                obj = getattr(obj, attr)
+                break
+        cls_name = obj.__class__.__name__
+
+    if isinstance(obj, dict) or cls_name == "_AnsibleLazyTemplateDict":
+        return {_deep_unwrap(k): _deep_unwrap(v) for k, v in obj.items()}
+    if isinstance(obj, list) or cls_name == "_AnsibleLazyTemplateList":
+        return [_deep_unwrap(x) for x in obj]
+
+    return obj
+
+
 def _parse(raw: Any) -> StorageConfig:
     """Validate and parse raw Ansible input into a StorageConfig."""
-    return StorageConfig.model_validate(raw)
+    return StorageConfig.model_validate(_deep_unwrap(raw))
 
 
 def storage_to_cinder_helm_values(raw: Any) -> HelmValues:

--- a/releasenotes/notes/ubuntu-2404-support-5db257c24f87b616.yaml
+++ b/releasenotes/notes/ubuntu-2404-support-5db257c24f87b616.yaml
@@ -1,0 +1,15 @@
+---
+features:
+  - |
+    Added support for Ubuntu 24.04-based Atmosphere deployments.
+fixes:
+  - |
+    Updated Molecule preparation, Magnum image selection, and Kubernetes
+    resource rendering for compatibility with current Ansible versions.
+  - |
+    Fixed Open vSwitch deployments where the virtual IP init container could
+    wait forever for an IPv4 address on ``br-ex`` before the role assigned the
+    managed address.
+  - |
+    Wait for Neutron network availability zones before provisioning configured
+    networks.

--- a/roles/ibm_block_csi_driver/tasks/main.yml
+++ b/roles/ibm_block_csi_driver/tasks/main.yml
@@ -3,9 +3,11 @@
 - name: Deploy CSI
   kubernetes.core.k8s:
     state: present
-    template:
-      - path: ibm-block-csi-operator.yaml.j2
-      - path: csi.ibm.com_v1_ibmblockcsi_cr.yaml.j2
+    definition: >-
+      {{
+        (lookup('ansible.builtin.template', 'ibm-block-csi-operator.yaml.j2') | from_yaml_all | list)
+        + (lookup('ansible.builtin.template', 'csi.ibm.com_v1_ibmblockcsi_cr.yaml.j2') | from_yaml_all | list)
+      }}
 
 - name: Create Secret
   kubernetes.core.k8s:

--- a/roles/ingress/tasks/main.yml
+++ b/roles/ingress/tasks/main.yml
@@ -16,4 +16,4 @@
   run_once: true
   kubernetes.core.k8s:
     state: present
-    template: ingress.yml.j2
+    definition: "{{ lookup('ansible.builtin.template', 'ingress.yml.j2') | from_yaml }}"

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -57,9 +57,9 @@
             #!/bin/sh -x
 
             while true; do
-                ip -4 addr list dev {{ keepalived_interface }} | grep {{ keepalived_interface }}
+                ip link show dev {{ keepalived_interface }} >/dev/null 2>&1
 
-                # We detected an IP address
+                # We detected the interface that keepalived will manage.
                 if [ $? -eq 0 ]; then
                     break
                 fi

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -20,7 +20,14 @@
     namespace: openstack
   register: _pxc_service
 
-- name: Install MySQL python package
+- name: Install MySQL Python package from distro
+  when: ansible_facts['os_family'] == 'Debian'
+  ansible.builtin.package:
+    name: python3-pymysql
+    state: present
+
+- name: Install MySQL Python package with pip
+  when: ansible_facts['os_family'] != 'Debian'
   ansible.builtin.pip:
     name: PyMySQL
   register: _keycloak_pip_install

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -66,7 +66,7 @@
 - name: Create ConfigMap with all OpenID connect configurations
   run_once: true
   kubernetes.core.k8s:
-    template: configmap-openid-metadata.yml.j2
+    definition: "{{ lookup('ansible.builtin.template', 'configmap-openid-metadata.yml.j2') | from_yaml }}"
 
 - name: Create Keycloak clients
   no_log: true

--- a/roles/kube_prometheus_stack/tasks/main.yml
+++ b/roles/kube_prometheus_stack/tasks/main.yml
@@ -306,7 +306,7 @@
   run_once: true
   kubernetes.core.k8s:
     state: "{{ item.state }}"
-    template: configmap-dashboard.yaml.j2
+    definition: "{{ lookup('ansible.builtin.template', 'configmap-dashboard.yaml.j2') | from_yaml }}"
   loop:
     - name: haproxy
       state: present

--- a/roles/neutron/defaults/main.yml
+++ b/roles/neutron/defaults/main.yml
@@ -23,6 +23,10 @@ neutron_helm_values: {}
 # List of networks to provision inside OpenStack
 neutron_networks: []
 
+# List of network availability zones required before provisioning networks.
+neutron_network_availability_zones:
+  - nova
+
 # Class name to use for the Ingress
 neutron_ingress_class_name: "{{ atmosphere_ingress_class_name }}"
 

--- a/roles/neutron/tasks/main.yml
+++ b/roles/neutron/tasks/main.yml
@@ -92,6 +92,23 @@
           type: Available
           status: true
 
+    - name: Wait until network availability zones are ready
+      ansible.builtin.command:
+        cmd: >-
+          {{ ansible_playbook_python }} -c
+          'import openstack;
+          conn = openstack.connect(cloud="atmosphere");
+          print("\n".join(zone.name for zone in conn.network.availability_zones()))'
+      changed_when: false
+      register: _neutron_network_availability_zones
+      retries: 60
+      delay: 5
+      until: >-
+        neutron_network_availability_zones |
+        difference(_neutron_network_availability_zones.stdout_lines) |
+        length == 0
+      when: neutron_network_availability_zones | length > 0
+
     - name: Create networks
       openstack.cloud.network:
         cloud: atmosphere

--- a/roles/openstack_helm_endpoints/tasks/main.yml
+++ b/roles/openstack_helm_endpoints/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: Retrieve list of all the needed endpoints
   ansible.builtin.set_fact:
     openstack_helm_endpoints_list: |-
-      {{ lookup('ansible.builtin.file', '../../../charts/' ~ openstack_helm_endpoints_chart ~ '/values.yaml', split_lines=False) | from_yaml | community.general.json_query('keys(endpoints)') | difference(_openstack_helm_endpoints_ignore) }}
+      {{ (lookup('ansible.builtin.file', '../../../charts/' ~ openstack_helm_endpoints_chart ~ '/values.yaml', split_lines=False) | from_yaml).endpoints.keys() | list | difference(_openstack_helm_endpoints_ignore) }}
   when:
     - openstack_helm_endpoints_chart is defined
 

--- a/roles/openstacksdk/tasks/main.yml
+++ b/roles/openstacksdk/tasks/main.yml
@@ -12,7 +12,16 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Install openstacksdk
+- name: Install openstacksdk from distro
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - openstacksdk_version is not defined
+  ansible.builtin.package:
+    name: python3-openstacksdk
+    state: present
+
+- name: Install openstacksdk with pip
+  when: openstacksdk_version is defined or ansible_facts['os_family'] != 'Debian'
   ansible.builtin.pip:
     name: >-
       {{ 'openstacksdk==' + openstacksdk_version

--- a/roles/openstacksdk/tasks/main.yml
+++ b/roles/openstacksdk/tasks/main.yml
@@ -12,21 +12,21 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Install openstacksdk from distro
-  when:
-    - ansible_facts['os_family'] == 'Debian'
-    - openstacksdk_version is not defined
+- name: Install pip
+  when: ansible_facts['os_family'] == 'Debian'
   ansible.builtin.package:
-    name: python3-openstacksdk
+    name: python3-pip
     state: present
 
 - name: Install openstacksdk with pip
-  when: openstacksdk_version is defined or ansible_facts['os_family'] != 'Debian'
   ansible.builtin.pip:
     name: >-
       {{ 'openstacksdk==' + openstacksdk_version
          if openstacksdk_version is defined
          else 'openstacksdk>1' }}
+    break_system_packages: >-
+      {{ ansible_facts['distribution'] == 'Ubuntu' and
+         ansible_facts['distribution_version'] is version('24.04', '>=') }}
   register: _openstacksdk_pip_install
   retries: 3
   delay: 5

--- a/roles/portworx/tasks/main.yml
+++ b/roles/portworx/tasks/main.yml
@@ -47,9 +47,11 @@
   run_once: true
   kubernetes.core.k8s:
     state: present
-    template:
-      - portworx.yml
-      - config.yml
+    definition: >-
+      {{
+        (lookup('ansible.builtin.template', 'portworx.yml') | from_yaml_all | list)
+        + (lookup('ansible.builtin.template', 'config.yml') | from_yaml_all | list)
+      }}
 
 - name: Wait till the CRDs are created
   run_once: true
@@ -68,6 +70,8 @@
   run_once: true
   kubernetes.core.k8s:
     state: present
-    template:
-      - storage_cluster.yml
-      - storage_class.yml
+    definition: >-
+      {{
+        (lookup('ansible.builtin.template', 'storage_cluster.yml') | from_yaml_all | list)
+        + (lookup('ansible.builtin.template', 'storage_class.yml') | from_yaml_all | list)
+      }}

--- a/tests/unit/plugins/filter/test_storage.py
+++ b/tests/unit/plugins/filter/test_storage.py
@@ -91,6 +91,27 @@ _STORPOOL_BACKEND = {
 }
 
 
+class _LazyValue:
+    def __init__(self, value):
+        self._value = value
+
+
+class _AnsibleLazyTemplateDict(dict):
+    pass
+
+
+def _lazy_storage(raw):
+    if isinstance(raw, dict):
+        return _AnsibleLazyTemplateDict(
+            {_lazy_storage(key): _lazy_storage(value) for key, value in raw.items()}
+        )
+    if isinstance(raw, list):
+        return [_lazy_storage(value) for value in raw]
+    if isinstance(raw, str):
+        return _LazyValue(raw)
+    return raw
+
+
 class TestValidation:
     def test_empty_storage_is_valid(self):
         cfg = StorageConfig.model_validate({})
@@ -1017,6 +1038,12 @@ class TestStorageToLibvirtHelmValues:
 class TestStorageToCephProvisionersHelmValues:
     def test_no_ec_backends(self):
         result = storage_to_ceph_provisioners_helm_values(DEFAULT_STORAGE)
+        assert result == {}
+
+    def test_ansible_lazy_values_are_unwrapped(self):
+        result = storage_to_ceph_provisioners_helm_values(
+            _lazy_storage(DEFAULT_STORAGE)
+        )
         assert result == {}
 
     def test_no_volumes_config(self):


### PR DESCRIPTION
## Summary

Add support for Ubuntu 24.04-based Atmosphere deployments from `main`.

This branch has been rebuilt on `main` and no longer carries the PR #3842 stack.

Depends-On: https://github.com/vexxhost/ansible-collection-ceph/pull/113
Depends-On: https://github.com/vexxhost/atmosphere.common/pull/117

## Changes

- bump the incompatible `ansible.netcommon` Galaxy collection pin for the current Ansible stack
- use `ansible_facts[...]` in Molecule AIO preparation for modern Ansible compatibility
- keep the existing Magnum `_magnum_images` catalog and use `magnum_images: "{{ _magnum_images[-1:] }}"` so Molecule uploads only the newest image
- render affected `kubernetes.core.k8s` templates explicitly through `definition`
- unwrap Ansible lazy template values before validating storage filter inputs
- replace endpoint key discovery via `json_query('keys(endpoints)')` with native Jinja key handling
- fix the Open vSwitch keepalived first-boot deadlock by waiting for the VIP interface to exist before assigning the VIP
- wait for Neutron network availability zones before provisioning configured networks
- keep Ceph fake-device compatibility in the dependent Ceph collection PR instead of adding local fake-device playbooks
- keep `secretgen_controller` template rendering in the dependent `atmosphere.common` PR
- add the Ubuntu 24.04 release note

## Validation

Local main-based branch:

- `git diff --check`
- `pre-commit run black --files plugins/filter/storage.py`
- Python 3.12 `pre-commit run --all-files`: Black, flake8, and isort passed; local ansible-lint bootstrap reached repo linting but failed on unrelated `galaxy[no-changelog]` behavior not seen in GitHub Actions, where Ansible-lint passed
- Python 3.12 focused storage unit test: `6 passed`
- `reno report --output /tmp/atmosphere-pr4009-reno.rst`
- `ansible-playbook --syntax-check molecule/aio/prepare.yml`
- `ansible-playbook --syntax-check molecule/aio/converge.yml`

The syntax checks used a temporary `ANSIBLE_COLLECTIONS_PATH` containing this PR plus dependency PR #113 and `atmosphere.common` PR #117.

Open vSwitch AIO

- initial OVS AIO deploy and Tempest verify completed successfully after adding the Neutron availability-zone wait
- Tempest smoke passed: `Ran: 131`, `Passed: 129`, `Skipped: 2`, `Failed: 0`
- main-based PR tree rerun: `47bf111dd927cea496b5e2ad1c208230ca8f4d12`
- current PR head after CI formatting fix: `42afbf63660a9b82562c79c2eebcc5dac2ab3b59`
- current PR tree after CI formatting fix: `67d1eb9c1eca1164be6f1362013da6eb42c391b5`
- rerun finished with no failed recaps
- Neutron wait executed before network creation, then Neutron completed:
  - `Wait until network availability zones are ready`
  - `Create networks`
  - `==> [neutron] Deployment complete`
- Octavia and Magnum completed on the rerun:
  - `==> [octavia] Deployment complete`
  - `==> [magnum] Deployment complete`
  - `[magnum/magnum] instance : ok=50 changed=5 unreachable=0 failed=0 skipped=21 rescued=0 ignored=0`
- post-rerun checks passed: node Ready, no bad pods, Helm releases deployed, 41 OpenStack endpoints, Nova services up, OVS Neutron agents alive/up, Magnum image active, Ceph PGs active+clean with only the expected AIO no-replica warning
- detailed environment note: `/home/rico/notes/logs/atmosphere/260616.pr4009-ovs-aio-38-108-68-141.md`

Previous validation retained from this PR before the main retarget:

- OVN AIO with dependency PRs installed passed deploy and verify
- dependency PR code was verified in `/root/.ansible/collections` before deploy:
  - `vexxhost.ceph` PR #113 fake-device playbook loops over `ceph_osds` instead of reading `item.invocation.module_args.vg`
  - `atmosphere.common` PR #117 `secretgen_controller` renders `release.yml.tpl` through `lookup('ansible.builtin.template', ...) | from_yaml_all | list`
- Tempest smoke on `.159` passed: `Ran: 164`, `Passed: 163`, `Skipped: 1`, `Failed: 0`
- `.159` provider-network scenario passed: `tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_network_basic_ops ... ok`
- earlier OVS AIO passed `tox -e molecule-aio-openvswitch`
-  Tempest smoke passed: `Ran: 131`, `Passed: 129`, `Skipped: 2`, `Failed: 0`
- post-build checks passed: node Ready, no non-running pods, no non-deployed Helm releases, 41 OpenStack endpoints, Nova services up, OVS Neutron agents up, and expected AIO Ceph no-replica warning only
