### PR TITLE
fix(ci): install docutils only for Vale runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,10 +56,29 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - run: sudo apt-get install -y docutils
-      - uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
         with:
-          files: doc,releasenotes
+          fetch-depth: 0
+      - name: Find changed documentation files
+        id: changed-docs
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            range="origin/${{ github.base_ref }}...HEAD"
+          else
+            range="${{ github.event.before }}...HEAD"
+          fi
+
+          files="$(git diff --name-only --diff-filter=ACMRT "$range" -- doc releasenotes | paste -sd, -)"
+          echo "files=${files}" >> "$GITHUB_OUTPUT"
+      - name: Install documentation lint dependencies
+        if: steps.changed-docs.outputs.files != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docutils
+      - uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
+        if: steps.changed-docs.outputs.files != ''
+        with:
+          files: ${{ steps.changed-docs.outputs.files }}
           separator: ","
           fail_on_error: true
 

--- a/releasenotes/notes/vale-docutils-conditional-install-47e25a92f4efab30.yaml
+++ b/releasenotes/notes/vale-docutils-conditional-install-47e25a92f4efab30.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed the Vale CI job so it refreshes apt metadata before installing
+    documentation lint dependencies, and skips the dependency installation when
+    no documentation or release-note files changed.


### PR DESCRIPTION
## Summary

Make the Vale job prepare its documentation lint dependencies only when there are documentation or release-note files to lint.

## Changes

- fetch full history for the Vale checkout so the job can diff against the base range
- find changed files under `doc` and `releasenotes`
- run `apt-get update` before installing `docutils` to avoid stale hosted-runner apt metadata
- install `docutils` and run Vale only when matching files changed
- add the required release note for the CI cleanup

## Validation

- `git diff --check`
- parsed `.github/workflows/ci.yaml` and the release note with PyYAML
- `vale releasenotes/notes/vale-docutils-conditional-install-47e25a92f4efab30.yaml`
- `uvx reno report --output /tmp/atmosphere-pr4010-reno.rst`

Context: repeated Vale failures on hosted runners were caused by stale apt metadata while installing `docutils`; this keeps the apt refresh and avoids the install entirely when Vale has no files to lint.