### PR TITLE
ci(zuul): skip molecule jobs for docs changes

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -28,6 +28,9 @@
     nodeset: atmosphere-ubuntu-jammy-single-node
     pre-run: test-playbooks/molecule/pre.yml
     post-run: test-playbooks/molecule/post.yml
+    irrelevant-files:
+      - ^doc/.*$
+      - ^releasenotes/.*$
     required-projects:
       - ansible-collections/ansible.netcommon
       - ansible-collections/ansible.posix


### PR DESCRIPTION
## Summary
- Add `doc/` and `releasenotes/` as irrelevant files on the abstract `atmosphere-molecule` Zuul job.
- Let the existing molecule job variants inherit the skip behavior without duplicating pipeline entries.

## Testing
- `nix-shell -p ruby --run "ruby -e 'require \"yaml\"; YAML.load_file(\".zuul.yaml\", aliases: true); puts \"YAML OK\"'"`
- `git diff --check`