### PR TITLE
[Backport stable/zed] fix(networking): retry OVN and OVS image pulls

### DIFF
--- a/releasenotes/notes/retry-ovn-openvswitch-image-pulls-7f60fb42c0f54d23.yaml
+++ b/releasenotes/notes/retry-ovn-openvswitch-image-pulls-7f60fb42c0f54d23.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The OVN image pre-pull task now retries transient `crictl pull` failures
+    before failing the deployment.

--- a/roles/ovn/tasks/main.yml
+++ b/roles/ovn/tasks/main.yml
@@ -44,6 +44,9 @@
       ansible.builtin.command: crictl pull {{ atmosphere_images['ovn_controller'] }}
       register: pull_result
       changed_when: false
+      retries: 5
+      delay: 10
+      until: pull_result.rc == 0
 
     - name: Verify ovn-controller image pull
       ansible.builtin.assert:


### PR DESCRIPTION
# Description

Backport of #3998 to `stable/zed`.

This branch only has the OVN image pre-pull task, so the Open vSwitch hunk from the original change is not applicable here.
