### PR TITLE
fix(tempest): assign member role to dynamic users

### DIFF
--- a/releasenotes/notes/tempest-dynamic-member-role-1068cb2f41c6f1a9.yaml
+++ b/releasenotes/notes/tempest-dynamic-member-role-1068cb2f41c6f1a9.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Tempest now gives generated test users the ``member`` role, preventing
+    intermittent Horizon dashboard login failures during smoke tests.

--- a/roles/tempest/vars/main.yml
+++ b/roles/tempest/vars/main.yml
@@ -25,6 +25,9 @@ _tempest_helm_values:
       include_app_kubernetes_io: false
   conf:
     tempest:
+      auth:
+        tempest_roles:
+          - member
       service_available:
         cinder: true
         glance: true


### PR DESCRIPTION
## Summary
- Configure Tempest dynamic credentials to receive the `member` role.
- Add a release note for the Tempest/Horizon smoke test fix.

## Root Cause
Zuul build `a1e66a84bf3f454b9f91ed2f2966ef17` failed in `atmosphere-molecule-aio-openvswitch` because `tempest.scenario.test_dashboard_basic_ops.TestDashboardBasicOps.test_basic_scenario` logged into Horizon successfully, then Horizon returned `403` for `/project/`. The same buildset had a passing `atmosphere-molecule-aio-ovn` job, matching the intermittent failure pattern.

The rendered failing `tempest.conf` had `use_dynamic_credentials = true` and no `[auth] tempest_roles`, so Tempest-generated test users had no guaranteed project role. Horizon defaults project users to the `member` role, so this gives generated users that role explicitly.

Fixes #4057

## Validation
- Inspected the Zuul buildset and failing Tempest/Horizon logs via the Zuul API and archived artifacts.
- `git diff --cached --check`
- `nix develop --command reno report --no-show-source --output /tmp/reno-report.txt`
- Rendered the Tempest chart with the new role override and confirmed it emits `tempest_roles = member`.