### PR TITLE
ci(pre-commit): pin ansible-core for ansible-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,3 +46,5 @@ repos:
     rev: v25.6.1
     hooks:
       - id: ansible-lint
+        additional_dependencies:
+          - ansible-core==2.18.6


### PR DESCRIPTION
## Summary
- pin the ansible-lint pre-commit hook to ansible-core 2.18.6