### PR TITLE
feat(monitoring): add host network failure alerts

### DIFF
--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -710,6 +710,125 @@ talking with ``etcd`` with the following commands:
       --from-file=/etc/kubernetes/pki/etcd/healthcheck-client.crt \
       --from-file=/etc/kubernetes/pki/etcd/healthcheck-client.key
 
+``NodeBondingDegraded``
+=======================
+
+This alert fires when ``node-exporter`` reports that a bonded interface has
+fewer active slaves than configured slaves for more than 1 minute:
+
+.. code-block:: text
+
+  node_bonding_slaves - node_bonding_active != 0
+
+This is an early host-network signal. If the affected bond carries management,
+storage, or tenant underlay traffic, it can precede downstream alerts such as
+``KubeNodeNotReady``, ``KubeNodeUnreachable``, ``CephOSDDownHigh``, or Ceph
+heartbeat failures.
+
+**Likely Root Causes**
+
+- Physical ``NIC`` carrier loss, switch port failure, cable or optic issue.
+- ``NIC`` driver or firmware failure that causes a slave to stop transmitting.
+- ``PCIe`` device hang or host hardware fault affecting the ``NIC``.
+- Intentional maintenance on one side of a redundant bond.
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected node and bond:
+
+   .. code-block:: console
+
+     kubectl -n monitoring exec svc/kube-prometheus-stack-prometheus -- \
+       promtool query instant http://localhost:9090 \
+       'node_bonding_slaves{job="node-exporter"} - node_bonding_active{job="node-exporter"}'
+
+2. On the node, inspect bond state and slave status:
+
+   .. code-block:: console
+
+     cat /proc/net/bonding/<bond-name>
+     ip -d link show <bond-name>
+     ip -d link show <slave-interface>
+
+3. Check the kernel log for driver, queue timeout, carrier, or bond events:
+
+   .. code-block:: console
+
+     journalctl -k --since "30 minutes ago" | \
+       egrep -i 'NETDEV WATCHDOG|tx_timeout|link status|lost carrier|bond|i40e|ice|ixgbe|mlx5'
+
+4. Check physical ``NIC`` counters and driver details:
+
+   .. code-block:: console
+
+     ethtool -i <slave-interface>
+     ethtool -S <slave-interface> | \
+       egrep -i 'timeout|error|drop|reset|link|tx|rx'
+
+5. If this is not planned maintenance, move traffic away from the host before
+   invasive actions. For compute/storage nodes, cordon or drain workloads as
+   appropriate, confirm Ceph placement state, then reseat/replace cabling,
+   switch ports, optics, or update ``NIC`` firmware/driver according to the
+   failure evidence.
+
+``NodePhysicalNetworkTransmitErrors``
+=====================================
+
+This alert fires when a physical interface, identified through
+``node_ethtool_info``, records any transmit errors over a 5-minute window for
+more than 5 minutes. The alert excludes virtual and aggregate drivers such as
+``bonding``, ``geneve``, ``veth``, ``bridge``, ``vxlan``, and ``dummy`` so that
+it focuses on the underlay ``NIC`` device.
+
+Transmit errors on production underlay interfaces should be zero. Even a small
+burst can be an early warning for the same failure class that later appears as
+bond degradation, missed Ceph heartbeats, or Kubernetes node reachability loss.
+
+**Likely Root Causes**
+
+- ``NIC`` driver or firmware queue timeout.
+- Link partner, switch port, optic, or cable fault.
+- ``PCIe`` or hardware fault affecting the adapter.
+- Bad offload interaction or device reset under load.
+
+**Diagnostic and Remediation Steps**
+
+1. Identify the affected node, interface, driver, and error count:
+
+   .. code-block:: console
+
+     kubectl -n monitoring exec svc/kube-prometheus-stack-prometheus -- \
+       promtool query instant http://localhost:9090 \
+       '(increase(node_network_transmit_errs_total{job="node-exporter"}[5m])
+         * on(instance, device) group_left(driver)
+         node_ethtool_info{job="node-exporter"})'
+
+2. On the node, inspect the interface driver, firmware, and statistics:
+
+   .. code-block:: console
+
+     ethtool -i <interface>
+     ethtool -S <interface> | \
+       egrep -i 'timeout|error|drop|reset|link|tx|rx'
+
+3. Correlate with kernel and bond logs:
+
+   .. code-block:: console
+
+     journalctl -k --since "30 minutes ago" | \
+       egrep -i 'NETDEV WATCHDOG|tx_timeout|disable timeout|lost carrier|bond|i40e|ice|ixgbe|mlx5'
+
+4. If the interface is a bond slave, inspect the bond:
+
+   .. code-block:: console
+
+     grep -R . /proc/net/bonding/
+
+5. If errors continue or the host also shows bond degradation, treat it as an
+   underlay-host fault. Move workloads away where possible, preserve logs, then
+   remediate the physical path, switch port, ``NIC`` firmware/driver, or host
+   hardware based on the evidence.
+
 ``GeneveTransmitErrors``
 ========================
 

--- a/releasenotes/notes/add-host-network-failure-alerts-4b244ec365065918.yaml
+++ b/releasenotes/notes/add-host-network-failure-alerts-4b244ec365065918.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Adds faster host network failure detection to ``kube-prometheus-stack`` by
+    alerting on degraded bond interfaces after 1 minute and on physical
+    ``NIC`` transmit errors reported by ``node-exporter`` and ``ethtool``
+    metrics.

--- a/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
@@ -236,6 +236,13 @@ local mixins = {
                   description: 'Computed node memory utilization at {{ $labels.instance }} is {{ printf "%.2f" $value }}%, exceeding the threshold of 90% for 15 minutes. This computation includes free huge page capacity (node_memory_HugePages_Free * node_memory_Hugepagesize_bytes) in available memory to avoid false positives on compute nodes backed by huge pages. Normal behavior is below 90% sustained utilization.',
                   runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodememoryhighutilization',
                 },
+              } else if rule.alert == 'NodeBondingDegraded' then rule {
+                'for': '1m',
+                annotations+: {
+                  summary: 'Node network: bond interface degraded',
+                  description: 'Bond {{ $labels.master }} on {{ $labels.instance }} has fewer active slaves than configured slaves for more than 1 minute. This can precede node unreachable, Ceph heartbeat, and Kubernetes NotReady alerts when the bond carries management or storage traffic.',
+                  runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodebondingdegraded',
+                },
               } else rule
               for rule in group.rules
             ],
@@ -290,6 +297,25 @@ local mixins = {
                   summary: 'Node disk: high IO latency affecting workloads',
                   description: 'Average IO latency on {{ $labels.device }} at {{ $labels.instance }} is {{ $value | humanizeDuration }} over the last 5 minutes, which exceeds the threshold of 20ms. Normal SSD latency is below 1ms and normal HDD latency is below 15ms.',
                   runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodediskhighlatency',
+                },
+              },
+              {
+                alert: 'NodePhysicalNetworkTransmitErrors',
+                expr: |||
+                  (
+                    increase(node_network_transmit_errs_total{%(nodeExporterSelector)s}[5m])
+                    * on(instance, device) group_left(driver)
+                    node_ethtool_info{%(nodeExporterSelector)s, driver!~"^(bonding|bridge|dummy|geneve|tun|tap|veth|vxlan|openvswitch)$"}
+                  ) > 0
+                ||| % mixins.node._config,
+                'for': '5m',
+                labels: {
+                  severity: 'warning',
+                },
+                annotations: {
+                  summary: 'Node network: physical interface transmit errors',
+                  description: '{{ $labels.instance }} physical interface {{ $labels.device }} using driver {{ $labels.driver }} recorded {{ printf "%.0f" $value }} transmit errors in the last 5 minutes. Normal behavior is zero transmit errors on production underlay interfaces; driver, firmware, cable, switch port, or PCIe issues can make the host unreachable before Kubernetes or Ceph alerts fire.',
+                  runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodephysicalnetworktransmiterrors',
                 },
               },
             ],

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -235,11 +235,11 @@ tests:
   - interval: 1m
     input_series:
       - series: 'mysql_up{instance="percona-xtradb-pxc-0", job="pxc"}'
-        values: '1'
+        values: '1x6'
       - series: 'mysql_up{instance="percona-xtradb-pxc-1", job="pxc"}'
-        values: '1'
+        values: '1x6'
       - series: 'mysql_up{instance="percona-xtradb-pxc-2", job="pxc"}'
-        values: '0'
+        values: '0x6'
     alert_rule_test:
       - eval_time: 5m
         alertname: MysqlClusterDown
@@ -255,11 +255,11 @@ tests:
   - interval: 1m
     input_series:
       - series: 'mysql_up{instance="percona-xtradb-pxc-0", job="pxc"}'
-        values: '1'
+        values: '1x6'
       - series: 'mysql_up{instance="percona-xtradb-pxc-1", job="pxc"}'
-        values: '0'
+        values: '0x6'
       - series: 'mysql_up{instance="percona-xtradb-pxc-2", job="pxc"}'
-        values: '0'
+        values: '0x6'
     alert_rule_test:
       - eval_time: 5m
         alertname: MysqlClusterDown
@@ -1550,3 +1550,78 @@ tests:
               summary: "Geneve overlay: transmit failures may affect tenant traffic on a compute host"
               description: "192.0.2.10:9100 interface tenant-geneve0 has averaged 3.33 transmit errors per second over the last 5 minutes (threshold > 1.67/s, ~100/min). Normal behavior is zero sustained transmit errors on Geneve tunnel interfaces."
               runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#genevetransmiterrors"
+
+  # NodeBondingDegraded - should NOT fire when all slaves are active
+  - interval: 1m
+    input_series:
+      - series: 'node_bonding_slaves{job="node-exporter",instance="192.0.2.20:9100",master="bond0"}'
+        values: '2x5'
+      - series: 'node_bonding_active{job="node-exporter",instance="192.0.2.20:9100",master="bond0"}'
+        values: '2x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: NodeBondingDegraded
+        exp_alerts: []
+
+  # NodeBondingDegraded - should fire quickly when a bonded uplink loses a slave
+  - interval: 1m
+    input_series:
+      - series: 'node_bonding_slaves{job="node-exporter",instance="192.0.2.21:9100",master="bond0"}'
+        values: '2x5'
+      - series: 'node_bonding_active{job="node-exporter",instance="192.0.2.21:9100",master="bond0"}'
+        values: '1x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: NodeBondingDegraded
+        exp_alerts:
+          - exp_labels:
+              job: node-exporter
+              instance: 192.0.2.21:9100
+              master: bond0
+              severity: P3
+            exp_annotations:
+              summary: "Node network: bond interface degraded"
+              description: "Bond bond0 on 192.0.2.21:9100 has fewer active slaves than configured slaves for more than 1 minute. This can precede node unreachable, Ceph heartbeat, and Kubernetes NotReady alerts when the bond carries management or storage traffic."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodebondingdegraded"
+
+  # NodePhysicalNetworkTransmitErrors - should NOT fire for virtual devices or idle physical devices
+  - interval: 1m
+    input_series:
+      - series: 'node_network_transmit_errs_total{job="node-exporter",instance="192.0.2.30:9100",device="genev_sys_6081"}'
+        values: '0+10x10'
+      - series: 'node_ethtool_info{job="node-exporter",instance="192.0.2.30:9100",device="genev_sys_6081",driver="geneve"}'
+        values: '1x10'
+      - series: 'node_network_transmit_errs_total{job="node-exporter",instance="192.0.2.31:9100",device="enp1s0f0"}'
+        values: '0+0x10'
+      - series: 'node_ethtool_info{job="node-exporter",instance="192.0.2.31:9100",device="enp1s0f0",driver="i40e"}'
+        values: '1x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NodePhysicalNetworkTransmitErrors
+        exp_alerts: []
+
+  # NodePhysicalNetworkTransmitErrors - should fire for physical NIC transmit errors
+  - interval: 1m
+    input_series:
+      - series: 'node_network_transmit_errs_total{job="node-exporter",instance="192.0.2.32:9100",device="enp69s0f0"}'
+        values: '0+10x10'
+      - series: 'node_ethtool_info{job="node-exporter",instance="192.0.2.32:9100",device="enp69s0f0",driver="i40e"}'
+        values: '1x10'
+      - series: 'node_network_transmit_errs_total{job="node-exporter",instance="192.0.2.33:9100",device="bond0"}'
+        values: '0+10x10'
+      - series: 'node_ethtool_info{job="node-exporter",instance="192.0.2.33:9100",device="bond0",driver="bonding"}'
+        values: '1x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NodePhysicalNetworkTransmitErrors
+        exp_alerts:
+          - exp_labels:
+              job: node-exporter
+              instance: 192.0.2.32:9100
+              device: enp69s0f0
+              driver: i40e
+              severity: P3
+            exp_annotations:
+              summary: "Node network: physical interface transmit errors"
+              description: "192.0.2.32:9100 physical interface enp69s0f0 using driver i40e recorded 50 transmit errors in the last 5 minutes. Normal behavior is zero transmit errors on production underlay interfaces; driver, firmware, cable, switch port, or PCIe issues can make the host unreachable before Kubernetes or Ceph alerts fire."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodephysicalnetworktransmiterrors"


### PR DESCRIPTION
## Summary

- tune `NodeBondingDegraded` to alert after 1 minute with a production runbook
- add `NodePhysicalNetworkTransmitErrors` for physical NIC transmit errors using existing `node-exporter` and `ethtool` metrics
- add promtool coverage, monitoring documentation, and a reno release note
- fix two existing MySQL alert fixtures so the full rule suite passes with sustained `for: 5m` conditions

## Why

Bond failure can precede Kubernetes node unreachable alerts by roughly 16 minutes. These alerts are vendor-neutral and fit all production environments because they use the kube-prometheus-stack/node-exporter path already deployed by Atmosphere.

## Validation

- `go test ./roles/kube_prometheus_stack`
- `git diff --check HEAD~1..HEAD`