### PR TITLE
ci(molecule): use shared molecule templates

### DIFF
--- a/molecule/aio/inventory/group_vars/all/molecule.yml
+++ b/molecule/aio/inventory/group_vars/all/molecule.yml
@@ -1,0 +1,226 @@
+atmosphere_image_prefix: "harbor.atmosphere.dev/"
+atmosphere_network_backend: "{{ lookup('env', 'ATMOSPHERE_NETWORK_BACKEND') | default('ovn', True) }}"
+
+ceph_version: 18.2.7
+ceph_fsid: 4837cbf8-4f90-4300-b3f6-726c9b9f89b4
+ceph_conf_overrides:
+  - section: global
+    option: mon allow pool size one
+    value: true
+  - section: global
+    option: osd crush chooseleaf type
+    value: 0
+  - section: mon
+    option: auth allow insecure global id reclaim
+    value: false
+ceph_osd_devices:
+  - "/dev/ceph-{{ inventory_hostname_short }}-osd0/data"
+  - "/dev/ceph-{{ inventory_hostname_short }}-osd1/data"
+  - "/dev/ceph-{{ inventory_hostname_short }}-osd2/data"
+
+kube_vip_interface: "{{ ansible_facts['default_ipv4'].interface }}"
+kube_vip_address: 172.17.0.100
+
+kubernetes_hostname: "{{ ansible_facts['default_ipv4'].address }}"
+kubernetes_keepalived_interface: lo
+
+csi_driver: "{{ lookup('env', 'MOLECULE_CSI_DRIVER') | default('local-path-provisioner', True) }}"
+
+cilium_helm_values:
+  operator:
+    replicas: 1
+
+ceph_csi_rbd_helm_values:
+  provisioner:
+    replicaCount: 1
+
+cluster_issuer_type: self-signed
+
+valkey_helm_values:
+  replica:
+    replicaCount: 1
+
+ingress_nginx_helm_values:
+  controller:
+    config:
+      worker-processes: 2
+
+percona_xtradb_cluster_spec:
+  allowUnsafeConfigurations: true
+  pxc:
+    size: 1
+  haproxy:
+    size: 1
+
+keystone_helm_values:
+  pod:
+    replicas:
+      api: 1
+
+barbican_helm_values:
+  pod:
+    replicas:
+      api: 1
+
+rook_ceph_cluster_radosgw_spec:
+  metadataPool:
+    failureDomain: osd
+  dataPool:
+    failureDomain: osd
+  gateway:
+    instances: 1
+
+glance_helm_values:
+  conf:
+    glance:
+      DEFAULT:
+        workers: 2
+      glance_store:
+        rbd_store_replication: 1
+  pod:
+    replicas:
+      api: 1
+
+glance_images:
+  - name: cirros
+    url: http://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
+    min_disk: 1
+    disk_format: raw
+    container_format: bare
+    is_public: true
+
+staffeln_helm_values:
+  pod:
+    replicas:
+      api: 1
+      conductor: 1
+
+cinder_helm_values:
+  conf:
+    ceph:
+      pools:
+        backup:
+          replication: 1
+        cinder.volumes:
+          replication: 1
+    cinder:
+      DEFAULT:
+        osapi_volume_workers: 2
+  pod:
+    replicas:
+      api: 1
+      scheduler: 1
+
+placement_helm_values:
+  conf:
+    placement_api_uwsgi:
+      uwsgi:
+        processes: 2
+  pod:
+    replicas:
+      api: 1
+
+ovn_helm_values:
+  conf:
+    auto_bridge_add:
+      br-ex: null
+  pod:
+    replicas:
+      ovn_ovsdb_nb: 1
+      ovn_ovsdb_sb: 1
+      ovn_northd: 1
+
+coredns_helm_values:
+  replicaCount: 1
+
+nova_helm_values:
+  conf:
+    nova:
+      DEFAULT:
+        osapi_compute_workers: 2
+        metadata_workers: 2
+      conductor:
+        workers: 2
+      scheduler:
+        workers: 2
+  pod:
+    replicas:
+      api_metadata: 1
+      osapi: 1
+      conductor: 1
+      scheduler: 1
+      novncproxy: 1
+      spiceproxy: 1
+
+neutron_helm_values:
+  conf:
+    neutron:
+      DEFAULT:
+        api_workers: 2
+        rpc_workers: 2
+        metadata_workers: 2
+  pod:
+    replicas:
+      server: 1
+      rpc_server: 1
+
+heat_helm_values:
+  conf:
+    heat:
+      DEFAULT:
+        num_engine_workers: 2
+      heat_api:
+        workers: 2
+      heat_api_cfn:
+        workers: 2
+      heat_api_cloudwatch:
+        workers: 2
+  pod:
+    replicas:
+      api: 1
+      cfn: 1
+      cloudwatch: 1
+      engine: 1
+
+octavia_helm_values:
+  conf:
+    octavia:
+      controller_worker:
+        workers: 2
+    octavia_api_uwsgi:
+      uwsgi:
+        processes: 2
+  pod:
+    replicas:
+      api: 1
+      worker: 1
+      housekeeping: 1
+
+magnum_image_disk_format: qcow2
+magnum_images: "[ {{ _magnum_images[-1] }} ]"
+magnum_helm_values:
+  conf:
+    magnum:
+      api:
+        workers: 2
+      conductor:
+        workers: 2
+  pod:
+    replicas:
+      api: 1
+      conductor: 1
+
+manila_helm_values:
+  conf:
+    manila:
+      DEFAULT:
+        osapi_share_workers: 2
+  pod:
+    replicas:
+      api: 1
+      scheduler: 1
+
+horizon_helm_values:
+  pod:
+    replicas:
+      server: 1

--- a/molecule/aio/molecule.yml
+++ b/molecule/aio/molecule.yml
@@ -11,4 +11,4 @@ ansible:
     backend: ansible-playbook
     args:
       ansible_playbook:
-        - --inventory=${MOLECULE_PROJECT_DIRECTORY}/inventory.yaml
+        - --inventory=${MOLECULE_SCENARIO_DIRECTORY}/inventory/

--- a/molecule/aio/prepare.yml
+++ b/molecule/aio/prepare.yml
@@ -31,47 +31,8 @@
 - name: Generate workspace
   ansible.builtin.import_playbook: vexxhost.atmosphere.generate_workspace
   vars:
-    workspace_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
+    workspace_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/inventory"
     domain_name: "{{ ansible_default_ipv4['address'].replace('.', '-') }}.nip.io"
-
-- name: Setup networking
-  hosts: all
-  become: true
-  vars:
-    management_bridge: "br-mgmt"
-  tasks:
-    - name: Create bridge for management network
-      ignore_errors: true # noqa: ignore-errors
-      changed_when: false
-      ansible.builtin.command:
-        cmd: "ip link add name {{ management_bridge }} type bridge"
-
-    - name: Create fake interface for management bridge
-      ignore_errors: true # noqa: ignore-errors
-      changed_when: false
-      ansible.builtin.command:
-        cmd: "ip link add dummy0 type dummy"
-
-    - name: Assign dummy interface to management bridge
-      ignore_errors: true # noqa: ignore-errors
-      changed_when: false
-      ansible.builtin.command:
-        cmd: "ip link set dummy0 master {{ management_bridge }}"
-
-    - name: Assign IP address for management bridge
-      ignore_errors: true # noqa: ignore-errors
-      changed_when: false
-      ansible.builtin.command:
-        cmd: "ip addr add 10.96.240.200/24 dev {{ management_bridge }}"
-
-    - name: Bring up interfaces
-      ignore_errors: true # noqa: ignore-errors
-      changed_when: false
-      ansible.builtin.command:
-        cmd: "ip link set {{ item }} up"
-      loop:
-        - br-mgmt
-        - dummy0
 
 - name: Create fake devices for Ceph
   ansible.builtin.import_playbook: vexxhost.ceph.create_fake_devices

--- a/molecule/aio/prepare.yml
+++ b/molecule/aio/prepare.yml
@@ -34,6 +34,9 @@
     workspace_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/inventory"
     domain_name: "{{ ansible_default_ipv4['address'].replace('.', '-') }}.nip.io"
 
+- name: Setup management networking
+  ansible.builtin.import_playbook: ../shared/prepare/management-network.yml
+
 - name: Create fake devices for Ceph
   ansible.builtin.import_playbook: vexxhost.ceph.create_fake_devices
 

--- a/molecule/csi/group_vars
+++ b/molecule/csi/group_vars
@@ -1,1 +1,0 @@
-../aio/group_vars/

--- a/molecule/csi/host_vars
+++ b/molecule/csi/host_vars
@@ -1,1 +1,0 @@
-../aio/host_vars/

--- a/molecule/csi/inventory
+++ b/molecule/csi/inventory
@@ -1,0 +1,1 @@
+../aio/inventory/

--- a/molecule/csi/molecule.yml
+++ b/molecule/csi/molecule.yml
@@ -1,14 +1,1 @@
-# Copyright (c) 2025 VEXXHOST, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-ansible:
-  cfg:
-    defaults:
-      callbacks_enabled: ansible.posix.profile_tasks
-    connection:
-      pipelining: true
-  executor:
-    backend: ansible-playbook
-    args:
-      ansible_playbook:
-        - --inventory=${MOLECULE_PROJECT_DIRECTORY}/inventory.yaml
+../aio/molecule.yml

--- a/molecule/csi/prepare.yml
+++ b/molecule/csi/prepare.yml
@@ -25,5 +25,8 @@
         state: absent
         purge: true
 
+- name: Setup management networking
+  ansible.builtin.import_playbook: ../shared/prepare/management-network.yml
+
 - name: Create fake devices for Ceph
   ansible.builtin.import_playbook: vexxhost.ceph.create_fake_devices

--- a/molecule/keycloak/inventory
+++ b/molecule/keycloak/inventory
@@ -1,0 +1,1 @@
+../aio/inventory/

--- a/molecule/keycloak/prepare.yml
+++ b/molecule/keycloak/prepare.yml
@@ -42,7 +42,7 @@
 - name: Generate workspace
   ansible.builtin.import_playbook: vexxhost.atmosphere.generate_workspace
   vars:
-    workspace_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
+    workspace_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/inventory"
     domain_name: "{{ ansible_default_ipv4['address'].replace('.', '-') }}.nip.io"
 
 - name: Install Kubernetes

--- a/molecule/keycloak/prepare.yml
+++ b/molecule/keycloak/prepare.yml
@@ -45,6 +45,9 @@
     workspace_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/inventory"
     domain_name: "{{ ansible_default_ipv4['address'].replace('.', '-') }}.nip.io"
 
+- name: Setup management networking
+  ansible.builtin.import_playbook: ../shared/prepare/management-network.yml
+
 - name: Install Kubernetes
   ansible.builtin.import_playbook: vexxhost.atmosphere.kubernetes
 

--- a/molecule/shared/prepare/management-network.yml
+++ b/molecule/shared/prepare/management-network.yml
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Setup management networking
+  hosts: all
+  become: true
+  vars:
+    management_bridge: "br-mgmt"
+  tasks:
+    - name: Create bridge for management network
+      ignore_errors: true # noqa: ignore-errors
+      changed_when: false
+      ansible.builtin.command:
+        cmd: "ip link add name {{ management_bridge }} type bridge"
+
+    - name: Create fake interface for management bridge
+      ignore_errors: true # noqa: ignore-errors
+      changed_when: false
+      ansible.builtin.command:
+        cmd: "ip link add dummy0 type dummy"
+
+    - name: Assign dummy interface to management bridge
+      ignore_errors: true # noqa: ignore-errors
+      changed_when: false
+      ansible.builtin.command:
+        cmd: "ip link set dummy0 master {{ management_bridge }}"
+
+    - name: Assign IP address for management bridge
+      ignore_errors: true # noqa: ignore-errors
+      changed_when: false
+      ansible.builtin.command:
+        cmd: "ip addr add 10.96.240.200/24 dev {{ management_bridge }}"
+
+    - name: Bring up interfaces
+      ignore_errors: true # noqa: ignore-errors
+      changed_when: false
+      ansible.builtin.command:
+        cmd: "ip link set {{ item }} up"
+      loop:
+        - "{{ management_bridge }}"
+        - dummy0


### PR DESCRIPTION
## Summary

- Replace the inline Zuul Molecule job definitions with shared job templates.
- Add shared Molecule group variables for the AIO scenario.
- Reuse the AIO group variables from the Keycloak scenario.

Depends-On: https://github.com/vexxhost/atmosphere-zuul-jobs/pull/3

## Testing

- `git diff --check origin/main...HEAD`