### PR TITLE
fix(galaxy): constrain atmosphere.common on stable 2023.1

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,7 +16,7 @@ dependencies:
   community.mysql: 3.6.0
   kubernetes.core: 2.4.0
   openstack.cloud: 1.7.0
-  atmosphere.common: ">=0.6.0"
+  atmosphere.common: ">=0.6.0,<0.7.0"
   vexxhost.ceph: ">=3.1.2"
   vexxhost.kubernetes: ">=3.2.0"
 tags:


### PR DESCRIPTION
## Summary
- constrain atmosphere.common below 0.7.0 on stable/2023.1
- keep dependency resolution compatible with openstack.cloud 1.7.0