### PR TITLE
feat(cert_manager): configure OCI chart version

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,7 +18,7 @@ dependencies:
   openstack.cloud: ">=2.0.0"
   vexxhost.ceph: ">=3.2.0"
   atmosphere.common: ">=0.7.0"
-  vexxhost.kubernetes: ">=3.2.0"
+  vexxhost.kubernetes: ">=3.3.0"
 tags:
   - application
   - cloud

--- a/releasenotes/notes/cert-manager-oci-chart-47dfd2720b522f2d.yaml
+++ b/releasenotes/notes/cert-manager-oci-chart-47dfd2720b522f2d.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The cert-manager Helm chart is now managed through
+    ``atmosphere_images['cert_manager_helm_chart']`` and installed from OCI.

--- a/roles/cert_manager/tasks/main.yml
+++ b/roles/cert_manager/tasks/main.yml
@@ -16,10 +16,19 @@
   ansible.builtin.include_role:
     name: vexxhost.kubernetes.cert_manager
   vars:
+    cert_manager_helm_chart_repository: >-
+      oci://{{ atmosphere_images['cert_manager_helm_chart'] |
+      vexxhost.kubernetes.docker_image('name') }}
+    cert_manager_helm_chart_version: >-
+      {{ atmosphere_images['cert_manager_helm_chart'] |
+      vexxhost.kubernetes.docker_image('tag') }}
     cert_manager_image_cli: "{{ atmosphere_images['cert_manager_cli'] }}"
     cert_manager_image_controller: "{{ atmosphere_images['cert_manager_controller'] }}"
     cert_manager_image_cainjector: "{{ atmosphere_images['cert_manager_cainjector'] }}"
     cert_manager_image_webhook: "{{ atmosphere_images['cert_manager_webhook'] }}"
     cert_manager_image_acmesolver: "{{ atmosphere_images['cert_manager_acmesolver'] }}"
+    cert_manager_image_startupapicheck: >-
+      {{ atmosphere_images['cert_manager_startupapicheck'] |
+      default(atmosphere_images['cert_manager_cli']) }}
     cert_manager_node_selector:
       openstack-control-plane: enabled

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -21,6 +21,7 @@ _atmosphere_images:
   bootstrap: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/heat:main@sha256:3be2b3d1ab07714491f915307416d288783e484669a4b58a8fe3b7412b97044c"
   ceph_config_helper: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/libvirtd:main@sha256:3d8ac580f9a3235c9fdd27cda89717a651e34c9b029ae884d8b3fdbcc7bde2a8"
   ceph: "{{ atmosphere_image_prefix }}quay.io/ceph/ceph:v18.2.7"
+  cert_manager_helm_chart: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/charts/cert-manager:v1.11.5"
   cert_manager_cainjector: "{{ atmosphere_image_prefix }}quay.io/jetstack/cert-manager-cainjector:v1.12.17"
   cert_manager_cli: "{{ atmosphere_image_prefix }}quay.io/jetstack/cert-manager-ctl:v1.12.17"
   cert_manager_controller: "{{ atmosphere_image_prefix }}quay.io/jetstack/cert-manager-controller:v1.12.17"


### PR DESCRIPTION
## Summary

- add `_atmosphere_images.cert_manager_helm_chart` for the cert-manager OCI Helm chart ref
- derive `cert_manager_helm_chart_repository` and `cert_manager_helm_chart_version` from that `atmosphere_images` entry when including `vexxhost.kubernetes.cert_manager`
- require `vexxhost.kubernetes >=3.3.0` so the OCI chart implementation is used
- add a release note for the OCI chart change

## Testing

- `git diff --check`
- `nix develop --command env CGO_ENABLED=0 go test ./roles/defaults -run TestImageHasPrefix`
- `nix develop --command crane digest ghcr.io/vexxhost/charts/cert-manager:v1.11.5`
- `nix develop --command env PRE_COMMIT_HOME=/tmp/pre-commit-atmosphere-cert-manager pre-commit run end-of-file-fixer --files galaxy.yml roles/defaults/vars/main.yml roles/cert_manager/tasks/main.yml releasenotes/notes/cert-manager-oci-chart-47dfd2720b522f2d.yaml doc/source/deploy/certificates.rst`
- `nix develop --command env PRE_COMMIT_HOME=/tmp/pre-commit-atmosphere-cert-manager pre-commit run trailing-whitespace --files galaxy.yml roles/defaults/vars/main.yml roles/cert_manager/tasks/main.yml releasenotes/notes/cert-manager-oci-chart-47dfd2720b522f2d.yaml doc/source/deploy/certificates.rst`
- `nix develop --command env PRE_COMMIT_HOME=/tmp/pre-commit-atmosphere-cert-manager pre-commit run mixed-line-ending --files galaxy.yml roles/defaults/vars/main.yml roles/cert_manager/tasks/main.yml releasenotes/notes/cert-manager-oci-chart-47dfd2720b522f2d.yaml doc/source/deploy/certificates.rst`

`ansible-lint` currently cannot resolve `vexxhost.kubernetes >=3.3.0` from Galaxy until the dependent collection release PR lands, which is why this PR is linked with Zuul `Depends-On`.

Depends-On: https://github.com/vexxhost/ansible-collection-kubernetes/pull/285