### PR TITLE
[Backport stable/zed] feat(cert_manager): configure OCI chart version

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,7 +18,7 @@ dependencies:
   openstack.cloud: 1.7.0
   atmosphere.common: ">=0.6.0"
   vexxhost.ceph: ">=3.1.2"
-  vexxhost.kubernetes: ">=3.2.0"
+  vexxhost.kubernetes: ">=3.3.0"
 tags:
   - application
   - cloud

--- a/releasenotes/notes/cert-manager-oci-chart-47dfd2720b522f2d.yaml
+++ b/releasenotes/notes/cert-manager-oci-chart-47dfd2720b522f2d.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The cert-manager Helm chart is now managed through
+    ``atmosphere_images['cert_manager_helm_chart']`` and installed from OCI.

--- a/roles/cert_manager/tasks/main.yml
+++ b/roles/cert_manager/tasks/main.yml
@@ -43,10 +43,19 @@
   ansible.builtin.include_role:
     name: vexxhost.kubernetes.cert_manager
   vars:
+    cert_manager_helm_chart_repository: >-
+      oci://{{ atmosphere_images['cert_manager_helm_chart'] |
+      vexxhost.kubernetes.docker_image('name') }}
+    cert_manager_helm_chart_version: >-
+      {{ atmosphere_images['cert_manager_helm_chart'] |
+      vexxhost.kubernetes.docker_image('tag') }}
     cert_manager_image_cli: "{{ atmosphere_images['cert_manager_cli'] }}"
     cert_manager_image_controller: "{{ atmosphere_images['cert_manager_controller'] }}"
     cert_manager_image_cainjector: "{{ atmosphere_images['cert_manager_cainjector'] }}"
     cert_manager_image_webhook: "{{ atmosphere_images['cert_manager_webhook'] }}"
     cert_manager_image_acmesolver: "{{ atmosphere_images['cert_manager_acmesolver'] }}"
+    cert_manager_image_startupapicheck: >-
+      {{ atmosphere_images['cert_manager_startupapicheck'] |
+      default(atmosphere_images['cert_manager_cli']) }}
     cert_manager_node_selector:
       openstack-control-plane: enabled

--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -21,6 +21,7 @@ _atmosphere_images:
   bootstrap: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/heat:zed@sha256:634678556c04e8e52ec7ea731705bd8c3219e689d5dc1262bf12b3640a06af14"
   ceph_config_helper: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/libvirtd:zed@sha256:a985d35be1a2343a5d0d17a0172474807b07cb81506824f871761b0d7e8760be"
   ceph: "{{ atmosphere_image_prefix }}quay.io/ceph/ceph:v18.2.1"
+  cert_manager_helm_chart: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/charts/cert-manager:v1.11.5"
   cert_manager_cainjector: "{{ atmosphere_image_prefix }}quay.io/jetstack/cert-manager-cainjector:v1.12.10"
   cert_manager_cli: "{{ atmosphere_image_prefix }}quay.io/jetstack/cert-manager-ctl:v1.12.10"
   cert_manager_controller: "{{ atmosphere_image_prefix }}quay.io/jetstack/cert-manager-controller:v1.12.10"


### PR DESCRIPTION
# Description
Backport of #4078 to `stable/zed`.