### PR TITLE
refactor(molecule): split AIO defaults from env overrides

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -2,6 +2,7 @@
     vars:
       atmosphere_workspace_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
       molecule_environment:
+        ATMOSPHERE_IMAGE_PREFIX: "{{ atmosphere_image_prefix | default('') }}"
         ATMOSPHERE_NETWORK_BACKEND: "{{ atmosphere_network_backend | default('openvswitch') }}"
         ATMOSPHERE_ZUUL_INVENTORY: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/inventory.yaml"
     templates:

--- a/molecule/aio/group_vars/all/00-aio-base.yml
+++ b/molecule/aio/group_vars/all/00-aio-base.yml
@@ -1,5 +1,3 @@
-atmosphere_image_prefix: "{{ lookup('env', 'ATMOSPHERE_IMAGE_PREFIX') | default('', True) }}"
-atmosphere_network_backend: "{{ lookup('env', 'ATMOSPHERE_NETWORK_BACKEND') | default('openvswitch', True) }}"
 cluster_issuer_type: self-signed
 ceph_conf_overrides:
   - section: global
@@ -75,6 +73,13 @@ staffeln_helm_values:
     replicas:
       api: 1
       conductor: 1
+senlin_helm_values:
+  pod:
+    replicas:
+      api: 1
+      conductor: 1
+      engine: 1
+      health_manager: 1
 cinder_helm_values:
   conf:
     ceph:

--- a/molecule/aio/group_vars/all/90-env.yml
+++ b/molecule/aio/group_vars/all/90-env.yml
@@ -1,0 +1,2 @@
+atmosphere_image_prefix: "{{ lookup('env', 'ATMOSPHERE_IMAGE_PREFIX') | default('', true) }}"
+atmosphere_network_backend: "{{ lookup('env', 'ATMOSPHERE_NETWORK_BACKEND') | default('openvswitch', true) }}"

--- a/molecule/keycloak/group_vars
+++ b/molecule/keycloak/group_vars
@@ -1,0 +1,1 @@
+../aio/group_vars

--- a/molecule/keycloak/group_vars/all/molecule.yml
+++ b/molecule/keycloak/group_vars/all/molecule.yml
@@ -1,1 +1,0 @@
-../../../aio/group_vars/all/molecule.yml


### PR DESCRIPTION
## Summary

- split checked-in AIO Molecule vars into stable defaults and env-derived overrides
- add missing `senlin_helm_values` so the checked-in AIO profile covers the external Zuul AIO defaults
- pass `ATMOSPHERE_IMAGE_PREFIX` through Zuul `molecule_environment` so CI-only image prefixing is env-driven
- make keycloak consume the whole AIO `group_vars` tree, matching CSI, so it sees both AIO vars files

## Validation

- YAML load of `molecule/aio/group_vars/all/00-aio-base.yml` and `90-env.yml`
- compared checked-in AIO profile vars against `vexxhost/atmosphere-zuul-jobs` `atmosphere-molecule-aio` vars and confirmed no missing profile vars except job-owned `molecule_scenario`
- `uv run pre-commit run end-of-file-fixer --files .zuul.yaml molecule/aio/group_vars/all/00-aio-base.yml molecule/aio/group_vars/all/90-env.yml`
- `uv run pre-commit run trailing-whitespace --files .zuul.yaml molecule/aio/group_vars/all/00-aio-base.yml molecule/aio/group_vars/all/90-env.yml`
- `uv run pre-commit run mixed-line-ending --files .zuul.yaml molecule/aio/group_vars/all/00-aio-base.yml molecule/aio/group_vars/all/90-env.yml`

## Note

A full local pre-commit run is currently blocked before file checks by the upstream `ansible-lint` pre-commit environment failing to install with a `project.license` metadata validation error.