### PR TITLE
fix(storage): handle Ceph RBD backend edge cases

### DIFF
--- a/plugins/filter/storage.py
+++ b/plugins/filter/storage.py
@@ -55,8 +55,8 @@ class ErasureCodedSpec(_StrictBase):
 
     @model_validator(mode="after")
     def _validate_coding_params(self) -> Self:
-        if self.m >= self.k:
-            raise ValueError(f"m ({self.m}) must be less than k ({self.k})")
+        if self.m > self.k:
+            raise ValueError(f"m ({self.m}) must not exceed k ({self.k})")
         return self
 
 
@@ -683,29 +683,43 @@ def storage_to_libvirt_helm_values(raw: Any) -> HelmValues:
     ephemeral = storage.ephemeral
     default_backend_name = volumes.default if volumes else None
     backends_config = volumes.backends if volumes else {}
+    seen_ceph_secrets: set[tuple[str, str]] = set()
 
     ceph_conf: dict[str, Any] = {"enabled": False}
 
     if isinstance(ephemeral, EphemeralBackendRbd):
         ceph_conf["enabled"] = True
 
+    default_backend = (
+        backends_config.get(default_backend_name) if default_backend_name else None
+    )
+    if isinstance(default_backend, LibvirtSecretSpec):
+        secret_uuid = str(default_backend.secret_uuid)
+        ceph_conf["enabled"] = True
+        ceph_conf["cinder"] = {
+            "user": default_backend.user,
+            "secret_uuid": secret_uuid,
+        }
+        seen_ceph_secrets.add((default_backend.user, secret_uuid))
+
     for name, backend in backends_config.items():
         if not isinstance(backend, LibvirtSecretSpec):
             continue
-        ceph_conf["enabled"] = True
         if name == default_backend_name:
-            ceph_conf["cinder"] = {
+            continue
+        ceph_conf["enabled"] = True
+        secret_uuid = str(backend.secret_uuid)
+        ceph_secret = (backend.user, secret_uuid)
+        if ceph_secret in seen_ceph_secrets:
+            continue
+        seen_ceph_secrets.add(ceph_secret)
+        ceph_conf.setdefault("additional_users", []).append(
+            {
                 "user": backend.user,
-                "secret_uuid": str(backend.secret_uuid),
+                "secret_uuid": secret_uuid,
+                "secret_name": f"cinder-volume-rbd-keyring-{name.replace('_', '-')}",
             }
-        else:
-            ceph_conf.setdefault("additional_users", []).append(
-                {
-                    "user": backend.user,
-                    "secret_uuid": str(backend.secret_uuid),
-                    "secret_name": f"cinder-volume-rbd-keyring-{name.replace('_', '-')}",
-                }
-            )
+        )
 
     return {"conf": {"ceph": ceph_conf}}
 

--- a/releasenotes/notes/allow-equal-ec-km-e3972370bed615c0.yaml
+++ b/releasenotes/notes/allow-equal-ec-km-e3972370bed615c0.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed validation for erasure-coded Ceph pools so ``m`` can be equal to
+    ``k``.
+  - |
+    Reused Ceph RBD volume credentials no longer create duplicate ``libvirt``
+    keyring resources.

--- a/tests/unit/plugins/filter/test_storage.py
+++ b/tests/unit/plugins/filter/test_storage.py
@@ -119,8 +119,8 @@ class TestValidation:
                 }
             )
 
-    def test_erasure_coded_m_ge_k_rejected(self):
-        with pytest.raises(ValidationError, match="m.*must be less than k"):
+    def test_erasure_coded_m_gt_k_rejected(self):
+        with pytest.raises(ValidationError, match="m.*must not exceed k"):
             StorageConfig.model_validate(
                 {
                     "volumes": {
@@ -143,29 +143,32 @@ class TestValidation:
                 }
             )
 
-    def test_erasure_coded_m_equal_k_rejected(self):
-        with pytest.raises(ValidationError, match="m.*must be less than k"):
-            StorageConfig.model_validate(
-                {
-                    "volumes": {
-                        "default": "ec1",
-                        "backends": {
-                            "ec1": {
-                                "type": "rbd-ec",
-                                "pool": "test",
-                                "erasure_coded": {
-                                    "k": 3,
-                                    "m": 3,
-                                    "failure_domain": "host",
-                                },
-                                "metadata_replication": 3,
-                                "user": "cinder",
-                                "secret_uuid": "457eb676-33da-42ec-9a8c-9293d545c337",
-                            }
-                        },
-                    }
+    def test_erasure_coded_m_equal_k_valid(self):
+        cfg = StorageConfig.model_validate(
+            {
+                "volumes": {
+                    "default": "ec1",
+                    "backends": {
+                        "ec1": {
+                            "type": "rbd-ec",
+                            "pool": "test",
+                            "erasure_coded": {
+                                "k": 3,
+                                "m": 3,
+                                "failure_domain": "host",
+                            },
+                            "metadata_replication": 3,
+                            "user": "cinder",
+                            "secret_uuid": "457eb676-33da-42ec-9a8c-9293d545c337",
+                        }
+                    },
                 }
-            )
+            }
+        )
+
+        assert cfg.volumes is not None
+        backend = cfg.volumes.backends["ec1"]
+        assert getattr(backend, "erasure_coded").m == 3
 
     def test_image_default_not_in_backends(self):
         with pytest.raises(ValidationError, match="default.*not in backends"):
@@ -953,6 +956,48 @@ class TestStorageToLibvirtHelmValues:
         assert len(additional) == 2
         users = {u["user"] for u in additional}
         assert users == {"cinder-ssd", "cinder-nvme"}
+
+    def test_duplicate_libvirt_secret_is_not_repeated(self):
+        storage = {
+            "volumes": {
+                "default": "ceph",
+                "backends": {
+                    "ceph": {
+                        "type": "rbd",
+                        "pool": "vms",
+                        "user": "cinder",
+                        "secret_uuid": "af49f2ad-75fc-4a0c-8ec0-f6e35bac5413",
+                    },
+                    "ecpool": {
+                        "type": "rbd-ec",
+                        "pool": "ecpool_metadata",
+                        "data_pool": "ecpool",
+                        "user": "ec-pool",
+                        "secret_uuid": "0a5880da-fae4-469e-9d3c-b64c12030c9d",
+                        "metadata_replication": 3,
+                        "erasure_coded": {
+                            "k": 3,
+                            "m": 2,
+                            "failure_domain": "host",
+                        },
+                    },
+                    "rust": {
+                        "type": "rbd",
+                        "pool": "vms_hdd",
+                        "user": "cinder",
+                        "secret_uuid": "af49f2ad-75fc-4a0c-8ec0-f6e35bac5413",
+                    },
+                },
+            },
+        }
+
+        result = storage_to_libvirt_helm_values(storage)
+
+        assert result["conf"]["ceph"]["cinder"]["user"] == "cinder"
+        additional = result["conf"]["ceph"]["additional_users"]
+        assert len(additional) == 1
+        assert additional[0]["user"] == "ec-pool"
+        assert additional[0]["secret_name"] == "cinder-volume-rbd-keyring-ecpool"
 
     def test_no_ceph(self):
         storage = {


### PR DESCRIPTION
## Summary
- Allow erasure-coded Ceph pool validation to accept `m == k` while still rejecting `m > k`.
- Avoid emitting duplicate `libvirt` Ceph keyring resources when multiple RBD volume backends reuse the same Ceph user and secret UUID.
- Add regression coverage for both cases and update the release note.

## Testing
- `nix-shell -p uv python313 libffi pkg-config --run 'uv run --python python3.13 --group dev --with pytest-ansible pytest tests/unit/plugins/filter/test_storage.py -q'`
- `git diff --check`
- `nix-shell -p python312Packages.reno --run 'reno report --output /tmp/atmosphere-reno.rst'`