### PR TITLE
fix(storage): allow overriding default rbd backend

### DIFF
--- a/plugins/filter/storage.py
+++ b/plugins/filter/storage.py
@@ -482,11 +482,30 @@ EphemeralBackend = Annotated[
 ]
 
 
+def _drop_none_backends(data: Any) -> Any:
+    """Drop backend entries explicitly set to ``None``.
+
+    Role defaults include an ``rbd1`` backend for Ceph deployments.  When a
+    config repo replaces that backend set, Ansible's recursive combine leaves
+    the default entry in place unless the repo can explicitly null it out.
+    """
+    if not isinstance(data, dict):
+        return data
+    backends = data.get("backends")
+    if isinstance(backends, dict):
+        data["backends"] = {
+            name: spec for name, spec in backends.items() if spec is not None
+        }
+    return data
+
+
 class ImageStorageConfig(_StrictBase):
     default: str = Field(description="Name of the default image backend.")
     backends: dict[str, ImageBackend] = Field(
         min_length=1, description="Mapping of backend name to image backend config."
     )
+
+    _drop_none_backends = model_validator(mode="before")(_drop_none_backends)
 
     @model_validator(mode="after")
     def _validate_default_in_backends(self) -> Self:
@@ -502,6 +521,8 @@ class VolumeStorageConfig(_StrictBase):
     backends: dict[str, VolumeBackend] = Field(
         min_length=1, description="Mapping of backend name to volume backend config."
     )
+
+    _drop_none_backends = model_validator(mode="before")(_drop_none_backends)
 
     @model_validator(mode="after")
     def _validate_default_in_backends(self) -> Self:
@@ -580,6 +601,11 @@ def storage_to_cinder_helm_values(raw: Any) -> HelmValues:
         backends_config.keys()
     )
     result["conf"]["cinder"]["DEFAULT"]["default_volume_type"] = default_backend
+    if isinstance(
+        backends_config.get(default_backend),
+        (VolumeBackendRbd, VolumeBackendRbdEc),
+    ):
+        result["ceph_client"] = {"internal_ceph_backend": default_backend}
 
     if backup is not None:
         backup.amend_cinder_backup(result)

--- a/releasenotes/notes/storage-rbd1-opt-out-2e7f6b9f4c85a1d0.yaml
+++ b/releasenotes/notes/storage-rbd1-opt-out-2e7f6b9f4c85a1d0.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed ``atmosphere_storage`` handling so deployments can remove the
+    role-default ``rbd1`` image or volume backend by setting that backend to
+    ``null`` after recursive inventory merging.
+  - |
+    Fixed Cinder Helm values derived from ``atmosphere_storage`` so a renamed
+    default Ceph RBD backend is also used as the chart's internal Ceph backend,
+    avoiding spurious ``cinder-volume-rbd-keyring-rbd1`` secret mounts.

--- a/tests/unit/plugins/filter/test_storage.py
+++ b/tests/unit/plugins/filter/test_storage.py
@@ -211,6 +211,43 @@ class TestValidation:
                 }
             )
 
+    def test_volume_backend_set_to_none_is_dropped(self):
+        cfg = StorageConfig.model_validate(
+            {
+                "volumes": {
+                    "default": "ceph",
+                    "backends": {
+                        "rbd1": None,
+                        "ceph": {
+                            "type": "rbd",
+                            "pool": "vms",
+                            "user": "cinder",
+                            "secret_uuid": "af49f2ad-75fc-4a0c-8ec0-f6e35bac5413",
+                        },
+                    },
+                },
+            }
+        )
+
+        assert cfg.volumes is not None
+        assert set(cfg.volumes.backends) == {"ceph"}
+
+    def test_image_backend_set_to_none_is_dropped(self):
+        cfg = StorageConfig.model_validate(
+            {
+                "images": {
+                    "default": "cinder_store",
+                    "backends": {
+                        "rbd1": None,
+                        "cinder_store": {"type": "cinder"},
+                    },
+                },
+            }
+        )
+
+        assert cfg.images is not None
+        assert set(cfg.images.backends) == {"cinder_store"}
+
     def test_invalid_backend_type_rejected(self):
         with pytest.raises(ValidationError):
             StorageConfig.model_validate(
@@ -308,6 +345,44 @@ class TestStorageToCinderHelmValues:
         assert backend["image_volume_cache_max_count"] == 50
         assert result["conf"]["cinder"]["DEFAULT"]["enabled_backends"] == "rbd1"
         assert result["conf"]["cinder"]["DEFAULT"]["default_volume_type"] == "rbd1"
+        assert result["ceph_client"]["internal_ceph_backend"] == "rbd1"
+
+    def test_renamed_default_rbd_masks_rbd1(self):
+        storage = {
+            **DEFAULT_STORAGE,
+            "volumes": {
+                "default": "ceph",
+                "backends": {
+                    "rbd1": None,
+                    "ceph": {
+                        "type": "rbd",
+                        "pool": "vms",
+                        "user": "cinder",
+                        "secret_uuid": "af49f2ad-75fc-4a0c-8ec0-f6e35bac5413",
+                    },
+                    "ecpool": {
+                        "type": "rbd-ec",
+                        "pool": "ecpool_metadata",
+                        "data_pool": "ecpool",
+                        "user": "ec-pool",
+                        "secret_uuid": "0a5880da-fae4-469e-9d3c-b64c12030c9d",
+                        "metadata_replication": 3,
+                        "erasure_coded": {
+                            "k": 2,
+                            "m": 2,
+                            "failure_domain": "host",
+                        },
+                    },
+                },
+            },
+        }
+
+        result = storage_to_cinder_helm_values(storage)
+
+        assert set(result["conf"]["backends"]) == {"ceph", "ecpool"}
+        assert result["conf"]["cinder"]["DEFAULT"]["enabled_backends"] == "ceph,ecpool"
+        assert result["conf"]["cinder"]["DEFAULT"]["default_volume_type"] == "ceph"
+        assert result["ceph_client"]["internal_ceph_backend"] == "ceph"
 
     def test_rbd_custom_chunk_size(self):
         storage = {
@@ -986,6 +1061,43 @@ class TestStorageToLibvirtHelmValues:
                         "pool": "vms_hdd",
                         "user": "cinder",
                         "secret_uuid": "af49f2ad-75fc-4a0c-8ec0-f6e35bac5413",
+                    },
+                },
+            },
+        }
+
+        result = storage_to_libvirt_helm_values(storage)
+
+        assert result["conf"]["ceph"]["cinder"]["user"] == "cinder"
+        additional = result["conf"]["ceph"]["additional_users"]
+        assert len(additional) == 1
+        assert additional[0]["user"] == "ec-pool"
+        assert additional[0]["secret_name"] == "cinder-volume-rbd-keyring-ecpool"
+
+    def test_libvirt_renamed_default_rbd_masks_rbd1(self):
+        storage = {
+            "volumes": {
+                "default": "ceph",
+                "backends": {
+                    "rbd1": None,
+                    "ceph": {
+                        "type": "rbd",
+                        "pool": "vms",
+                        "user": "cinder",
+                        "secret_uuid": "af49f2ad-75fc-4a0c-8ec0-f6e35bac5413",
+                    },
+                    "ecpool": {
+                        "type": "rbd-ec",
+                        "pool": "ecpool_metadata",
+                        "data_pool": "ecpool",
+                        "user": "ec-pool",
+                        "secret_uuid": "0a5880da-fae4-469e-9d3c-b64c12030c9d",
+                        "metadata_replication": 3,
+                        "erasure_coded": {
+                            "k": 2,
+                            "m": 2,
+                            "failure_domain": "host",
+                        },
                     },
                 },
             },


### PR DESCRIPTION
## Summary
- allow `atmosphere_storage` backends set to `null` to be dropped after recursive merge, so role-default `rbd1` can be opted out
- set Cinder `ceph_client.internal_ceph_backend` from the selected default RBD/RBD-EC volume backend
- add storage filter regression tests and a release note for the renamed default RBD backend case

## Testing
- `nix-shell -p uv python312 libffi.dev pkg-config --run 'env UV_PROJECT_ENVIRONMENT=.venv312 uv run --python python3.12 --with pytest --with pytest-ansible pytest tests/unit/plugins/filter/test_storage.py'` (`68 passed`)
- `nix-shell -p uv python312 libffi.dev pkg-config --run 'env UV_PROJECT_ENVIRONMENT=.venv312 uv run --python python3.12 --with pytest --with pytest-ansible pytest tests/unit/plugins/filter'` (fails in existing `test_openstack_helm_image_tags_for_magnum`, where current `main` returns the newer `atmosphere_image_prefix`/digest-style values while the test expects older image tags)