### PR TITLE
feat(storage): add NetApp Cinder backend

### DIFF
--- a/doc/source/deploy/storage.rst
+++ b/doc/source/deploy/storage.rst
@@ -226,6 +226,30 @@ Dell PowerStore (``powerstore``)
     password: <password>
     protocol: iscsi    # or fc
 
+NetApp ONTAP (``netapp``)
+=========================
+
+NetApp ONTAP integration using the OpenStack Cinder NetApp unified driver.
+Atmosphere supports the ``iscsi``, ``fc``, ``nfs``, and ``nvme`` Cinder
+protocols.
+
+For additional options, see the `Cinder NetApp volume driver documentation
+<https://docs.openstack.org/cinder/latest/configuration/block-storage/drivers/netapp-volume-driver.html>`_.
+
+.. code-block:: yaml
+
+    type: netapp
+    protocol: iscsi    # or fc, nfs, nvme
+    address: <management_ip_or_hostname>
+    username: <username>
+    password: <password>
+    vserver: <svm_name>
+    transport_type: https  # optional, defaults to https
+    server_port: 443       # optional, defaults to 443
+    nfs_shares_config:     # optional, for nfs backends
+      - 10.0.0.20:/cinder
+    netapp_options: {}     # optional additional Cinder NetApp options
+
 Pure storage (``pure``)
 =======================
 
@@ -295,9 +319,9 @@ these values:
 ``type: none``
   Disable the Cinder backup service and its storage-init job.
 
-For non-Ceph volume backends such as PowerStore, Pure Storage, StorPool, or
-Nimble, set ``backup.type: none`` unless you still plan to use Ceph for
-backups.
+For non-Ceph volume backends such as PowerStore, NetApp, Pure Storage,
+StorPool, or Nimble, set ``backup.type: none`` unless you still plan to use
+Ceph for backups.
 
 If you keep Ceph backups while using a non-Ceph volume backend, define the
 backup block explicitly:
@@ -364,6 +388,34 @@ Using Dell PowerStore
             username: admin
             password: secret
             protocol: iscsi
+      backup:
+        type: none
+      ephemeral:
+        type: local
+
+Using NetApp ONTAP storage
+==========================
+
+.. code-block:: yaml
+
+    atmosphere_storage:
+      images:
+        default: cinder_store
+        backends:
+          rbd1: null
+          cinder_store:
+            type: cinder
+      volumes:
+        default: netapp1
+        backends:
+          rbd1: null
+          netapp1:
+            type: netapp
+            protocol: iscsi
+            address: 10.0.0.10
+            username: admin
+            password: secret
+            vserver: svm_cinder
       backup:
         type: none
       ephemeral:

--- a/plugins/filter/storage.py
+++ b/plugins/filter/storage.py
@@ -286,6 +286,84 @@ class VolumeBackendPowerstore(_HostAttachedVolumeBackend):
         result["conf"]["backends"][name] = self.cinder_backend_config(name)
 
 
+class VolumeBackendNetApp(_HostAttachedVolumeBackend):
+    """NetApp ONTAP volume backend."""
+
+    type: Literal["netapp"]
+    protocol: Literal["iscsi", "fc", "nfs", "nvme"] = Field(
+        description="Storage protocol."
+    )
+    address: str = Field(description="Cluster management address (IP or hostname).")
+    username: str = Field(description="Username credential.")
+    password: str = Field(description="Password credential.")
+    vserver: str = Field(description="ONTAP SVM name.")
+    transport_type: Literal["http", "https"] = Field(
+        default="https", description="Transport protocol for ONTAP management API."
+    )
+    server_port: int = Field(default=443, description="ONTAP management API port.")
+    nfs_shares_config: str | list[str] | None = Field(
+        default=None,
+        description="NFS shares content for NetApp NFS Cinder backends.",
+    )
+    use_multipath_for_image_xfer: bool = Field(
+        default=True,
+        description="Enable multipath for Cinder image transfers.",
+    )
+    netapp_options: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional Cinder NetApp driver options.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_nfs_shares_config(self) -> Self:
+        if (
+            self.protocol == "nfs"
+            and self.nfs_shares_config is None
+            and "nfs_shares_config" not in self.netapp_options
+        ):
+            raise ValueError(
+                "NetApp NFS backends require nfs_shares_config or "
+                "netapp_options.nfs_shares_config"
+            )
+        return self
+
+    def cinder_backend_config(self, name: str) -> dict[str, Any]:
+        """Generate Cinder backend config for NetApp ONTAP."""
+        config: dict[str, Any] = {
+            "volume_backend_name": name,
+            "volume_driver": "cinder.volume.drivers.netapp.common.NetAppDriver",
+            "netapp_storage_family": "ontap_cluster",
+            "netapp_storage_protocol": self.protocol,
+            "netapp_server_hostname": self.address,
+            "netapp_server_port": self.server_port,
+            "netapp_login": self.username,
+            "netapp_password": self.password,
+            "netapp_vserver": self.vserver,
+            "netapp_transport_type": self.transport_type,
+            "use_multipath_for_image_xfer": self.use_multipath_for_image_xfer,
+        }
+        if self.nfs_shares_config is not None:
+            config["nfs_shares_config"] = self.nfs_shares_config
+        config.update(self.netapp_options)
+        return config
+
+    def amend_cinder(self, result: HelmValues, name: str) -> None:
+        """Amend Cinder Helm values for a NetApp ONTAP volume backend."""
+        super().amend_cinder(result, name)
+        result["conf"]["backends"][name] = self.cinder_backend_config(name)
+        result.setdefault("pod", {})
+        result["pod"]["useHostNetwork"] = {"volume": True}
+        result["pod"]["security_context"] = {
+            "cinder_volume": {
+                "container": {
+                    "cinder_volume": {
+                        "privileged": True,
+                    }
+                }
+            },
+        }
+
+
 class _VolumeBackendPureBase(_HostAttachedVolumeBackend):
     """Pure Storage FlashArray volume backend."""
 
@@ -491,6 +569,7 @@ VolumeBackend = Annotated[
         VolumeBackendRbd,
         VolumeBackendRbdEc,
         VolumeBackendPowerstore,
+        VolumeBackendNetApp,
         VolumeBackendPure,
         VolumeBackendStorpool,
         VolumeBackendNimble,
@@ -702,9 +781,23 @@ def _parse(raw: Any) -> StorageConfig:
     return StorageConfig.model_validate(raw)
 
 
+def _masked_backend_names(raw: Any, section: str) -> list[str]:
+    """Return backend names explicitly set to ``None`` in raw input."""
+    if not isinstance(raw, dict):
+        return []
+    storage_section = raw.get(section)
+    if not isinstance(storage_section, dict):
+        return []
+    backends = storage_section.get("backends")
+    if not isinstance(backends, dict):
+        return []
+    return [name for name, backend in backends.items() if backend is None]
+
+
 def storage_to_cinder_helm_values(raw: Any) -> HelmValues:
     """Derive Cinder Helm values from atmosphere_storage."""
 
+    masked_backend_names = _masked_backend_names(raw, "volumes")
     storage = _parse(raw)
     volumes = storage.volumes
     backup = storage.backup
@@ -712,6 +805,9 @@ def storage_to_cinder_helm_values(raw: Any) -> HelmValues:
     backends_config = volumes.backends if volumes else {}
 
     result: HelmValues = {"conf": {"backends": {}, "cinder": {"DEFAULT": {}}}}
+
+    for name in masked_backend_names:
+        result["conf"]["backends"][name] = None
 
     for name, backend in backends_config.items():
         backend.amend_cinder(result, name)

--- a/releasenotes/notes/add-netapp-cinder-backend-91d37cf6054a9d2b.yaml
+++ b/releasenotes/notes/add-netapp-cinder-backend-91d37cf6054a9d2b.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Added first-class NetApp ONTAP Cinder backend support to
+    ``atmosphere_storage``. Deployments can now configure
+    ``atmosphere_storage.volumes.backends.<name>.type: netapp`` for the
+    OpenStack Cinder NetApp unified driver with iSCSI, Fibre Channel, NFS, or
+    NVMe protocols.

--- a/tests/unit/plugins/filter/test_storage.py
+++ b/tests/unit/plugins/filter/test_storage.py
@@ -78,6 +78,15 @@ _POWERSTORE_BACKEND = {
     "protocol": "iscsi",
 }
 
+_NETAPP_ISCSI_BACKEND = {
+    "type": "netapp",
+    "protocol": "iscsi",
+    "address": "10.0.0.10",
+    "username": "admin",
+    "password": "secret",
+    "vserver": "svm_cinder",
+}
+
 _PURE_ISCSI_BACKEND = {
     "type": "pure",
     "protocol": "iscsi",
@@ -107,6 +116,16 @@ _NIMBLE_FC_BACKEND = {
 }
 
 _NIMBLE_POD_SECURITY_CONTEXT = {
+    "cinder_volume": {
+        "container": {
+            "cinder_volume": {
+                "privileged": True,
+            }
+        }
+    }
+}
+
+_NETAPP_POD_SECURITY_CONTEXT = {
     "cinder_volume": {
         "container": {
             "cinder_volume": {
@@ -342,6 +361,22 @@ class TestValidation:
                 }
             )
 
+    def test_netapp_nfs_requires_shares_config(self):
+        with pytest.raises(ValidationError, match="NetApp NFS backends require"):
+            StorageConfig.model_validate(
+                {
+                    "volumes": {
+                        "default": "netapp",
+                        "backends": {
+                            "netapp": {
+                                **_NETAPP_ISCSI_BACKEND,
+                                "protocol": "nfs",
+                            },
+                        },
+                    },
+                }
+            )
+
     def test_erasure_coded_k_below_minimum_rejected(self):
         with pytest.raises(ValidationError):
             StorageConfig.model_validate(
@@ -444,7 +479,8 @@ class TestStorageToCinderHelmValues:
 
         result = storage_to_cinder_helm_values(storage)
 
-        assert set(result["conf"]["backends"]) == {"ceph", "ecpool"}
+        assert set(result["conf"]["backends"]) == {"rbd1", "ceph", "ecpool"}
+        assert result["conf"]["backends"]["rbd1"] is None
         assert result["conf"]["cinder"]["DEFAULT"]["enabled_backends"] == "ceph,ecpool"
         assert result["conf"]["cinder"]["DEFAULT"]["default_volume_type"] == "ceph"
         assert result["ceph_client"]["internal_ceph_backend"] == "ceph"
@@ -625,6 +661,132 @@ class TestStorageToCinderHelmValues:
         result = storage_to_cinder_helm_values(storage)
         assert result["conf"]["backends"]["ps"]["storage_protocol"] == "FC"
 
+    def test_netapp_iscsi_backend(self):
+        storage = {
+            **DEFAULT_STORAGE,
+            "volumes": {
+                "default": "netapp",
+                "backends": {"netapp": _NETAPP_ISCSI_BACKEND},
+            },
+            "backup": {"type": "none"},
+        }
+        result = storage_to_cinder_helm_values(storage)
+
+        backend = result["conf"]["backends"]["netapp"]
+        assert (
+            backend["volume_driver"]
+            == "cinder.volume.drivers.netapp.common.NetAppDriver"
+        )
+        assert backend["netapp_storage_family"] == "ontap_cluster"
+        assert backend["netapp_storage_protocol"] == "iscsi"
+        assert backend["netapp_server_hostname"] == "10.0.0.10"
+        assert backend["netapp_server_port"] == 443
+        assert backend["netapp_login"] == "admin"
+        assert backend["netapp_password"] == "secret"
+        assert backend["netapp_vserver"] == "svm_cinder"
+        assert backend["netapp_transport_type"] == "https"
+        assert backend["use_multipath_for_image_xfer"] is True
+        assert result["conf"]["enable_iscsi"] is True
+        assert result["pod"]["useHostNetwork"] == {"volume": True}
+        assert result["pod"]["security_context"] == _NETAPP_POD_SECURITY_CONTEXT
+        assert result["manifests"]["job_storage_init"] is False
+
+    def test_netapp_fc_backend(self):
+        storage = {
+            **DEFAULT_STORAGE,
+            "volumes": {
+                "default": "netapp",
+                "backends": {
+                    "netapp": {**_NETAPP_ISCSI_BACKEND, "protocol": "fc"},
+                },
+            },
+            "backup": {"type": "none"},
+        }
+        result = storage_to_cinder_helm_values(storage)
+
+        backend = result["conf"]["backends"]["netapp"]
+        assert backend["netapp_storage_protocol"] == "fc"
+        assert backend["use_multipath_for_image_xfer"] is True
+
+    def test_netapp_nfs_backend_with_shares_config(self):
+        storage = {
+            **DEFAULT_STORAGE,
+            "volumes": {
+                "default": "netapp",
+                "backends": {
+                    "netapp": {
+                        **_NETAPP_ISCSI_BACKEND,
+                        "protocol": "nfs",
+                        "nfs_shares_config": ["10.0.0.20:/cinder"],
+                    },
+                },
+            },
+            "backup": {"type": "none"},
+        }
+        result = storage_to_cinder_helm_values(storage)
+
+        backend = result["conf"]["backends"]["netapp"]
+        assert backend["netapp_storage_protocol"] == "nfs"
+        assert backend["nfs_shares_config"] == ["10.0.0.20:/cinder"]
+
+    def test_netapp_backend_custom_options(self):
+        storage = {
+            **DEFAULT_STORAGE,
+            "volumes": {
+                "default": "netapp",
+                "backends": {
+                    "netapp": {
+                        **_NETAPP_ISCSI_BACKEND,
+                        "protocol": "nvme",
+                        "transport_type": "http",
+                        "server_port": 80,
+                        "use_multipath_for_image_xfer": False,
+                        "netapp_options": {
+                            "netapp_lun_space_reservation": "disabled",
+                            "netapp_lun_ostype": "linux",
+                        },
+                    },
+                },
+            },
+            "backup": {"type": "none"},
+        }
+        result = storage_to_cinder_helm_values(storage)
+
+        backend = result["conf"]["backends"]["netapp"]
+        assert backend["netapp_storage_protocol"] == "nvme"
+        assert backend["netapp_transport_type"] == "http"
+        assert backend["netapp_server_port"] == 80
+        assert backend["use_multipath_for_image_xfer"] is False
+        assert backend["netapp_lun_space_reservation"] == "disabled"
+        assert backend["netapp_lun_ostype"] == "linux"
+
+    def test_netapp_with_rbd1_default_nulled_out(self):
+        storage = {
+            "images": {
+                "default": "cinder_store",
+                "backends": {
+                    "rbd1": None,
+                    "cinder_store": {"type": "cinder"},
+                },
+            },
+            "volumes": {
+                "default": "netapp1",
+                "backends": {
+                    "rbd1": None,
+                    "netapp1": _NETAPP_ISCSI_BACKEND,
+                },
+            },
+            "backup": {"type": "none"},
+            "ephemeral": {"type": "local"},
+        }
+        result = storage_to_cinder_helm_values(storage)
+
+        assert result["conf"]["backends"]["rbd1"] is None
+        assert result["storage"] == "netapp"
+        assert result["conf"]["cinder"]["DEFAULT"]["enabled_backends"] == "netapp1"
+        assert result["conf"]["cinder"]["DEFAULT"]["default_volume_type"] == "netapp1"
+        assert result["manifests"]["job_storage_init"] is False
+
     def test_pure_iscsi_backend(self):
         storage = {
             **DEFAULT_STORAGE,
@@ -796,7 +958,7 @@ class TestStorageToCinderHelmValues:
         }
         result = storage_to_cinder_helm_values(storage)
 
-        assert "rbd1" not in result["conf"]["backends"]
+        assert result["conf"]["backends"]["rbd1"] is None
         assert result["storage"] == "nimble"
         assert result["manifests"]["job_storage_init"] is False
         assert result["conf"]["enable_iscsi"] is True
@@ -1094,6 +1256,18 @@ class TestStorageToNovaHelmValues:
             },
         }
         result = storage_to_nova_helm_values(storage)
+        assert result["conf"]["enable_iscsi"] is True
+
+    def test_iscsi_from_netapp_volume_backend(self):
+        storage = {
+            "ephemeral": {"type": "local"},
+            "volumes": {
+                "default": "netapp",
+                "backends": {"netapp": _NETAPP_ISCSI_BACKEND},
+            },
+        }
+        result = storage_to_nova_helm_values(storage)
+        assert result["conf"]["ceph"]["enabled"] is False
         assert result["conf"]["enable_iscsi"] is True
 
     def test_rbd_volumes_no_iscsi(self):


### PR DESCRIPTION
## Summary

- Add first-class NetApp ONTAP Cinder backend support via `type: netapp`
- Support `iscsi`, `fc`, `nfs`, and `nvme` Cinder NetApp protocols
- Preserve explicit `rbd1: null` backend masks when rendering Cinder Helm values
- Add storage documentation, release note, and focused unit coverage

## Relation to the Trident CSI PR

This PR is intentionally separate from the Trident CSI PR. The Trident PR covers Kubernetes PVC provisioning through NetApp Trident; this PR covers OpenStack Cinder provisioning through the Cinder NetApp driver.

For customer testing before both PRs merge, combine them locally by applying this NetApp Cinder commit on top of the Trident CSI branch:

```bash
git fetch origin feat/add-trident-csi feat/add-netapp-cinder-backend
git switch -c test/netapp-trident-combined origin/feat/add-trident-csi
git cherry-pick ccbd7bdad5200cbdb62361f354c7cf18fde7be57
```

Then use the combined branch for an Atmosphere deployment that enables both:

- `csi_driver: trident` for Kubernetes PVCs
- `atmosphere_storage.volumes.backends.<name>.type: netapp` for Cinder
