### PR TITLE
feat(storage): add NetApp support on stable/2025.2

### DIFF
--- a/doc/source/deploy/csi.rst
+++ b/doc/source/deploy/csi.rst
@@ -128,12 +128,28 @@ Trident CSI driver by updating your Ansible inventory as follows:
 
 Use ``trident`` as the Atmosphere ``csi_driver`` value.  The Kubernetes CSI
 provisioner remains ``csi.trident.netapp.io``, and the backend driver is
-selected separately with values such as ``ontap-san`` or ``ontap-nas``.
+selected separately with values such as ``ontap-san``,
+``ontap-san-economy``, or ``ontap-nas``.
 
 By default, Atmosphere configures Trident with the ``ontap-san`` storage driver
-and creates the ``general`` StorageClass using the
-``csi.trident.netapp.io`` provisioner. This is appropriate for
-``ReadWriteOnce`` PVCs backed by iSCSI LUNs.
+and ``trident_csi_access_protocol: iscsi``. It creates the ``general``
+StorageClass using the ``csi.trident.netapp.io`` provisioner. This is
+appropriate for ``ReadWriteOnce`` PVCs backed by iSCSI LUNs.
+
+To use Fibre Channel with the ``ontap-san`` driver, set
+``trident_csi_access_protocol: fc``:
+
+.. code-block:: yaml
+
+    csi_driver: trident
+    trident_csi_storage_driver: ontap-san
+    trident_csi_access_protocol: fc
+    trident_csi_management_lif: <FILL IN>
+    trident_csi_svm: <FILL IN>
+    trident_csi_username: <FILL IN>
+    trident_csi_password: <FILL IN>
+
+The ``ontap-san-economy`` driver supports iSCSI only.
 
 If you need shared ``ReadWriteMany`` PVCs, use an ONTAP NAS backend instead:
 
@@ -159,12 +175,20 @@ backend object, and StorageClass without waiting for a successful backend bind.
 .. admonition:: SAN multipathing
     :class: warning
 
-    For ``ontap-san`` backends, Trident requires working iSCSI and multipath
-    configuration on every Kubernetes node. Atmosphere installs the host
-    packages, ensures an iSCSI initiator name exists, and configures
-    ``find_multipaths no`` by default. You can disable the multipath edit by
-    setting ``trident_csi_configure_multipath: false`` if your hosts already
-    manage that configuration elsewhere.
+    For ``ontap-san`` backends, Trident requires working SAN host preparation
+    and multipath configuration on every Kubernetes node. Atmosphere
+    configures ``find_multipaths no`` by default.
+
+    For iSCSI, Atmosphere installs the Trident iSCSI host packages, starts the
+    required services, and ensures an initiator name exists.
+
+    For Fibre Channel, Atmosphere installs the FC helper and multipath
+    packages that Trident expects. FC switch zoning and host HBA presentation
+    still need to be in place before you deploy the role.
+
+    You can disable the multipath edit by setting
+    ``trident_csi_configure_multipath: false`` if your hosts already manage
+    that configuration elsewhere.
 
 *********
 IBM Block

--- a/doc/source/deploy/csi.rst
+++ b/doc/source/deploy/csi.rst
@@ -111,6 +111,61 @@ PowerStore configuration. This includes specifying the block protocol, which
 can either be Fibre Channel (FC) or iSCSI, depending on your network
 infrastructure.
 
+**************
+NetApp Trident
+**************
+
+For environments using NetApp ONTAP storage such as AFF arrays, configure the
+Trident CSI driver by updating your Ansible inventory as follows:
+
+.. code-block:: yaml
+
+    csi_driver: trident
+    trident_csi_management_lif: <FILL IN>
+    trident_csi_svm: <FILL IN>
+    trident_csi_username: <FILL IN>
+    trident_csi_password: <FILL IN>
+
+Use ``trident`` as the Atmosphere ``csi_driver`` value.  The Kubernetes CSI
+provisioner remains ``csi.trident.netapp.io``, and the backend driver is
+selected separately with values such as ``ontap-san`` or ``ontap-nas``.
+
+By default, Atmosphere configures Trident with the ``ontap-san`` storage driver
+and creates the ``general`` StorageClass using the
+``csi.trident.netapp.io`` provisioner. This is appropriate for
+``ReadWriteOnce`` PVCs backed by iSCSI LUNs.
+
+If you need shared ``ReadWriteMany`` PVCs, use an ONTAP NAS backend instead:
+
+.. code-block:: yaml
+
+    csi_driver: trident
+    trident_csi_storage_driver: ontap-nas
+    trident_csi_management_lif: <FILL IN>
+    trident_csi_data_lif: <FILL IN>
+    trident_csi_svm: <FILL IN>
+    trident_csi_username: <FILL IN>
+    trident_csi_password: <FILL IN>
+    trident_csi_fs_type: ""
+
+You can pass additional backend options through
+``trident_csi_backend_options`` and additional StorageClass parameters through
+``trident_csi_storage_class_parameters``.
+
+For test environments that do not have access to ONTAP yet, set
+``trident_csi_wait_for_backend: false`` so the role can validate the operator,
+backend object, and StorageClass without waiting for a successful backend bind.
+
+.. admonition:: SAN multipathing
+    :class: warning
+
+    For ``ontap-san`` backends, Trident requires working iSCSI and multipath
+    configuration on every Kubernetes node. Atmosphere installs the host
+    packages, ensures an iSCSI initiator name exists, and configures
+    ``find_multipaths no`` by default. You can disable the multipath edit by
+    setting ``trident_csi_configure_multipath: false`` if your hosts already
+    manage that configuration elsewhere.
+
 *********
 IBM Block
 *********

--- a/doc/source/deploy/csi.rst
+++ b/doc/source/deploy/csi.rst
@@ -136,9 +136,9 @@ and ``trident_csi_access_protocol: iscsi``. It creates the ``general``
 StorageClass using the ``csi.trident.netapp.io`` provisioner. This is
 appropriate for ``ReadWriteOnce`` PVCs backed by iSCSI LUNs.
 
-Atmosphere sets ``trident_csi_fs_type: ext4`` by default so Kubernetes
-``fsGroup`` handling works for block-backed PVCs. Valid values are ``ext3``,
-``ext4``, and ``xfs``.
+Atmosphere sets ``trident_csi_fs_type: ext4`` by default for block-backed PVCs
+so Kubernetes ``fsGroup`` handling works as expected. Valid block filesystem
+values are ``ext3``, ``ext4``, and ``xfs``.
 
 For deployments that expect a large number of PVCs, consider using
 ``trident_csi_storage_driver: ontap-san-economy``.
@@ -171,10 +171,15 @@ If you need shared ``ReadWriteMany`` PVCs, use an ONTAP NAS backend instead:
     trident_csi_management_lif: <FILL IN>
     trident_csi_username: <FILL IN>
     trident_csi_password: <FILL IN>
-    trident_csi_fs_type: ext4
+    trident_csi_fs_type: nfs
 
 The ONTAP NAS drivers also support SMB for Windows nodes by setting
 ``trident_csi_access_protocol: smb``.
+
+For ``trident_csi_access_protocol: nfs``, Atmosphere defaults
+``trident_csi_fs_type`` to ``nfs`` because Trident will always present an NFS
+filesystem for ONTAP NAS volumes. For ``trident_csi_access_protocol: smb``,
+Atmosphere omits ``trident_csi_fs_type`` by default.
 
 Atmosphere does not set ``trident_csi_svm`` or ``trident_csi_data_lif`` by
 default.  Set ``trident_csi_svm`` only when using cluster-scoped credentials

--- a/doc/source/deploy/csi.rst
+++ b/doc/source/deploy/csi.rst
@@ -122,9 +122,9 @@ Trident CSI driver by updating your Ansible inventory as follows:
 
     csi_driver: trident
     trident_csi_management_lif: <FILL IN>
-    trident_csi_svm: <FILL IN>
     trident_csi_username: <FILL IN>
     trident_csi_password: <FILL IN>
+    trident_csi_fs_type: ext4
 
 Use ``trident`` as the Atmosphere ``csi_driver`` value.  The Kubernetes CSI
 provisioner remains ``csi.trident.netapp.io``, and the backend driver is
@@ -136,8 +136,16 @@ and ``trident_csi_access_protocol: iscsi``. It creates the ``general``
 StorageClass using the ``csi.trident.netapp.io`` provisioner. This is
 appropriate for ``ReadWriteOnce`` PVCs backed by iSCSI LUNs.
 
+Atmosphere sets ``trident_csi_fs_type: ext4`` by default so Kubernetes
+``fsGroup`` handling works for block-backed PVCs. Valid values are ``ext3``,
+``ext4``, and ``xfs``.
+
+For deployments that expect a large number of PVCs, consider using
+``trident_csi_storage_driver: ontap-san-economy``.
+
 To use Fibre Channel with the ``ontap-san`` driver, set
-``trident_csi_access_protocol: fc``:
+``trident_csi_access_protocol: fc``. FC should only be used for bare-metal
+Kubernetes nodes with host HBA presentation and switch zoning already in place:
 
 .. code-block:: yaml
 
@@ -145,11 +153,13 @@ To use Fibre Channel with the ``ontap-san`` driver, set
     trident_csi_storage_driver: ontap-san
     trident_csi_access_protocol: fc
     trident_csi_management_lif: <FILL IN>
-    trident_csi_svm: <FILL IN>
     trident_csi_username: <FILL IN>
     trident_csi_password: <FILL IN>
+    trident_csi_fs_type: ext4
 
-The ``ontap-san-economy`` driver supports iSCSI only.
+The ``ontap-san`` driver also supports NVMe/TCP by setting
+``trident_csi_access_protocol: nvme``. The ``ontap-san-economy`` driver
+supports iSCSI only.
 
 If you need shared ``ReadWriteMany`` PVCs, use an ONTAP NAS backend instead:
 
@@ -157,12 +167,28 @@ If you need shared ``ReadWriteMany`` PVCs, use an ONTAP NAS backend instead:
 
     csi_driver: trident
     trident_csi_storage_driver: ontap-nas
+    trident_csi_access_protocol: nfs
     trident_csi_management_lif: <FILL IN>
-    trident_csi_data_lif: <FILL IN>
-    trident_csi_svm: <FILL IN>
     trident_csi_username: <FILL IN>
     trident_csi_password: <FILL IN>
-    trident_csi_fs_type: ""
+    trident_csi_fs_type: ext4
+
+The ONTAP NAS drivers also support SMB for Windows nodes by setting
+``trident_csi_access_protocol: smb``.
+
+Atmosphere does not set ``trident_csi_svm`` or ``trident_csi_data_lif`` by
+default.  Set ``trident_csi_svm`` only when using cluster-scoped credentials
+and the backend must target a specific SVM. Set ``trident_csi_data_lif`` only
+for NAS backends when a specific data LIF must be selected. Do not set
+``trident_csi_data_lif`` for SAN backends.
+
+By default, Atmosphere sets the following backend options:
+
+.. code-block:: yaml
+
+    trident_csi_use_rest: false
+    trident_csi_name_template: >-
+      {{ .volume.Name }}_{{ .volume.Namespace }}_{{ .volume.RequestName }}
 
 You can pass additional backend options through
 ``trident_csi_backend_options`` and additional StorageClass parameters through

--- a/doc/source/deploy/storage.rst
+++ b/doc/source/deploy/storage.rst
@@ -226,6 +226,30 @@ Dell PowerStore (``powerstore``)
     password: <password>
     protocol: iscsi    # or fc
 
+NetApp ONTAP (``netapp``)
+=========================
+
+NetApp ONTAP integration using the OpenStack Cinder NetApp unified driver.
+Atmosphere supports the ``iscsi``, ``fc``, ``nfs``, and ``nvme`` Cinder
+protocols.
+
+For additional options, see the `Cinder NetApp volume driver documentation
+<https://docs.openstack.org/cinder/latest/configuration/block-storage/drivers/netapp-volume-driver.html>`_.
+
+.. code-block:: yaml
+
+    type: netapp
+    protocol: iscsi    # or fc, nfs, nvme
+    address: <management_ip_or_hostname>
+    username: <username>
+    password: <password>
+    vserver: <svm_name>
+    transport_type: https  # optional, defaults to https
+    server_port: 443       # optional, defaults to 443
+    nfs_shares_config:     # optional, for nfs backends
+      - 10.0.0.20:/cinder
+    netapp_options: {}     # optional additional Cinder NetApp options
+
 Pure storage (``pure``)
 =======================
 
@@ -295,9 +319,9 @@ these values:
 ``type: none``
   Disable the Cinder backup service and its storage-init job.
 
-For non-Ceph volume backends such as PowerStore, Pure Storage, StorPool, or
-Nimble, set ``backup.type: none`` unless you still plan to use Ceph for
-backups.
+For non-Ceph volume backends such as PowerStore, NetApp, Pure Storage,
+StorPool, or Nimble, set ``backup.type: none`` unless you still plan to use
+Ceph for backups.
 
 If you keep Ceph backups while using a non-Ceph volume backend, define the
 backup block explicitly:
@@ -392,6 +416,34 @@ Using HPE Nimble storage
             password: secret
             protocol: iscsi
             nimble_subnet_label: "*"
+      backup:
+        type: none
+      ephemeral:
+        type: local
+
+Using NetApp ONTAP storage
+==========================
+
+.. code-block:: yaml
+
+    atmosphere_storage:
+      images:
+        default: cinder_store
+        backends:
+          rbd1: null
+          cinder_store:
+            type: cinder
+      volumes:
+        default: netapp1
+        backends:
+          rbd1: null
+          netapp1:
+            type: netapp
+            protocol: iscsi
+            address: 10.0.0.10
+            username: admin
+            password: secret
+            vserver: svm_cinder
       backup:
         type: none
       ephemeral:

--- a/plugins/filter/storage.py
+++ b/plugins/filter/storage.py
@@ -286,6 +286,84 @@ class VolumeBackendPowerstore(_HostAttachedVolumeBackend):
         result["conf"]["backends"][name] = self.cinder_backend_config(name)
 
 
+class VolumeBackendNetApp(_HostAttachedVolumeBackend):
+    """NetApp ONTAP volume backend."""
+
+    type: Literal["netapp"]
+    protocol: Literal["iscsi", "fc", "nfs", "nvme"] = Field(
+        description="Storage protocol."
+    )
+    address: str = Field(description="Cluster management address (IP or hostname).")
+    username: str = Field(description="Username credential.")
+    password: str = Field(description="Password credential.")
+    vserver: str = Field(description="ONTAP SVM name.")
+    transport_type: Literal["http", "https"] = Field(
+        default="https", description="Transport protocol for ONTAP management API."
+    )
+    server_port: int = Field(default=443, description="ONTAP management API port.")
+    nfs_shares_config: str | list[str] | None = Field(
+        default=None,
+        description="NFS shares content for NetApp NFS Cinder backends.",
+    )
+    use_multipath_for_image_xfer: bool = Field(
+        default=True,
+        description="Enable multipath for Cinder image transfers.",
+    )
+    netapp_options: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional Cinder NetApp driver options.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_nfs_shares_config(self) -> Self:
+        if (
+            self.protocol == "nfs"
+            and self.nfs_shares_config is None
+            and "nfs_shares_config" not in self.netapp_options
+        ):
+            raise ValueError(
+                "NetApp NFS backends require nfs_shares_config or "
+                "netapp_options.nfs_shares_config"
+            )
+        return self
+
+    def cinder_backend_config(self, name: str) -> dict[str, Any]:
+        """Generate Cinder backend config for NetApp ONTAP."""
+        config: dict[str, Any] = {
+            "volume_backend_name": name,
+            "volume_driver": "cinder.volume.drivers.netapp.common.NetAppDriver",
+            "netapp_storage_family": "ontap_cluster",
+            "netapp_storage_protocol": self.protocol,
+            "netapp_server_hostname": self.address,
+            "netapp_server_port": self.server_port,
+            "netapp_login": self.username,
+            "netapp_password": self.password,
+            "netapp_vserver": self.vserver,
+            "netapp_transport_type": self.transport_type,
+            "use_multipath_for_image_xfer": self.use_multipath_for_image_xfer,
+        }
+        if self.nfs_shares_config is not None:
+            config["nfs_shares_config"] = self.nfs_shares_config
+        config.update(self.netapp_options)
+        return config
+
+    def amend_cinder(self, result: HelmValues, name: str) -> None:
+        """Amend Cinder Helm values for a NetApp ONTAP volume backend."""
+        super().amend_cinder(result, name)
+        result["conf"]["backends"][name] = self.cinder_backend_config(name)
+        result.setdefault("pod", {})
+        result["pod"]["useHostNetwork"] = {"volume": True}
+        result["pod"]["security_context"] = {
+            "cinder_volume": {
+                "container": {
+                    "cinder_volume": {
+                        "privileged": True,
+                    }
+                }
+            },
+        }
+
+
 class _VolumeBackendPureBase(_HostAttachedVolumeBackend):
     """Pure Storage FlashArray volume backend."""
 
@@ -491,6 +569,7 @@ VolumeBackend = Annotated[
         VolumeBackendRbd,
         VolumeBackendRbdEc,
         VolumeBackendPowerstore,
+        VolumeBackendNetApp,
         VolumeBackendPure,
         VolumeBackendStorpool,
         VolumeBackendNimble,
@@ -702,9 +781,23 @@ def _parse(raw: Any) -> StorageConfig:
     return StorageConfig.model_validate(raw)
 
 
+def _masked_backend_names(raw: Any, section: str) -> list[str]:
+    """Return backend names explicitly set to ``None`` in raw input."""
+    if not isinstance(raw, dict):
+        return []
+    storage_section = raw.get(section)
+    if not isinstance(storage_section, dict):
+        return []
+    backends = storage_section.get("backends")
+    if not isinstance(backends, dict):
+        return []
+    return [name for name, backend in backends.items() if backend is None]
+
+
 def storage_to_cinder_helm_values(raw: Any) -> HelmValues:
     """Derive Cinder Helm values from atmosphere_storage."""
 
+    masked_backend_names = _masked_backend_names(raw, "volumes")
     storage = _parse(raw)
     volumes = storage.volumes
     backup = storage.backup
@@ -712,6 +805,9 @@ def storage_to_cinder_helm_values(raw: Any) -> HelmValues:
     backends_config = volumes.backends if volumes else {}
 
     result: HelmValues = {"conf": {"backends": {}, "cinder": {"DEFAULT": {}}}}
+
+    for name in masked_backend_names:
+        result["conf"]["backends"][name] = None
 
     for name, backend in backends_config.items():
         backend.amend_cinder(result, name)

--- a/releasenotes/notes/add-netapp-cinder-backend-91d37cf6054a9d2b.yaml
+++ b/releasenotes/notes/add-netapp-cinder-backend-91d37cf6054a9d2b.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Added first-class NetApp ONTAP Cinder backend support to
+    ``atmosphere_storage``. Deployments can now configure
+    ``atmosphere_storage.volumes.backends.<name>.type: netapp`` for the
+    OpenStack Cinder NetApp unified driver with iSCSI, Fibre Channel, NFS, or
+    NVMe protocols.

--- a/releasenotes/notes/add-trident-csi-driver-8f7a2e11b3f0d9c4.yaml
+++ b/releasenotes/notes/add-trident-csi-driver-8f7a2e11b3f0d9c4.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added support for deploying NetApp Trident as an Atmosphere CSI driver by
+    setting ``csi_driver: trident``. The new ``trident_csi`` role installs the
+    Trident operator, creates a Trident backend, and provisions the
+    ``general`` StorageClass using ``csi.trident.netapp.io``.

--- a/releasenotes/notes/trident-csi-fc-support-9d55a20eda6306f2.yaml
+++ b/releasenotes/notes/trident-csi-fc-support-9d55a20eda6306f2.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Atmosphere now supports Fibre Channel with the NetApp Trident CSI role.
+    Set ``trident_csi_access_protocol`` to ``fc`` with
+    ``trident_csi_storage_driver: ontap-san`` to prepare Trident hosts for
+    Fibre Channel instead of iSCSI.

--- a/roles/trident_csi/README.md
+++ b/roles/trident_csi/README.md
@@ -1,4 +1,6 @@
 # `trident_csi`
 
 Installs NetApp Trident as the Kubernetes CSI driver and configures a Trident
-backend plus the `general` StorageClass used by Atmosphere services.
+backend plus the `general` StorageClass used by Atmosphere services. The role
+defaults to `ontap-san` over iSCSI and also supports Fibre Channel with
+`trident_csi_access_protocol: fc`.

--- a/roles/trident_csi/README.md
+++ b/roles/trident_csi/README.md
@@ -1,0 +1,4 @@
+# `trident_csi`
+
+Installs NetApp Trident as the Kubernetes CSI driver and configures a Trident
+backend plus the `general` StorageClass used by Atmosphere services.

--- a/roles/trident_csi/README.md
+++ b/roles/trident_csi/README.md
@@ -3,4 +3,6 @@
 Installs NetApp Trident as the Kubernetes CSI driver and configures a Trident
 backend plus the `general` StorageClass used by Atmosphere services. The role
 defaults to `ontap-san` over iSCSI and also supports Fibre Channel with
-`trident_csi_access_protocol: fc`.
+`trident_csi_access_protocol: fc`, NVMe/TCP with
+`trident_csi_access_protocol: nvme`, and ONTAP NAS backends with
+`trident_csi_access_protocol: nfs` or `smb`.

--- a/roles/trident_csi/defaults/main.yml
+++ b/roles/trident_csi/defaults/main.yml
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+---
+trident_csi_version: "26.02.0"
+trident_csi_installer_url: >-
+  {{
+    'https://github.com/NetApp/trident/releases/download/v' ~
+    trident_csi_version ~
+    '/trident-installer-' ~
+    trident_csi_version ~
+    '.tar.gz'
+  }}
+trident_csi_installer_checksum: ""
+trident_csi_installer_archive: >-
+  /var/lib/trident-installer-{{ trident_csi_version }}.tar.gz
+trident_csi_installer_directory: >-
+  /var/lib/trident-installer-{{ trident_csi_version }}
+trident_csi_orchestrator_crd: >-
+  trident.netapp.io_tridentorchestrators_crd_post1.16.yaml
+trident_csi_operator_bundle: bundle.yaml
+
+trident_csi_namespace: trident
+trident_csi_kubeconfig: >-
+  {{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}
+trident_csi_orchestrator_name: trident
+trident_csi_orchestrator_options: {}
+trident_csi_orchestrator_wait_retries: 120
+trident_csi_orchestrator_wait_delay: 10
+
+trident_csi_supported_storage_drivers:
+  - ontap-san
+  - ontap-san-economy
+  - ontap-nas
+  - ontap-nas-economy
+  - ontap-nas-flexgroup
+trident_csi_san_storage_drivers:
+  - ontap-san
+  - ontap-san-economy
+
+trident_csi_storage_driver: ontap-san
+trident_csi_backend_version: 1
+trident_csi_backend_config_name: ontap-san
+trident_csi_backend_name: "{{ trident_csi_backend_config_name }}"
+trident_csi_backend_secret_name: "{{ trident_csi_backend_config_name }}-secret"
+trident_csi_backend_deletion_policy: retain
+trident_csi_backend_options: {}
+trident_csi_wait_for_backend: true
+trident_csi_backend_wait_retries: 60
+trident_csi_backend_wait_delay: 10
+trident_csi_storage_prefix: atmosphere_
+# trident_csi_management_lif:
+# trident_csi_data_lif:
+# trident_csi_svm:
+# trident_csi_username:
+# trident_csi_password:
+
+trident_csi_configure_san: >-
+  {{ trident_csi_storage_driver in trident_csi_san_storage_drivers }}
+trident_csi_san_packages:
+  Debian:
+    - open-iscsi
+    - multipath-tools
+  RedHat:
+    - iscsi-initiator-utils
+    - device-mapper-multipath
+  default:
+    - open-iscsi
+    - multipath-tools
+trident_csi_san_services:
+  Debian:
+    - iscsid
+    - open-iscsi
+    - multipathd
+  RedHat:
+    - iscsid
+    - multipathd
+  default:
+    - iscsid
+    - multipathd
+trident_csi_initiator_name_path: /etc/iscsi/initiatorname.iscsi
+trident_csi_configure_multipath: true
+trident_csi_multipath_conf_path: /etc/multipath.conf
+trident_csi_multipath_find_multipaths: "no"
+
+trident_csi_storage_class_name: general
+trident_csi_storage_class_default: true
+trident_csi_storage_class_reclaim_policy: Delete
+trident_csi_storage_class_volume_binding_mode: WaitForFirstConsumer
+trident_csi_storage_class_allow_volume_expansion: true
+trident_csi_fs_type: ext4
+trident_csi_storage_class_parameters: {}

--- a/roles/trident_csi/defaults/main.yml
+++ b/roles/trident_csi/defaults/main.yml
@@ -45,11 +45,21 @@ trident_csi_supported_storage_drivers:
   - ontap-nas
   - ontap-nas-economy
   - ontap-nas-flexgroup
+trident_csi_supported_access_protocols:
+  - iscsi
+  - fc
 trident_csi_san_storage_drivers:
   - ontap-san
   - ontap-san-economy
+trident_csi_fc_storage_drivers:
+  - ontap-san
 
 trident_csi_storage_driver: ontap-san
+# SAN access protocol for ``ontap-san`` volumes.
+# Use ``fc`` only with ``trident_csi_storage_driver: ontap-san``.
+#
+# trident_csi_access_protocol: iscsi
+trident_csi_access_protocol: iscsi
 trident_csi_backend_version: 1
 trident_csi_backend_config_name: ontap-san
 trident_csi_backend_name: "{{ trident_csi_backend_config_name }}"
@@ -68,27 +78,61 @@ trident_csi_storage_prefix: atmosphere_
 
 trident_csi_configure_san: >-
   {{ trident_csi_storage_driver in trident_csi_san_storage_drivers }}
+trident_csi_configure_iscsi: >-
+  {{ trident_csi_configure_san and trident_csi_access_protocol == 'iscsi' }}
+trident_csi_configure_fc: >-
+  {{ trident_csi_configure_san and trident_csi_access_protocol == 'fc' }}
 trident_csi_san_packages:
-  Debian:
-    - open-iscsi
-    - multipath-tools
-  RedHat:
-    - iscsi-initiator-utils
-    - device-mapper-multipath
-  default:
-    - open-iscsi
-    - multipath-tools
+  iscsi:
+    Debian:
+      - open-iscsi
+      - lsscsi
+      - sg3-utils
+      - multipath-tools
+      - scsitools
+    RedHat:
+      - lsscsi
+      - iscsi-initiator-utils
+      - device-mapper-multipath
+    default:
+      - open-iscsi
+      - lsscsi
+      - sg3-utils
+      - multipath-tools
+      - scsitools
+  fc:
+    Debian:
+      - lsscsi
+      - sg3-utils
+      - multipath-tools
+      - scsitools
+    RedHat:
+      - lsscsi
+      - device-mapper-multipath
+    default:
+      - lsscsi
+      - sg3-utils
+      - multipath-tools
+      - scsitools
 trident_csi_san_services:
-  Debian:
-    - iscsid
-    - open-iscsi
-    - multipathd
-  RedHat:
-    - iscsid
-    - multipathd
-  default:
-    - iscsid
-    - multipathd
+  iscsi:
+    Debian:
+      - iscsid
+      - open-iscsi
+      - multipathd
+    RedHat:
+      - iscsid
+      - multipathd
+    default:
+      - iscsid
+      - multipathd
+  fc:
+    Debian:
+      - multipathd
+    RedHat:
+      - multipathd
+    default:
+      - multipathd
 trident_csi_initiator_name_path: /etc/iscsi/initiatorname.iscsi
 trident_csi_configure_multipath: true
 trident_csi_multipath_conf_path: /etc/multipath.conf

--- a/roles/trident_csi/defaults/main.yml
+++ b/roles/trident_csi/defaults/main.yml
@@ -48,15 +48,39 @@ trident_csi_supported_storage_drivers:
 trident_csi_supported_access_protocols:
   - iscsi
   - fc
+  - nvme
+  - nfs
+  - smb
 trident_csi_san_storage_drivers:
   - ontap-san
   - ontap-san-economy
+trident_csi_nas_storage_drivers:
+  - ontap-nas
+  - ontap-nas-economy
+  - ontap-nas-flexgroup
+trident_csi_san_access_protocols:
+  - iscsi
+  - fc
+  - nvme
+trident_csi_nas_access_protocols:
+  - nfs
+  - smb
 trident_csi_fc_storage_drivers:
   - ontap-san
+trident_csi_nvme_storage_drivers:
+  - ontap-san
+trident_csi_san_type_map:
+  iscsi: iscsi
+  fc: fcp
+  nvme: nvme
+trident_csi_nas_type_map:
+  nfs: nfs
+  smb: smb
 
 trident_csi_storage_driver: ontap-san
 # SAN access protocol for ``ontap-san`` volumes.
-# Use ``fc`` only with ``trident_csi_storage_driver: ontap-san``.
+# Use ``fc`` or ``nvme`` only with ``trident_csi_storage_driver: ontap-san``.
+# Use ``nfs`` or ``smb`` with the ONTAP NAS drivers.
 #
 # trident_csi_access_protocol: iscsi
 trident_csi_access_protocol: iscsi
@@ -65,6 +89,9 @@ trident_csi_backend_config_name: ontap-san
 trident_csi_backend_name: "{{ trident_csi_backend_config_name }}"
 trident_csi_backend_secret_name: "{{ trident_csi_backend_config_name }}-secret"
 trident_csi_backend_deletion_policy: retain
+trident_csi_use_rest: false
+trident_csi_name_template: !unsafe >-
+  {{ .volume.Name }}_{{ .volume.Namespace }}_{{ .volume.RequestName }}
 trident_csi_backend_options: {}
 trident_csi_wait_for_backend: true
 trident_csi_backend_wait_retries: 60
@@ -100,6 +127,16 @@ trident_csi_san_packages:
       - sg3-utils
       - multipath-tools
       - scsitools
+  nvme:
+    Debian:
+      - nvme-cli
+      - multipath-tools
+    RedHat:
+      - nvme-cli
+      - device-mapper-multipath
+    default:
+      - nvme-cli
+      - multipath-tools
   fc:
     Debian:
       - lsscsi
@@ -127,6 +164,13 @@ trident_csi_san_services:
       - iscsid
       - multipathd
   fc:
+    Debian:
+      - multipathd
+    RedHat:
+      - multipathd
+    default:
+      - multipathd
+  nvme:
     Debian:
       - multipathd
     RedHat:

--- a/roles/trident_csi/defaults/main.yml
+++ b/roles/trident_csi/defaults/main.yml
@@ -187,5 +187,12 @@ trident_csi_storage_class_default: true
 trident_csi_storage_class_reclaim_policy: Delete
 trident_csi_storage_class_volume_binding_mode: WaitForFirstConsumer
 trident_csi_storage_class_allow_volume_expansion: true
-trident_csi_fs_type: ext4
+trident_csi_default_fs_type_map:
+  iscsi: ext4
+  fc: ext4
+  nvme: ext4
+  nfs: nfs
+  smb: ""
+trident_csi_fs_type: >-
+  {{ trident_csi_default_fs_type_map[trident_csi_access_protocol] }}
 trident_csi_storage_class_parameters: {}

--- a/roles/trident_csi/meta/main.yml
+++ b/roles/trident_csi/meta/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 VEXXHOST, Inc.
+# Copyright (c) 2026 VEXXHOST, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -15,7 +15,7 @@
 ---
 galaxy_info:
   author: VEXXHOST, Inc.
-  description: Meta role for managing CSI
+  description: Ansible role for NetApp Trident CSI
   license: Apache-2.0
   min_ansible_version: 5.5.0
   standalone: false
@@ -31,19 +31,3 @@ galaxy_info:
 
 dependencies:
   - role: defaults
-  - role: local_path_provisioner
-    when: csi_driver == "local-path-provisioner"
-  - role: ceph_csi_rbd
-    when: csi_driver == "rbd"
-  - role: powerstore_csi
-    when: csi_driver == "powerstore"
-  - role: portworx
-    when: csi_driver == "portworx"
-  - role: storpool_csi
-    when: csi_driver == "storpool"
-  - role: ibm_block_csi_driver
-    when: csi_driver == "ibm-block"
-  - role: hpe_nimble_csi
-    when: csi_driver == "hpe-nimble"
-  - role: trident_csi
-    when: csi_driver == "trident"

--- a/roles/trident_csi/tasks/main.yml
+++ b/roles/trident_csi/tasks/main.yml
@@ -17,6 +17,7 @@
   ansible.builtin.assert:
     that:
       - trident_csi_storage_driver in trident_csi_supported_storage_drivers
+      - trident_csi_access_protocol in trident_csi_supported_access_protocols
       - trident_csi_management_lif is defined
       - trident_csi_svm is defined
       - trident_csi_username is defined
@@ -24,7 +25,18 @@
     fail_msg: >-
       Trident CSI requires trident_csi_management_lif, trident_csi_svm,
       trident_csi_username, trident_csi_password, and a supported
-      trident_csi_storage_driver.
+      trident_csi_storage_driver and trident_csi_access_protocol.
+
+- name: Validate Trident SAN access protocol
+  ansible.builtin.assert:
+    that:
+      - >-
+        trident_csi_access_protocol != 'fc' or
+        trident_csi_storage_driver in trident_csi_fc_storage_drivers
+    fail_msg: >-
+      trident_csi_access_protocol: fc is supported only when
+      trident_csi_storage_driver is set to one of
+      {{ trident_csi_fc_storage_drivers | join(', ') }}.
 
 - name: Install Trident SAN host packages
   ansible.builtin.package:
@@ -34,8 +46,8 @@
   vars:
     _trident_csi_san_package_names: >-
       {{
-        trident_csi_san_packages[ansible_os_family] |
-        default(trident_csi_san_packages.default)
+        trident_csi_san_packages[trident_csi_access_protocol][ansible_os_family] |
+        default(trident_csi_san_packages[trident_csi_access_protocol].default)
       }}
 
 - name: Start Trident SAN services
@@ -48,27 +60,27 @@
   vars:
     _trident_csi_san_service_names: >-
       {{
-        trident_csi_san_services[ansible_os_family] |
-        default(trident_csi_san_services.default)
+        trident_csi_san_services[trident_csi_access_protocol][ansible_os_family] |
+        default(trident_csi_san_services[trident_csi_access_protocol].default)
       }}
 
 - name: Check iSCSI initiator name file
   ansible.builtin.stat:
     path: "{{ trident_csi_initiator_name_path }}"
   register: _trident_csi_initiator_name
-  when: trident_csi_configure_san | bool
+  when: trident_csi_configure_iscsi | bool
 
 - name: Read iSCSI initiator name file
   ansible.builtin.slurp:
     src: "{{ trident_csi_initiator_name_path }}"
   register: _trident_csi_initiator_name_content
   when:
-    - trident_csi_configure_san | bool
+    - trident_csi_configure_iscsi | bool
     - _trident_csi_initiator_name.stat.exists
 
 - name: Configure iSCSI initiator name
   when:
-    - trident_csi_configure_san | bool
+    - trident_csi_configure_iscsi | bool
     - >-
       not _trident_csi_initiator_name.stat.exists or
       'InitiatorName=' not in

--- a/roles/trident_csi/tasks/main.yml
+++ b/roles/trident_csi/tasks/main.yml
@@ -1,0 +1,329 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+---
+- name: Validate Trident CSI configuration
+  ansible.builtin.assert:
+    that:
+      - trident_csi_storage_driver in trident_csi_supported_storage_drivers
+      - trident_csi_management_lif is defined
+      - trident_csi_svm is defined
+      - trident_csi_username is defined
+      - trident_csi_password is defined
+    fail_msg: >-
+      Trident CSI requires trident_csi_management_lif, trident_csi_svm,
+      trident_csi_username, trident_csi_password, and a supported
+      trident_csi_storage_driver.
+
+- name: Install Trident SAN host packages
+  ansible.builtin.package:
+    name: "{{ _trident_csi_san_package_names }}"
+    state: present
+  when: trident_csi_configure_san | bool
+  vars:
+    _trident_csi_san_package_names: >-
+      {{
+        trident_csi_san_packages[ansible_os_family] |
+        default(trident_csi_san_packages.default)
+      }}
+
+- name: Start Trident SAN services
+  ansible.builtin.service:
+    name: "{{ item }}"
+    enabled: true
+    state: started
+  loop: "{{ _trident_csi_san_service_names }}"
+  when: trident_csi_configure_san | bool
+  vars:
+    _trident_csi_san_service_names: >-
+      {{
+        trident_csi_san_services[ansible_os_family] |
+        default(trident_csi_san_services.default)
+      }}
+
+- name: Check iSCSI initiator name file
+  ansible.builtin.stat:
+    path: "{{ trident_csi_initiator_name_path }}"
+  register: _trident_csi_initiator_name
+  when: trident_csi_configure_san | bool
+
+- name: Read iSCSI initiator name file
+  ansible.builtin.slurp:
+    src: "{{ trident_csi_initiator_name_path }}"
+  register: _trident_csi_initiator_name_content
+  when:
+    - trident_csi_configure_san | bool
+    - _trident_csi_initiator_name.stat.exists
+
+- name: Configure iSCSI initiator name
+  when:
+    - trident_csi_configure_san | bool
+    - >-
+      not _trident_csi_initiator_name.stat.exists or
+      'InitiatorName=' not in
+      (_trident_csi_initiator_name_content.content | default('') | b64decode)
+  block:
+    - name: Generate iSCSI initiator name
+      changed_when: true
+      ansible.builtin.command:
+        cmd: iscsi-iname
+      register: _trident_csi_iscsi_iname
+
+    - name: Write iSCSI initiator name
+      ansible.builtin.copy:
+        content: "InitiatorName={{ _trident_csi_iscsi_iname.stdout }}\n"
+        dest: "{{ trident_csi_initiator_name_path }}"
+        owner: root
+        group: root
+        mode: "0644"
+
+- name: Check multipath configuration
+  ansible.builtin.stat:
+    path: "{{ trident_csi_multipath_conf_path }}"
+  register: _trident_csi_multipath_conf
+  when:
+    - trident_csi_configure_san | bool
+    - trident_csi_configure_multipath | bool
+
+- name: Read multipath configuration
+  ansible.builtin.slurp:
+    src: "{{ trident_csi_multipath_conf_path }}"
+  register: _trident_csi_multipath_conf_content
+  when:
+    - trident_csi_configure_san | bool
+    - trident_csi_configure_multipath | bool
+    - _trident_csi_multipath_conf.stat.exists
+
+- name: Set multipath configuration content fact
+  ansible.builtin.set_fact:
+    _trident_csi_multipath_conf_text: >-
+      {{
+        _trident_csi_multipath_conf_content.content |
+        default('') |
+        b64decode
+      }}
+  when:
+    - trident_csi_configure_san | bool
+    - trident_csi_configure_multipath | bool
+
+- name: Update existing find_multipaths setting
+  ansible.builtin.lineinfile:
+    path: "{{ trident_csi_multipath_conf_path }}"
+    regexp: '^\s*find_multipaths\s+'
+    line: "    find_multipaths {{ trident_csi_multipath_find_multipaths }}"
+  register: _trident_csi_multipath_line
+  when:
+    - trident_csi_configure_san | bool
+    - trident_csi_configure_multipath | bool
+    - >-
+      'find_multipaths' in
+      (_trident_csi_multipath_conf_text | default(''))
+
+- name: Add Trident multipath defaults
+  ansible.builtin.blockinfile:
+    path: "{{ trident_csi_multipath_conf_path }}"
+    create: true
+    owner: root
+    group: root
+    mode: "0644"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK: NetApp Trident CSI"
+    block: |
+      defaults {
+          find_multipaths {{ trident_csi_multipath_find_multipaths }}
+      }
+  register: _trident_csi_multipath_block
+  when:
+    - trident_csi_configure_san | bool
+    - trident_csi_configure_multipath | bool
+    - >-
+      'find_multipaths' not in
+      (_trident_csi_multipath_conf_text | default(''))
+
+- name: Restart multipathd after Trident multipath changes
+  ansible.builtin.service:
+    name: multipathd
+    state: restarted
+  when:
+    - trident_csi_configure_san | bool
+    - trident_csi_configure_multipath | bool
+    - >-
+      (_trident_csi_multipath_line.changed | default(false)) or
+      (_trident_csi_multipath_block.changed | default(false))
+
+- name: Create Trident namespace
+  run_once: true
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ trident_csi_kubeconfig }}"
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ trident_csi_namespace }}"
+
+- name: Create Trident installer directory
+  run_once: true
+  ansible.builtin.file:
+    path: "{{ trident_csi_installer_directory }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Download Trident installer package
+  run_once: true
+  ansible.builtin.get_url:
+    url: "{{ trident_csi_installer_url }}"
+    dest: "{{ trident_csi_installer_archive }}"
+    checksum: "{{ trident_csi_installer_checksum | default(omit, true) }}"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Extract Trident installer package
+  run_once: true
+  ansible.builtin.unarchive:
+    src: "{{ trident_csi_installer_archive }}"
+    dest: "{{ trident_csi_installer_directory }}"
+    remote_src: true
+    extra_opts:
+      - --strip-components=1
+    creates: "{{ trident_csi_installer_directory }}/deploy"
+
+- name: Create TridentOrchestrator CRD
+  run_once: true
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ trident_csi_kubeconfig }}"
+    src: >-
+      {{
+        trident_csi_installer_directory ~
+        '/deploy/crds/' ~
+        trident_csi_orchestrator_crd
+      }}
+
+- name: Wait for TridentOrchestrator CRD
+  run_once: true
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    kubeconfig: "{{ trident_csi_kubeconfig }}"
+    name: tridentorchestrators.trident.netapp.io
+  register: _trident_csi_orchestrator_crd
+  retries: 60
+  delay: 5
+  until: _trident_csi_orchestrator_crd.resources | length > 0
+
+- name: Deploy Trident operator
+  run_once: true
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ trident_csi_kubeconfig }}"
+    src: >-
+      {{
+        trident_csi_installer_directory ~
+        '/deploy/' ~
+        trident_csi_operator_bundle
+      }}
+
+- name: Create TridentOrchestrator
+  run_once: true
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ trident_csi_kubeconfig }}"
+    template:
+      - path: tridentorchestrator.yaml.j2
+
+- name: Wait for Trident installation
+  run_once: true
+  kubernetes.core.k8s_info:
+    api_version: trident.netapp.io/v1
+    kind: TridentOrchestrator
+    kubeconfig: "{{ trident_csi_kubeconfig }}"
+    name: "{{ trident_csi_orchestrator_name }}"
+  register: _trident_csi_orchestrator
+  retries: "{{ trident_csi_orchestrator_wait_retries }}"
+  delay: "{{ trident_csi_orchestrator_wait_delay }}"
+  until:
+    - _trident_csi_orchestrator.resources | length > 0
+    - >-
+      (_trident_csi_orchestrator.resources[0].status.status | default('')) ==
+      'Installed'
+
+- name: Wait for TridentBackendConfig CRD
+  run_once: true
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    kubeconfig: "{{ trident_csi_kubeconfig }}"
+    name: tridentbackendconfigs.trident.netapp.io
+  register: _trident_csi_backend_config_crd
+  retries: 60
+  delay: 5
+  until: _trident_csi_backend_config_crd.resources | length > 0
+
+- name: Create Trident backend credentials
+  run_once: true
+  no_log: true
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ trident_csi_kubeconfig }}"
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ trident_csi_backend_secret_name }}"
+        namespace: "{{ trident_csi_namespace }}"
+      type: Opaque
+      stringData:
+        username: "{{ trident_csi_username }}"
+        password: "{{ trident_csi_password }}"
+
+- name: Create Trident backend
+  run_once: true
+  no_log: true
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ trident_csi_kubeconfig }}"
+    template:
+      - path: backend.yaml.j2
+
+- name: Wait for Trident backend binding
+  run_once: true
+  kubernetes.core.k8s_info:
+    api_version: trident.netapp.io/v1
+    kind: TridentBackendConfig
+    kubeconfig: "{{ trident_csi_kubeconfig }}"
+    name: "{{ trident_csi_backend_config_name }}"
+    namespace: "{{ trident_csi_namespace }}"
+  register: _trident_csi_backend_config
+  retries: "{{ trident_csi_backend_wait_retries }}"
+  delay: "{{ trident_csi_backend_wait_delay }}"
+  until:
+    - _trident_csi_backend_config.resources | length > 0
+    - >-
+      (_trident_csi_backend_config.resources[0].status.phase |
+      default('')) == 'Bound'
+    - >-
+      (_trident_csi_backend_config.resources[0].status.lastOperationStatus |
+      default('')) == 'Success'
+  when: trident_csi_wait_for_backend | bool
+
+- name: Create Trident StorageClass
+  run_once: true
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ trident_csi_kubeconfig }}"
+    template:
+      - path: storageclass.yaml.j2

--- a/roles/trident_csi/tasks/main.yml
+++ b/roles/trident_csi/tasks/main.yml
@@ -19,24 +19,33 @@
       - trident_csi_storage_driver in trident_csi_supported_storage_drivers
       - trident_csi_access_protocol in trident_csi_supported_access_protocols
       - trident_csi_management_lif is defined
-      - trident_csi_svm is defined
       - trident_csi_username is defined
       - trident_csi_password is defined
     fail_msg: >-
-      Trident CSI requires trident_csi_management_lif, trident_csi_svm,
-      trident_csi_username, trident_csi_password, and a supported
-      trident_csi_storage_driver and trident_csi_access_protocol.
+      Trident CSI requires trident_csi_management_lif, trident_csi_username,
+      trident_csi_password, and supported trident_csi_storage_driver and
+      trident_csi_access_protocol values.
 
-- name: Validate Trident SAN access protocol
+- name: Validate Trident storage driver access protocol
   ansible.builtin.assert:
     that:
       - >-
+        (
+          trident_csi_storage_driver in trident_csi_san_storage_drivers and
+          trident_csi_access_protocol in trident_csi_san_access_protocols
+        ) or (
+          trident_csi_storage_driver in trident_csi_nas_storage_drivers and
+          trident_csi_access_protocol in trident_csi_nas_access_protocols
+        )
+      - >-
         trident_csi_access_protocol != 'fc' or
         trident_csi_storage_driver in trident_csi_fc_storage_drivers
+      - >-
+        trident_csi_access_protocol != 'nvme' or
+        trident_csi_storage_driver in trident_csi_nvme_storage_drivers
     fail_msg: >-
-      trident_csi_access_protocol: fc is supported only when
-      trident_csi_storage_driver is set to one of
-      {{ trident_csi_fc_storage_drivers | join(', ') }}.
+      The selected trident_csi_access_protocol is not supported by
+      trident_csi_storage_driver.
 
 - name: Install Trident SAN host packages
   ansible.builtin.package:
@@ -44,10 +53,12 @@
     state: present
   when: trident_csi_configure_san | bool
   vars:
+    _trident_csi_san_protocol_packages: >-
+      {{ trident_csi_san_packages[trident_csi_access_protocol] }}
     _trident_csi_san_package_names: >-
       {{
-        trident_csi_san_packages[trident_csi_access_protocol][ansible_os_family] |
-        default(trident_csi_san_packages[trident_csi_access_protocol].default)
+        _trident_csi_san_protocol_packages[ansible_os_family] |
+        default(_trident_csi_san_protocol_packages.default)
       }}
 
 - name: Start Trident SAN services
@@ -58,10 +69,12 @@
   loop: "{{ _trident_csi_san_service_names }}"
   when: trident_csi_configure_san | bool
   vars:
+    _trident_csi_san_protocol_services: >-
+      {{ trident_csi_san_services[trident_csi_access_protocol] }}
     _trident_csi_san_service_names: >-
       {{
-        trident_csi_san_services[trident_csi_access_protocol][ansible_os_family] |
-        default(trident_csi_san_services[trident_csi_access_protocol].default)
+        _trident_csi_san_protocol_services[ansible_os_family] |
+        default(_trident_csi_san_protocol_services.default)
       }}
 
 - name: Check iSCSI initiator name file

--- a/roles/trident_csi/templates/backend.yaml.j2
+++ b/roles/trident_csi/templates/backend.yaml.j2
@@ -1,0 +1,23 @@
+apiVersion: trident.netapp.io/v1
+kind: TridentBackendConfig
+metadata:
+  name: "{{ trident_csi_backend_config_name }}"
+  namespace: "{{ trident_csi_namespace }}"
+spec:
+  version: {{ trident_csi_backend_version }}
+  backendName: "{{ trident_csi_backend_name }}"
+  storageDriverName: "{{ trident_csi_storage_driver }}"
+  managementLIF: "{{ trident_csi_management_lif }}"
+{% if trident_csi_data_lif is defined and trident_csi_data_lif | string | length > 0 %}
+  dataLIF: "{{ trident_csi_data_lif }}"
+{% endif %}
+  svm: "{{ trident_csi_svm }}"
+{% if trident_csi_storage_prefix | string | length > 0 %}
+  storagePrefix: "{{ trident_csi_storage_prefix }}"
+{% endif %}
+  deletionPolicy: "{{ trident_csi_backend_deletion_policy }}"
+  credentials:
+    name: "{{ trident_csi_backend_secret_name }}"
+{% if trident_csi_backend_options | length > 0 %}
+{{ trident_csi_backend_options | to_nice_yaml(indent=2) | indent(2, true) }}
+{% endif %}

--- a/roles/trident_csi/templates/backend.yaml.j2
+++ b/roles/trident_csi/templates/backend.yaml.j2
@@ -8,16 +8,29 @@ spec:
   backendName: "{{ trident_csi_backend_name }}"
   storageDriverName: "{{ trident_csi_storage_driver }}"
   managementLIF: "{{ trident_csi_management_lif }}"
-{% if trident_csi_data_lif is defined and trident_csi_data_lif | string | length > 0 %}
+{% set _trident_csi_render_data_lif = (
+  trident_csi_storage_driver in trident_csi_nas_storage_drivers and
+  trident_csi_data_lif is defined and
+  trident_csi_data_lif | string | length > 0
+) %}
+{% if _trident_csi_render_data_lif %}
   dataLIF: "{{ trident_csi_data_lif }}"
 {% endif %}
+{% if trident_csi_svm is defined and trident_csi_svm | string | length > 0 %}
   svm: "{{ trident_csi_svm }}"
+{% endif %}
+{% if trident_csi_storage_driver in trident_csi_san_storage_drivers %}
+  sanType: "{{ trident_csi_san_type_map[trident_csi_access_protocol] }}"
+{% endif %}
+{% if trident_csi_storage_driver in trident_csi_nas_storage_drivers %}
+  nasType: "{{ trident_csi_nas_type_map[trident_csi_access_protocol] }}"
+{% endif %}
 {% if trident_csi_storage_prefix | string | length > 0 %}
   storagePrefix: "{{ trident_csi_storage_prefix }}"
 {% endif %}
   deletionPolicy: "{{ trident_csi_backend_deletion_policy }}"
   credentials:
     name: "{{ trident_csi_backend_secret_name }}"
-{% if trident_csi_backend_options | length > 0 %}
-{{ trident_csi_backend_options | to_nice_yaml(indent=2) | indent(2, true) }}
+{% if _trident_csi_backend_options | length > 0 %}
+{{ _trident_csi_backend_options | to_nice_yaml(indent=2) | indent(2, true) }}
 {% endif %}

--- a/roles/trident_csi/templates/storageclass.yaml.j2
+++ b/roles/trident_csi/templates/storageclass.yaml.j2
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "{{ trident_csi_storage_class_name }}"
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "{{ trident_csi_storage_class_default | bool | lower }}"
+provisioner: csi.trident.netapp.io
+allowVolumeExpansion: {{ trident_csi_storage_class_allow_volume_expansion | bool | lower }}
+reclaimPolicy: "{{ trident_csi_storage_class_reclaim_policy }}"
+volumeBindingMode: "{{ trident_csi_storage_class_volume_binding_mode }}"
+parameters:
+{{ _trident_csi_storage_class_parameters | to_nice_yaml(indent=2) | indent(2, true) }}

--- a/roles/trident_csi/templates/tridentorchestrator.yaml.j2
+++ b/roles/trident_csi/templates/tridentorchestrator.yaml.j2
@@ -1,0 +1,9 @@
+apiVersion: trident.netapp.io/v1
+kind: TridentOrchestrator
+metadata:
+  name: "{{ trident_csi_orchestrator_name }}"
+spec:
+  namespace: "{{ trident_csi_namespace }}"
+{% if trident_csi_orchestrator_options | length > 0 %}
+{{ trident_csi_orchestrator_options | to_nice_yaml(indent=2) | indent(2, true) }}
+{% endif %}

--- a/roles/trident_csi/vars/main.yml
+++ b/roles/trident_csi/vars/main.yml
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+---
+_trident_csi_storage_class_base_parameters:
+  backendType: "{{ trident_csi_storage_driver }}"
+
+_trident_csi_storage_class_fs_type_parameters: >-
+  {{
+    (trident_csi_fs_type | string | length > 0) |
+    ternary({'fsType': trident_csi_fs_type}, {})
+  }}
+
+_trident_csi_storage_class_parameters: >-
+  {{
+    _trident_csi_storage_class_base_parameters |
+    combine(_trident_csi_storage_class_fs_type_parameters) |
+    combine(trident_csi_storage_class_parameters)
+  }}

--- a/roles/trident_csi/vars/main.yml
+++ b/roles/trident_csi/vars/main.yml
@@ -13,6 +13,17 @@
 # under the License.
 
 ---
+_trident_csi_backend_default_options:
+  useREST: "{{ trident_csi_use_rest | bool }}"
+  defaults:
+    nameTemplate: "{{ trident_csi_name_template }}"
+
+_trident_csi_backend_options: >-
+  {{
+    _trident_csi_backend_default_options |
+    combine(trident_csi_backend_options, recursive=True)
+  }}
+
 _trident_csi_storage_class_base_parameters:
   backendType: "{{ trident_csi_storage_driver }}"
 

--- a/tests/unit/plugins/filter/test_storage.py
+++ b/tests/unit/plugins/filter/test_storage.py
@@ -78,6 +78,15 @@ _POWERSTORE_BACKEND = {
     "protocol": "iscsi",
 }
 
+_NETAPP_ISCSI_BACKEND = {
+    "type": "netapp",
+    "protocol": "iscsi",
+    "address": "10.0.0.10",
+    "username": "admin",
+    "password": "secret",
+    "vserver": "svm_cinder",
+}
+
 _PURE_ISCSI_BACKEND = {
     "type": "pure",
     "protocol": "iscsi",
@@ -107,6 +116,16 @@ _NIMBLE_FC_BACKEND = {
 }
 
 _NIMBLE_POD_SECURITY_CONTEXT = {
+    "cinder_volume": {
+        "container": {
+            "cinder_volume": {
+                "privileged": True,
+            }
+        }
+    }
+}
+
+_NETAPP_POD_SECURITY_CONTEXT = {
     "cinder_volume": {
         "container": {
             "cinder_volume": {
@@ -342,6 +361,22 @@ class TestValidation:
                 }
             )
 
+    def test_netapp_nfs_requires_shares_config(self):
+        with pytest.raises(ValidationError, match="NetApp NFS backends require"):
+            StorageConfig.model_validate(
+                {
+                    "volumes": {
+                        "default": "netapp",
+                        "backends": {
+                            "netapp": {
+                                **_NETAPP_ISCSI_BACKEND,
+                                "protocol": "nfs",
+                            },
+                        },
+                    },
+                }
+            )
+
     def test_erasure_coded_k_below_minimum_rejected(self):
         with pytest.raises(ValidationError):
             StorageConfig.model_validate(
@@ -444,7 +479,8 @@ class TestStorageToCinderHelmValues:
 
         result = storage_to_cinder_helm_values(storage)
 
-        assert set(result["conf"]["backends"]) == {"ceph", "ecpool"}
+        assert set(result["conf"]["backends"]) == {"rbd1", "ceph", "ecpool"}
+        assert result["conf"]["backends"]["rbd1"] is None
         assert result["conf"]["cinder"]["DEFAULT"]["enabled_backends"] == "ceph,ecpool"
         assert result["conf"]["cinder"]["DEFAULT"]["default_volume_type"] == "ceph"
         assert result["ceph_client"]["internal_ceph_backend"] == "ceph"
@@ -624,6 +660,132 @@ class TestStorageToCinderHelmValues:
         }
         result = storage_to_cinder_helm_values(storage)
         assert result["conf"]["backends"]["ps"]["storage_protocol"] == "FC"
+
+    def test_netapp_iscsi_backend(self):
+        storage = {
+            **DEFAULT_STORAGE,
+            "volumes": {
+                "default": "netapp",
+                "backends": {"netapp": _NETAPP_ISCSI_BACKEND},
+            },
+            "backup": {"type": "none"},
+        }
+        result = storage_to_cinder_helm_values(storage)
+
+        backend = result["conf"]["backends"]["netapp"]
+        assert (
+            backend["volume_driver"]
+            == "cinder.volume.drivers.netapp.common.NetAppDriver"
+        )
+        assert backend["netapp_storage_family"] == "ontap_cluster"
+        assert backend["netapp_storage_protocol"] == "iscsi"
+        assert backend["netapp_server_hostname"] == "10.0.0.10"
+        assert backend["netapp_server_port"] == 443
+        assert backend["netapp_login"] == "admin"
+        assert backend["netapp_password"] == "secret"
+        assert backend["netapp_vserver"] == "svm_cinder"
+        assert backend["netapp_transport_type"] == "https"
+        assert backend["use_multipath_for_image_xfer"] is True
+        assert result["conf"]["enable_iscsi"] is True
+        assert result["pod"]["useHostNetwork"] == {"volume": True}
+        assert result["pod"]["security_context"] == _NETAPP_POD_SECURITY_CONTEXT
+        assert result["manifests"]["job_storage_init"] is False
+
+    def test_netapp_fc_backend(self):
+        storage = {
+            **DEFAULT_STORAGE,
+            "volumes": {
+                "default": "netapp",
+                "backends": {
+                    "netapp": {**_NETAPP_ISCSI_BACKEND, "protocol": "fc"},
+                },
+            },
+            "backup": {"type": "none"},
+        }
+        result = storage_to_cinder_helm_values(storage)
+
+        backend = result["conf"]["backends"]["netapp"]
+        assert backend["netapp_storage_protocol"] == "fc"
+        assert backend["use_multipath_for_image_xfer"] is True
+
+    def test_netapp_nfs_backend_with_shares_config(self):
+        storage = {
+            **DEFAULT_STORAGE,
+            "volumes": {
+                "default": "netapp",
+                "backends": {
+                    "netapp": {
+                        **_NETAPP_ISCSI_BACKEND,
+                        "protocol": "nfs",
+                        "nfs_shares_config": ["10.0.0.20:/cinder"],
+                    },
+                },
+            },
+            "backup": {"type": "none"},
+        }
+        result = storage_to_cinder_helm_values(storage)
+
+        backend = result["conf"]["backends"]["netapp"]
+        assert backend["netapp_storage_protocol"] == "nfs"
+        assert backend["nfs_shares_config"] == ["10.0.0.20:/cinder"]
+
+    def test_netapp_backend_custom_options(self):
+        storage = {
+            **DEFAULT_STORAGE,
+            "volumes": {
+                "default": "netapp",
+                "backends": {
+                    "netapp": {
+                        **_NETAPP_ISCSI_BACKEND,
+                        "protocol": "nvme",
+                        "transport_type": "http",
+                        "server_port": 80,
+                        "use_multipath_for_image_xfer": False,
+                        "netapp_options": {
+                            "netapp_lun_space_reservation": "disabled",
+                            "netapp_lun_ostype": "linux",
+                        },
+                    },
+                },
+            },
+            "backup": {"type": "none"},
+        }
+        result = storage_to_cinder_helm_values(storage)
+
+        backend = result["conf"]["backends"]["netapp"]
+        assert backend["netapp_storage_protocol"] == "nvme"
+        assert backend["netapp_transport_type"] == "http"
+        assert backend["netapp_server_port"] == 80
+        assert backend["use_multipath_for_image_xfer"] is False
+        assert backend["netapp_lun_space_reservation"] == "disabled"
+        assert backend["netapp_lun_ostype"] == "linux"
+
+    def test_netapp_with_rbd1_default_nulled_out(self):
+        storage = {
+            "images": {
+                "default": "cinder_store",
+                "backends": {
+                    "rbd1": None,
+                    "cinder_store": {"type": "cinder"},
+                },
+            },
+            "volumes": {
+                "default": "netapp1",
+                "backends": {
+                    "rbd1": None,
+                    "netapp1": _NETAPP_ISCSI_BACKEND,
+                },
+            },
+            "backup": {"type": "none"},
+            "ephemeral": {"type": "local"},
+        }
+        result = storage_to_cinder_helm_values(storage)
+
+        assert result["conf"]["backends"]["rbd1"] is None
+        assert result["storage"] == "netapp"
+        assert result["conf"]["cinder"]["DEFAULT"]["enabled_backends"] == "netapp1"
+        assert result["conf"]["cinder"]["DEFAULT"]["default_volume_type"] == "netapp1"
+        assert result["manifests"]["job_storage_init"] is False
 
     def test_pure_iscsi_backend(self):
         storage = {
@@ -1094,6 +1256,18 @@ class TestStorageToNovaHelmValues:
             },
         }
         result = storage_to_nova_helm_values(storage)
+        assert result["conf"]["enable_iscsi"] is True
+
+    def test_iscsi_from_netapp_volume_backend(self):
+        storage = {
+            "ephemeral": {"type": "local"},
+            "volumes": {
+                "default": "netapp",
+                "backends": {"netapp": _NETAPP_ISCSI_BACKEND},
+            },
+        }
+        result = storage_to_nova_helm_values(storage)
+        assert result["conf"]["ceph"]["enabled"] is False
         assert result["conf"]["enable_iscsi"] is True
 
     def test_rbd_volumes_no_iscsi(self):

--- a/tests/unit/plugins/filter/test_storage.py
+++ b/tests/unit/plugins/filter/test_storage.py
@@ -958,8 +958,9 @@ class TestStorageToCinderHelmValues:
         }
         result = storage_to_cinder_helm_values(storage)
 
-        assert "rbd1" not in result["conf"]["backends"]
+        assert result["conf"]["backends"]["rbd1"] is None
         assert result["storage"] == "nimble"
+        assert result["conf"]["cinder"]["DEFAULT"]["enabled_backends"] == "nimble1"
         assert result["manifests"]["job_storage_init"] is False
         assert result["conf"]["enable_iscsi"] is True
 


### PR DESCRIPTION
## Summary

This integration PR is based on `stable/2025.2` and cherry-picks the pending NetApp storage changes onto a released 7.x baseline.

Included changes:

- Trident CSI support for Kubernetes PVCs
- Trident Fibre Channel protocol support
- First-class NetApp ONTAP Cinder backend support via `type: netapp`

The intent is to provide a stable branch for validating NetApp-backed Kubernetes PVCs and OpenStack Cinder volumes before the individual feature PRs are merged.

## Usage

Use this branch directly for validation:

```bash
git fetch origin feat/netapp-storage-stable-2025.2
git switch --detach origin/feat/netapp-storage-stable-2025.2
```

Configure both storage layers in inventory:

- `csi_driver: trident` for Kubernetes PVCs
- `atmosphere_storage.volumes.backends.<name>.type: netapp` for OpenStack Cinder
