### PR TITLE
fix(kube_prometheus_stack): wait for configured Keycloak API

### DIFF
--- a/releasenotes/notes/kube-prometheus-stack-keycloak-api-readiness-5651895caf043cbd.yaml
+++ b/releasenotes/notes/kube-prometheus-stack-keycloak-api-readiness-5651895caf043cbd.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The ``kube_prometheus_stack`` role now waits for the configured Keycloak
+    API URL before managing realms and clients instead of requiring a local
+    Kubernetes ``StatefulSet``.

--- a/roles/kube_prometheus_stack/tasks/main.yml
+++ b/roles/kube_prometheus_stack/tasks/main.yml
@@ -13,16 +13,14 @@
 # under the License.
 
 - name: Wait until Keycloak service is ready
-  kubernetes.core.k8s_info:
-    api_version: apps/v1
-    kind: StatefulSet
-    name: keycloak
-    namespace: auth-system
+  ansible.builtin.uri:
+    url: "{{ kube_prometheus_stack_keycloak_server_url }}/realms/{{ kube_prometheus_stack_keycloak_admin_realm_name }}"
+    status_code: 200
+    validate_certs: "{{ cluster_issuer_type != 'self-signed' }}"
   register: kube_prometheus_stack_keycloak_service
   retries: 120
   delay: 5
-  until:
-    - kube_prometheus_stack_keycloak_service.resources[0].status.replicas == kube_prometheus_stack_keycloak_service.resources[0].status.readyReplicas # noqa: yaml[line-length]
+  until: kube_prometheus_stack_keycloak_service.status == 200
 
 - name: Create Keycloak realm
   no_log: true


### PR DESCRIPTION
## Summary
- wait for the configured Keycloak API URL and admin realm before managing monitoring realms and clients
- stop assuming a local `auth-system/keycloak` StatefulSet exists
- add a release note for the readiness-check fix

## Tests
- `git diff --check`
- `nix-shell -p ansible-lint --run "ansible-lint --offline roles/kube_prometheus_stack/tasks/main.yml"`