### PR TITLE
fix(openstack-exporter): pass Designate DB URL to database exporter

### DIFF
--- a/releasenotes/notes/openstack-database-exporter-designate-dsn-7b9c2e1d4f5a8c63.yaml
+++ b/releasenotes/notes/openstack-database-exporter-designate-dsn-7b9c2e1d4f5a8c63.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Passed the Designate database connection URL to the OpenStack database
+    exporter so it can expose Designate database metrics.

--- a/roles/openstack_exporter/tasks/main.yml
+++ b/roles/openstack_exporter/tasks/main.yml
@@ -125,6 +125,7 @@
   register: _db_secrets
   loop:
     - cinder-db-user
+    - designate-db-user
     - glance-db-user
     - heat-db-user
     - ironic-db-user


### PR DESCRIPTION
## Summary

- include `designate-db-user` when building the OpenStack database exporter DSN secret
- add a release note for the Designate exporter DSN wiring