### PR TITLE
feat(keycloak): add PostgreSQL migration path

### DIFF
--- a/playbooks/keycloak-migrate-to-postgresql.yml
+++ b/playbooks/keycloak-migrate-to-postgresql.yml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Migrate Keycloak from MySQL to PostgreSQL
+  hosts: controllers
+  become: true
+  pre_tasks:
+    - name: Require PostgreSQL as the configured Keycloak backend
+      ansible.builtin.assert:
+        that:
+          - keycloak_database_vendor | default('mysql') == 'postgres'
+        fail_msg: >-
+          Set keycloak_database_vendor to "postgres" in the deployment
+          configuration before running this migration playbook.
+  roles:
+    - role: keycloak_database_migration
+      tags:
+        - keycloak-database-migration

--- a/releasenotes/notes/keycloak-postgresql-migration-6450dd7cc07ef343.yaml
+++ b/releasenotes/notes/keycloak-postgresql-migration-6450dd7cc07ef343.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - Adds support for running Keycloak against a dedicated external PostgreSQL
+    database rather than the shared MySQL/PXC cluster.
+upgrade:
+  - Before upgrading Keycloak beyond 24.0.5, configure
+    ``keycloak_database_vendor`` as ``postgres`` along with an empty
+    PostgreSQL database and its application secret, then run
+    ``playbooks/keycloak-migrate-to-postgresql.yml``. The playbook stops
+    Keycloak, exports and imports the data with the image currently deployed,
+    and restores the MySQL-backed release if migration fails.

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -28,7 +28,24 @@ keycloak_ingress_cluster_issuer: "{{ atmosphere_ingress_cluster_issuer }}"
 keycloak_admin_username: admin
 keycloak_admin_password: "{{ undef(hint='You must specify a Keycloak admin password using keycloak_admin_password') }}"
 
+keycloak_database_vendor: mysql
 keycloak_database_username: keycloak
 keycloak_database_password: "{{ undef('You must specify a Keycloak database password using keycloak_database_password') }}"
 keycloak_database_name: keycloak
+keycloak_postgresql_host: ""
+keycloak_postgresql_port: 5432
+keycloak_postgresql_secret_name: keycloak-postgresql
+keycloak_postgresql_secret_key: password
+keycloak_database_host: >-
+  {{ keycloak_postgresql_host if keycloak_database_vendor == 'postgres' else
+  openstack_helm_endpoints.oslo_db.hosts.default + '.openstack' }}
+keycloak_database_port: >-
+  {{ keycloak_postgresql_port if keycloak_database_vendor == 'postgres' else 3306 }}
+keycloak_database_jdbc_scheme: >-
+  {{ 'postgresql' if keycloak_database_vendor == 'postgres' else 'mysql' }}
+keycloak_database_existing_secret: >-
+  {{ keycloak_postgresql_secret_name if keycloak_database_vendor == 'postgres' else '' }}
+keycloak_database_password_secret_key: >-
+  {{ keycloak_postgresql_secret_key if keycloak_database_vendor == 'postgres' else 'db-password' }}
+keycloak_database_migration_marker_name: keycloak-postgresql-migration
 keycloak_host_tls_secret_name: "{{ openstack_helm_ingress_secret_name | default(keycloak_host + '-tls')}}"

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -12,7 +12,45 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Get the Kuberentes service for Percona XtraDB Cluster
+- name: Validate Keycloak database vendor
+  ansible.builtin.assert:
+    that:
+      - keycloak_database_vendor in ['mysql', 'postgres']
+    fail_msg: >-
+      keycloak_database_vendor must be either "mysql" or "postgres".
+
+- name: Validate PostgreSQL settings
+  when: keycloak_database_vendor == 'postgres'
+  ansible.builtin.assert:
+    that:
+      - keycloak_postgresql_host | length > 0
+      - keycloak_postgresql_secret_name | length > 0
+      - keycloak_postgresql_secret_key | length > 0
+    fail_msg: >-
+      Set keycloak_postgresql_host, keycloak_postgresql_secret_name, and
+      keycloak_postgresql_secret_key when using the PostgreSQL backend.
+
+- name: Check for completed PostgreSQL migration
+  run_once: true
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: "{{ keycloak_database_migration_marker_name }}"
+    namespace: "{{ keycloak_helm_release_namespace }}"
+  register: _keycloak_database_migration_marker
+  failed_when: false
+
+- name: Prevent reverting a migrated deployment to MySQL
+  run_once: true
+  ansible.builtin.assert:
+    that:
+      - _keycloak_database_migration_marker.resources | default([]) | length == 0 or keycloak_database_vendor == 'postgres'
+    fail_msg: >-
+      This deployment has already been migrated to PostgreSQL. Set
+      keycloak_database_vendor to "postgres" before running Atmosphere again.
+
+- name: Get the Kubernetes service for Percona XtraDB Cluster
+  when: keycloak_database_vendor == 'mysql'
   run_once: true
   kubernetes.core.k8s_info:
     kind: Service
@@ -21,6 +59,7 @@
   register: _pxc_service
 
 - name: Install MySQL python package
+  when: keycloak_database_vendor == 'mysql'
   ansible.builtin.pip:
     name: PyMySQL
   register: _keycloak_pip_install
@@ -29,6 +68,7 @@
   until: _keycloak_pip_install is not failed
 
 - name: Check MySQL ready
+  when: keycloak_database_vendor == 'mysql'
   run_once: true
   community.mysql.mysql_info:
     login_host: "{{ _pxc_service.resources[0].spec.clusterIP }}"
@@ -42,6 +82,7 @@
   delay: 5
 
 - name: Create Keycloak database
+  when: keycloak_database_vendor == 'mysql'
   run_once: true
   community.mysql.mysql_db:
     login_host: "{{ _pxc_service.resources[0].spec.clusterIP }}"
@@ -50,6 +91,7 @@
     name: "{{ keycloak_database_name }}"
 
 - name: Create a Keycloak user
+  when: keycloak_database_vendor == 'mysql'
   run_once: true
   community.mysql.mysql_user:
     login_host: "{{ _pxc_service.resources[0].spec.clusterIP }}"
@@ -61,6 +103,7 @@
     priv: "{{ keycloak_database_name }}.*:ALL"
 
 - name: Disable pxc strict mode
+  when: keycloak_database_vendor == 'mysql'
   run_once: true
   community.mysql.mysql_query:
     login_host: "{{ _pxc_service.resources[0].spec.clusterIP }}"
@@ -106,6 +149,7 @@
     ingress_annotations: "{{ _keycloak_ingress_annotations | combine(keycloak_ingress_annotations, recursive=True) }}"
 
 - name: Enable pxc strict mode
+  when: keycloak_database_vendor == 'mysql'
   run_once: true
   community.mysql.mysql_query:
     login_host: "{{ _pxc_service.resources[0].spec.clusterIP }}"

--- a/roles/keycloak/vars/main.yml
+++ b/roles/keycloak/vars/main.yml
@@ -22,25 +22,24 @@ _keycloak_helm_values:
   containerSecurityContext:
     readOnlyRootFilesystem: false
     runAsUser: 1000
-  # Note(okozachenko1203): Mysql vendor is not supported by bitnami helm chart. As a workaround,
-  #                        we have to define jdbc connection string explicitly along side
-  #                        `externalDatabase` helm values.
+  # The upstream Keycloak image does not consume Bitnami's database variables,
+  # so configure the database using native KC_DB options.
   extraEnvVars:
     - name: KC_FEATURES
       value: "token-exchange,admin-fine-grained-authz"
     - name: KC_PROXY
       value: edge
     - name: KC_DB
-      value: mysql
+      value: "{{ keycloak_database_vendor }}"
     - name: KC_DB_URL
-      value: "jdbc:mysql://{{ openstack_helm_endpoints.oslo_db.hosts.default }}.openstack:3306/{{ keycloak_database_name }}"
+      value: "jdbc:{{ keycloak_database_jdbc_scheme }}://{{ keycloak_database_host }}:{{ keycloak_database_port }}/{{ keycloak_database_name }}"
     - name: KC_DB_USERNAME
       value: "{{ keycloak_database_username }}"
     - name: KC_DB_PASSWORD
       valueFrom:
         secretKeyRef:
-          key: db-password
-          name: keycloak-externaldb
+          key: "{{ keycloak_database_password_secret_key }}"
+          name: "{{ keycloak_database_existing_secret | default(keycloak_helm_release_name + '-externaldb', true) }}"
   command:
     - /opt/keycloak/bin/kc.sh
     - --verbose
@@ -57,11 +56,13 @@ _keycloak_helm_values:
     adminPassword: "{{ keycloak_admin_password }}"
     adminUser: "{{ keycloak_admin_username }}"
   externalDatabase:
-    host: "{{ openstack_helm_endpoints.oslo_db.hosts.default }}.openstack"
-    port: 3306
+    host: "{{ keycloak_database_host }}"
+    port: "{{ keycloak_database_port }}"
     database: "{{ keycloak_database_name }}"
     user: "{{ keycloak_database_username }}"
-    password: "{{ keycloak_database_password }}"
+    password: "{{ keycloak_database_password if keycloak_database_existing_secret | length == 0 else '' }}"
+    existingSecret: "{{ keycloak_database_existing_secret }}"
+    existingSecretPasswordKey: "{{ keycloak_database_password_secret_key }}"
   image:
     registry: "{{ atmosphere_images['keycloak'] | vexxhost.kubernetes.docker_image('domain') }}"
     repository: "{{ atmosphere_images['keycloak'] | vexxhost.kubernetes.docker_image('path') }}"

--- a/roles/keycloak_database_migration/README.md
+++ b/roles/keycloak_database_migration/README.md
@@ -1,0 +1,18 @@
+# keycloak_database_migration
+
+Migrates a running Keycloak 24 deployment from MySQL/PXC to a dedicated
+PostgreSQL 15 database using Keycloak's directory export and import commands.
+
+Before running the migration, configure these deployment settings:
+
+```yaml
+keycloak_database_vendor: postgres
+keycloak_postgresql_host: keycloak-postgresql.example.internal
+keycloak_postgresql_secret_name: keycloak-postgresql
+keycloak_postgresql_secret_key: password
+```
+
+The application secret must be in `auth-system`, and the PostgreSQL database
+must be empty. The migration stops Keycloak for a consistent export, uses the
+image from the current StatefulSet for both jobs, and restores the
+MySQL-backed release when a job or cutover fails.

--- a/roles/keycloak_database_migration/defaults/main.yml
+++ b/roles/keycloak_database_migration/defaults/main.yml
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+keycloak_database_migration_namespace: "{{ keycloak_helm_release_namespace | default('auth-system') }}"
+keycloak_database_migration_marker_name: keycloak-postgresql-migration
+keycloak_database_migration_pvc_name: keycloak-database-migration
+keycloak_database_migration_storage_class: general
+keycloak_database_migration_storage_size: 1Gi
+keycloak_database_migration_export_job_name: keycloak-export-mysql
+keycloak_database_migration_import_job_name: keycloak-import-postgresql
+keycloak_database_migration_poll_retries: 360
+keycloak_database_migration_poll_delay: 5
+keycloak_database_migration_cleanup: true
+keycloak_database_migration_image: ""
+
+keycloak_database_migration_source_host: "{{ openstack_helm_endpoints.oslo_db.hosts.default }}.openstack"
+keycloak_database_migration_source_port: 3306
+keycloak_database_migration_source_name: "{{ keycloak_database_name | default('keycloak') }}"
+keycloak_database_migration_source_username: "{{ keycloak_database_username | default('keycloak') }}"
+keycloak_database_migration_source_secret_name: keycloak-externaldb
+keycloak_database_migration_source_secret_key: db-password
+
+keycloak_database_migration_target_host: "{{ keycloak_postgresql_host }}"
+keycloak_database_migration_target_port: "{{ keycloak_postgresql_port }}"
+keycloak_database_migration_target_name: "{{ keycloak_database_name | default('keycloak') }}"
+keycloak_database_migration_target_username: "{{ keycloak_database_username | default('keycloak') }}"
+keycloak_database_migration_target_secret_name: "{{ keycloak_postgresql_secret_name }}"
+keycloak_database_migration_target_secret_key: "{{ keycloak_postgresql_secret_key }}"

--- a/roles/keycloak_database_migration/meta/main.yml
+++ b/roles/keycloak_database_migration/meta/main.yml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+galaxy_info:
+  author: VEXXHOST, Inc.
+  description: Migrate Keycloak from MySQL to PostgreSQL
+  license: Apache-2.0
+  min_ansible_version: 5.5.0
+  standalone: false
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+
+dependencies:
+  - role: defaults

--- a/roles/keycloak_database_migration/tasks/main.yml
+++ b/roles/keycloak_database_migration/tasks/main.yml
@@ -1,0 +1,213 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Check for completed Keycloak database migration
+  run_once: true
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: "{{ keycloak_database_migration_marker_name }}"
+    namespace: "{{ keycloak_database_migration_namespace }}"
+  register: _keycloak_database_migration_marker
+
+- name: Report completed Keycloak database migration
+  when: _keycloak_database_migration_marker.resources | length > 0
+  run_once: true
+  ansible.builtin.debug:
+    msg: Keycloak has already been migrated to PostgreSQL.
+
+- name: Migrate Keycloak database to PostgreSQL
+  when: _keycloak_database_migration_marker.resources | length == 0
+  run_once: true
+  block:
+    - name: Check MySQL application secret
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ keycloak_database_migration_source_secret_name }}"
+        namespace: "{{ keycloak_database_migration_namespace }}"
+      register: _keycloak_database_migration_source_secret
+
+    - name: Check PostgreSQL application secret
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ keycloak_database_migration_target_secret_name }}"
+        namespace: "{{ keycloak_database_migration_namespace }}"
+      register: _keycloak_database_migration_target_secret
+
+    - name: Get Keycloak StatefulSet
+      kubernetes.core.k8s_info:
+        api_version: apps/v1
+        kind: StatefulSet
+        name: "{{ keycloak_helm_release_name | default('keycloak') }}"
+        namespace: "{{ keycloak_database_migration_namespace }}"
+      register: _keycloak_database_migration_statefulset
+
+    - name: Validate migration prerequisites
+      ansible.builtin.assert:
+        that:
+          - keycloak_database_migration_target_host | length > 0
+          - keycloak_database_migration_target_name | length > 0
+          - keycloak_database_migration_target_username | length > 0
+          - _keycloak_database_migration_source_secret.resources | length == 1
+          - _keycloak_database_migration_target_secret.resources | length == 1
+          - >-
+            _keycloak_database_migration_source_secret.resources[0].data[
+            keycloak_database_migration_source_secret_key] | default('') | length > 0
+          - >-
+            _keycloak_database_migration_target_secret.resources[0].data[
+            keycloak_database_migration_target_secret_key] | default('') | length > 0
+          - _keycloak_database_migration_statefulset.resources | length == 1
+          - >-
+            (_keycloak_database_migration_statefulset.resources[0].status.readyReplicas | default(0) | int) ==
+            (_keycloak_database_migration_statefulset.resources[0].spec.replicas | default(1) | int)
+        fail_msg: >-
+          A PostgreSQL host, database, username, both application secrets
+          including their configured password keys, and a fully ready Keycloak
+          StatefulSet are required before migration.
+
+    - name: Record current Keycloak image
+      ansible.builtin.set_fact:
+        _keycloak_database_migration_image: >-
+          {{ keycloak_database_migration_image | default(
+          (_keycloak_database_migration_statefulset.resources[0].spec.template.spec.containers |
+          selectattr('name', 'equalto', 'keycloak') | map(attribute='image') | first), true) }}
+
+    - name: Validate Keycloak migration image
+      ansible.builtin.assert:
+        that:
+          - _keycloak_database_migration_image | length > 0
+        fail_msg: >-
+          Could not identify the Keycloak image from the running StatefulSet.
+          Set keycloak_database_migration_image explicitly before retrying.
+
+    - name: Remove previous migration jobs
+      kubernetes.core.k8s:
+        state: absent
+        api_version: batch/v1
+        kind: Job
+        name: "{{ item }}"
+        namespace: "{{ keycloak_database_migration_namespace }}"
+        wait: true
+      loop:
+        - "{{ keycloak_database_migration_export_job_name }}"
+        - "{{ keycloak_database_migration_import_job_name }}"
+
+    - name: Remove previous migration volume
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: PersistentVolumeClaim
+        name: "{{ keycloak_database_migration_pvc_name }}"
+        namespace: "{{ keycloak_database_migration_namespace }}"
+        wait: true
+
+    - name: Create migration volume
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: "{{ keycloak_database_migration_pvc_name }}"
+            namespace: "{{ keycloak_database_migration_namespace }}"
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            storageClassName: "{{ keycloak_database_migration_storage_class }}"
+            resources:
+              requests:
+                storage: "{{ keycloak_database_migration_storage_size }}"
+
+    - name: Stop Keycloak for a consistent export
+      kubernetes.core.k8s_scale:
+        api_version: apps/v1
+        kind: StatefulSet
+        name: "{{ keycloak_helm_release_name | default('keycloak') }}"
+        namespace: "{{ keycloak_database_migration_namespace }}"
+        replicas: 0
+        wait: true
+        wait_timeout: 300
+
+    - name: Export, import, and cut over Keycloak
+      block:
+        - name: Export Keycloak from MySQL
+          ansible.builtin.include_tasks:
+            file: run_job.yml
+          vars:
+            _keycloak_database_migration_job_name: "{{ keycloak_database_migration_export_job_name }}"
+            _keycloak_database_migration_job_args:
+              - export
+              - --dir
+              - /migration
+              - --users
+              - different_files
+              - --users-per-file
+              - "1000"
+            _keycloak_database_migration_job_env: "{{ _keycloak_database_migration_export_env }}"
+
+        - name: Import Keycloak into PostgreSQL
+          ansible.builtin.include_tasks:
+            file: run_job.yml
+          vars:
+            _keycloak_database_migration_job_name: "{{ keycloak_database_migration_import_job_name }}"
+            _keycloak_database_migration_job_args:
+              - import
+              - --dir
+              - /migration
+              - --override
+              - "true"
+            _keycloak_database_migration_job_env: "{{ _keycloak_database_migration_import_env }}"
+
+        - name: Deploy Keycloak with PostgreSQL
+          ansible.builtin.include_role:
+            name: keycloak
+          vars:
+            keycloak_database_vendor: postgres
+
+        - name: Record completed PostgreSQL migration
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: "{{ keycloak_database_migration_marker_name }}"
+                namespace: "{{ keycloak_database_migration_namespace }}"
+              data:
+                source: mysql
+                target: postgres
+                sourceImage: "{{ _keycloak_database_migration_image }}"
+
+        - name: Remove migration jobs and volume
+          when: keycloak_database_migration_cleanup | bool
+          kubernetes.core.k8s:
+            state: absent
+            api_version: "{{ item.api_version }}"
+            kind: "{{ item.kind }}"
+            name: "{{ item.name }}"
+            namespace: "{{ keycloak_database_migration_namespace }}"
+          loop:
+            - api_version: batch/v1
+              kind: Job
+              name: "{{ keycloak_database_migration_export_job_name }}"
+            - api_version: batch/v1
+              kind: Job
+              name: "{{ keycloak_database_migration_import_job_name }}"
+            - api_version: v1
+              kind: PersistentVolumeClaim
+              name: "{{ keycloak_database_migration_pvc_name }}"
+      rescue:
+        - name: Restore Keycloak with MySQL
+          ansible.builtin.include_role:
+            name: keycloak
+          vars:
+            keycloak_database_vendor: mysql
+
+        - name: Fail the PostgreSQL migration
+          ansible.builtin.fail:
+            msg: >-
+              Keycloak migration to PostgreSQL failed. The MySQL-backed
+              Keycloak release has been restored; inspect the migration job
+              logs before retrying.

--- a/roles/keycloak_database_migration/tasks/run_job.yml
+++ b/roles/keycloak_database_migration/tasks/run_job.yml
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: "Create migration job {{ _keycloak_database_migration_job_name }}"
+  run_once: true
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: "{{ _keycloak_database_migration_job_name }}"
+        namespace: "{{ keycloak_database_migration_namespace }}"
+      spec:
+        backoffLimit: 0
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: keycloak-database-migration
+          spec:
+            automountServiceAccountToken: false
+            restartPolicy: Never
+            nodeSelector:
+              openstack-control-plane: enabled
+            securityContext:
+              fsGroup: 1000
+            containers:
+              - name: keycloak
+                image: "{{ _keycloak_database_migration_image }}"
+                imagePullPolicy: IfNotPresent
+                command:
+                  - /opt/keycloak/bin/kc.sh
+                args: "{{ _keycloak_database_migration_job_args }}"
+                env: "{{ _keycloak_database_migration_job_env }}"
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: false
+                  runAsNonRoot: true
+                  runAsUser: 1000
+                  capabilities:
+                    drop:
+                      - ALL
+                volumeMounts:
+                  - name: migration
+                    mountPath: /migration
+            volumes:
+              - name: migration
+                persistentVolumeClaim:
+                  claimName: "{{ keycloak_database_migration_pvc_name }}"
+
+- name: "Wait for migration job {{ _keycloak_database_migration_job_name }}"
+  run_once: true
+  kubernetes.core.k8s_info:
+    api_version: batch/v1
+    kind: Job
+    name: "{{ _keycloak_database_migration_job_name }}"
+    namespace: "{{ keycloak_database_migration_namespace }}"
+  register: _keycloak_database_migration_job
+  retries: "{{ keycloak_database_migration_poll_retries }}"
+  delay: "{{ keycloak_database_migration_poll_delay }}"
+  until:
+    - _keycloak_database_migration_job.resources | length == 1
+    - >-
+      (_keycloak_database_migration_job.resources[0].status.succeeded | default(0) | int) == 1 or
+      (_keycloak_database_migration_job.resources[0].status.failed | default(0) | int) > 0
+
+- name: "Get migration job logs {{ _keycloak_database_migration_job_name }}"
+  run_once: true
+  kubernetes.core.k8s_log:
+    namespace: "{{ keycloak_database_migration_namespace }}"
+    label_selectors:
+      - "job-name={{ _keycloak_database_migration_job_name }}"
+  register: _keycloak_database_migration_job_log
+  failed_when: false
+
+- name: "Verify migration job succeeded {{ _keycloak_database_migration_job_name }}"
+  run_once: true
+  ansible.builtin.assert:
+    that:
+      - (_keycloak_database_migration_job.resources[0].status.succeeded | default(0) | int) == 1
+    fail_msg: "{{ _keycloak_database_migration_job_log.log | default('Keycloak migration job failed without logs.') }}"

--- a/roles/keycloak_database_migration/vars/main.yml
+++ b/roles/keycloak_database_migration/vars/main.yml
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+_keycloak_database_migration_export_env:
+  - name: KC_DB
+    value: mysql
+  - name: KC_DB_URL
+    value: "jdbc:mysql://{{ keycloak_database_migration_source_host }}:{{ keycloak_database_migration_source_port }}/{{ keycloak_database_migration_source_name }}"
+  - name: KC_DB_USERNAME
+    value: "{{ keycloak_database_migration_source_username }}"
+  - name: KC_DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "{{ keycloak_database_migration_source_secret_name }}"
+        key: "{{ keycloak_database_migration_source_secret_key }}"
+  - name: KC_TRANSACTION_XA_ENABLED
+    value: "false"
+
+_keycloak_database_migration_import_env:
+  - name: KC_DB
+    value: postgres
+  - name: KC_DB_URL
+    value: "jdbc:postgresql://{{ keycloak_database_migration_target_host }}:{{ keycloak_database_migration_target_port }}/{{ keycloak_database_migration_target_name }}"
+  - name: KC_DB_USERNAME
+    value: "{{ keycloak_database_migration_target_username }}"
+  - name: KC_DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "{{ keycloak_database_migration_target_secret_name }}"
+        key: "{{ keycloak_database_migration_target_secret_key }}"
+  - name: KC_TRANSACTION_XA_ENABLED
+    value: "false"


### PR DESCRIPTION
## Summary
- add a PostgreSQL backend option for Keycloak using an externally managed application secret
- add a controlled MySQL/PXC-to-PostgreSQL export, import, and cutover playbook
- prevent a migrated deployment from being unintentionally returned to MySQL

## Follow-up
CloudNativePG installation, CRD lifecycle, backup/restore, and Kubernetes-version support remain in #3314. This change deliberately consumes a dedicated PostgreSQL service so it can be reviewed independently of that unfinished operator work.

This provides the prerequisite migration path for the Keycloak 26.6.3 upgrade in #4096.