### PR TITLE
[ubuntu 24.04] fix(openstacksdk): avoid distro package uninstall

### DIFF
--- a/releasenotes/notes/ubuntu-2404-support-5db257c24f87b616.yaml
+++ b/releasenotes/notes/ubuntu-2404-support-5db257c24f87b616.yaml
@@ -13,3 +13,7 @@ fixes:
   - |
     Wait for Neutron network availability zones before provisioning configured
     networks.
+  - |
+    Install the modern OpenStackSDK dependency set as an overlay on Ubuntu
+    24.04 without attempting to uninstall distro-owned Python packages that do
+    not provide pip RECORD metadata.

--- a/roles/openstacksdk/tasks/main.yml
+++ b/roles/openstacksdk/tasks/main.yml
@@ -27,6 +27,11 @@
     break_system_packages: >-
       {{ ansible_facts['distribution'] == 'Ubuntu' and
          ansible_facts['distribution_version'] is version('24.04', '>=') }}
+    extra_args: >-
+      {{ '--ignore-installed'
+         if ansible_facts['distribution'] == 'Ubuntu' and
+            ansible_facts['distribution_version'] is version('24.04', '>=')
+         else omit }}
   register: _openstacksdk_pip_install
   retries: 3
   delay: 5


### PR DESCRIPTION
## Classification

**[ubuntu 24.04] specific real fix.** This PR is intentionally stacked on #4009 and contains only the Noble pip-overlay correction.

## Problem

PR #4009 correctly enables `break_system_packages` so Atmosphere can install a modern OpenStackSDK on Noble. Pip still attempts to uninstall Ubuntu's `typing_extensions` package, which has no pip RECORD metadata, so a clean deployment fails in the Keystone wave.

## Change

Pass `--ignore-installed` only on Ubuntu 24.04 and later. This overlays the modern OpenStackSDK dependency set under `/usr/local` without trying to uninstall distro-owned packages. Other distributions retain the existing behavior.

## Live validation

On a clean Ubuntu 24.04 AIO host, the pre-change role failed with:

```text
ERROR: Cannot uninstall typing_extensions 4.10.0, RECORD file not found.
```

The equivalent fixed command completed and `/usr/bin/python3` now imports:

- `openstacksdk 4.17.0` from `/usr/local/lib/python3.12/dist-packages`
- overlaid `typing_extensions` from `/usr/local/lib/python3.12/dist-packages`

Additional checks:

- `git diff --check`
- targeted `ansible-lint roles/openstacksdk/tasks/main.yml`: passed

## Stack

Depends on #4009.