### PR TITLE
fix(openstack): preserve self-signed certificate policy

### DIFF
--- a/plugins/module_utils/openstack.py
+++ b/plugins/module_utils/openstack.py
@@ -31,9 +31,7 @@ class OpenStackActionBase(ActionBase):
         admin_password = templar.template(
             task_vars.get("openstack_helm_endpoints_keystone_admin_password")
         )
-        cluster_issuer_type = templar.template(
-            task_vars.get("cluster_issuer_type")
-        )
+        cluster_issuer_type = templar.template(task_vars.get("cluster_issuer_type"))
         validate_certs = cluster_issuer_type != "self-signed"
 
         module_args = self._task.args.copy()

--- a/plugins/module_utils/openstack.py
+++ b/plugins/module_utils/openstack.py
@@ -31,9 +31,10 @@ class OpenStackActionBase(ActionBase):
         admin_password = templar.template(
             task_vars.get("openstack_helm_endpoints_keystone_admin_password")
         )
-        validate_certs = bool(
-            templar.template("{{ cluster_issuer_type != 'self-signed' }}")
+        cluster_issuer_type = templar.template(
+            task_vars.get("cluster_issuer_type")
         )
+        validate_certs = cluster_issuer_type != "self-signed"
 
         module_args = self._task.args.copy()
         openstack_args = {

--- a/releasenotes/notes/preserve-self-signed-certificate-policy-3eaf8a6386883c1b.yaml
+++ b/releasenotes/notes/preserve-self-signed-certificate-policy-3eaf8a6386883c1b.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed OpenStack action plugins to disable certificate validation when
+    ``cluster_issuer_type`` is ``self-signed`` under newer Ansible templating.
+    Previously, a rendered ``"False"`` string was treated as a truthy Python
+    boolean and caused bootstrap requests to reject the self-signed endpoint.

--- a/releasenotes/notes/ubuntu-2404-support-5db257c24f87b616.yaml
+++ b/releasenotes/notes/ubuntu-2404-support-5db257c24f87b616.yaml
@@ -13,3 +13,7 @@ fixes:
   - |
     Wait for Neutron network availability zones before provisioning configured
     networks.
+  - |
+    Install the modern OpenStackSDK dependency set as an overlay on Ubuntu
+    24.04 without attempting to uninstall distro-owned Python packages that do
+    not provide pip RECORD metadata.

--- a/roles/openstacksdk/tasks/main.yml
+++ b/roles/openstacksdk/tasks/main.yml
@@ -27,6 +27,11 @@
     break_system_packages: >-
       {{ ansible_facts['distribution'] == 'Ubuntu' and
          ansible_facts['distribution_version'] is version('24.04', '>=') }}
+    extra_args: >-
+      {{ '--ignore-installed'
+         if ansible_facts['distribution'] == 'Ubuntu' and
+            ansible_facts['distribution_version'] is version('24.04', '>=')
+         else omit }}
   register: _openstacksdk_pip_install
   retries: 3
   delay: 5


### PR DESCRIPTION
## Summary

- render `cluster_issuer_type` directly in the OpenStack action base
- derive `validate_certs` with a string comparison instead of `bool()`
- keep certificate verification enabled for non-self-signed issuers

## Why

Newer Ansible templating can return the text `"False"` for the prior expression. Python treats that non-empty string as true, so OpenStack action plugins incorrectly verify Atmosphere's self-signed AIO certificate and fail Keystone bootstrap.

## Validation

- `git diff --check`
- `uvx black --check plugins/module_utils/openstack.py`
- `uvx flake8 plugins/module_utils/openstack.py`
- live failure reproduced on an Ubuntu 24.04 AIO before this change; end-to-end rerun is in progress

## Stack

- Base: #4139 (`755b6b5b58c25877489aa8d5aac96c47e34003fd`)
- Head: `810dd73855a987497822fa308874a5e28b5242bf`

This is a general compatibility fix, not Ubuntu 24.04-specific.