### PR TITLE
fix(deploy): let in-flight components finish

### DIFF
--- a/.github/styles/config/vocabularies/Base/accept.txt
+++ b/.github/styles/config/vocabularies/Base/accept.txt
@@ -92,6 +92,7 @@ WSGI
 [Pp]ortworx
 agent
 allowed-address-pair
+ansible-compat
 atmosphere_images
 backend
 backport

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,5 @@ repos:
     rev: v25.6.1
     hooks:
       - id: ansible-lint
+        additional_dependencies:
+          - ansible-core==2.18.6

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -54,6 +54,8 @@
     roles:
       - zuul: opendev.org/openstack/openstack-helm
     vars:
+      molecule_environment:
+        ATMOSPHERE_ZUUL_INVENTORY: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/inventory.yaml"
       atmosphere_image_prefix: "harbor.atmosphere.dev/"
       ceph_fsid: 4837cbf8-4f90-4300-b3f6-726c9b9f89b4
       ceph_public_network: "{{ ansible_facts['default_ipv4']['network'] + '/' + (ansible_facts['default_ipv4']['prefix'] | string) }}"
@@ -116,179 +118,6 @@
     nodeset: atmosphere-ubuntu-jammy-single-node-16
     vars:
       molecule_scenario: aio
-      ceph_version: 18.2.7
-      kubernetes_keepalived_interface: br-mgmt
-      csi_driver: local-path-provisioner
-      cluster_issuer_type: self-signed
-      valkey_helm_values:
-        replica:
-          replicaCount: 1
-      ingress_nginx_helm_values:
-        controller:
-          config:
-            worker-processes: 2
-      percona_xtradb_cluster_spec:
-        allowUnsafeConfigurations: true
-        pxc:
-          size: 1
-        haproxy:
-          size: 1
-      keystone_helm_values:
-        pod:
-          replicas:
-            api: 1
-      barbican_helm_values:
-        pod:
-          replicas:
-            api: 1
-      rook_ceph_cluster_radosgw_spec:
-        metadataPool:
-          failureDomain: osd
-        dataPool:
-          failureDomain: osd
-        gateway:
-          instances: 1
-      glance_helm_values:
-        conf:
-          glance:
-            DEFAULT:
-              workers: 2
-            glance_store:
-              rbd_store_replication: 1
-        pod:
-          replicas:
-            api: 1
-      glance_images:
-        - name: cirros
-          url: http://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
-          min_disk: 1
-          disk_format: raw
-          container_format: bare
-          is_public: true
-      staffeln_helm_values:
-        pod:
-          replicas:
-            api: 1
-            conductor: 1
-      cinder_helm_values:
-        conf:
-          ceph:
-            pools:
-              backup:
-                replication: 1
-              cinder.volumes:
-                replication: 1
-          cinder:
-            DEFAULT:
-              osapi_volume_workers: 2
-        pod:
-          replicas:
-            api: 1
-            scheduler: 1
-      placement_helm_values:
-        conf:
-          placement_api_uwsgi:
-            uwsgi:
-              processes: 2
-        pod:
-          replicas:
-            api: 1
-      ovn_helm_values:
-        conf:
-          auto_bridge_add:
-            br-ex: null
-        pod:
-          replicas:
-            ovn_ovsdb_nb: 1
-            ovn_ovsdb_sb: 1
-            ovn_northd: 1
-      coredns_helm_values:
-        replicaCount: 1
-      nova_helm_values:
-        conf:
-          nova:
-            DEFAULT:
-              osapi_compute_workers: 2
-              metadata_workers: 2
-            conductor:
-              workers: 2
-            scheduler:
-              workers: 2
-        pod:
-          replicas:
-            api_metadata: 1
-            osapi: 1
-            conductor: 1
-            scheduler: 1
-            novncproxy: 1
-            spiceproxy: 1
-      neutron_helm_values:
-        conf:
-          neutron:
-            DEFAULT:
-              api_workers: 2
-              rpc_workers: 2
-              metadata_workers: 2
-        pod:
-          replicas:
-            server: 1
-            rpc_server: 1
-      heat_helm_values:
-        conf:
-          heat:
-            DEFAULT:
-              num_engine_workers: 2
-            heat_api:
-              workers: 2
-            heat_api_cfn:
-              workers: 2
-            heat_api_cloudwatch:
-              workers: 2
-        pod:
-          replicas:
-            api: 1
-            cfn: 1
-            cloudwatch: 1
-            engine: 1
-      octavia_helm_values:
-        conf:
-          octavia:
-            controller_worker:
-              workers: 2
-          octavia_api_uwsgi:
-            uwsgi:
-              processes: 2
-        pod:
-          replicas:
-            api: 1
-            worker: 1
-            housekeeping: 1
-      magnum_helm_values:
-        conf:
-          magnum:
-            api:
-              workers: 2
-            conductor:
-              workers: 2
-        pod:
-          replicas:
-            api: 1
-            conductor: 1
-      magnum_image_disk_format: qcow2
-      magnum_images: "[ {{ _magnum_images[-1] }} ]"
-      manila_helm_values:
-        conf:
-          manila:
-            DEFAULT:
-              osapi_share_workers: 2
-        pod:
-          replicas:
-            api: 1
-            scheduler: 1
-      horizon_helm_values:
-        pod:
-          replicas:
-            server: 1
 
 - job:
     name: atmosphere-molecule-aio-openvswitch
@@ -298,6 +127,8 @@
       - test-playbooks/molecule/run.yml
     vars:
       atmosphere_network_backend: openvswitch
+      molecule_environment:
+        ATMOSPHERE_NETWORK_BACKEND: openvswitch
 
 - job:
     name: atmosphere-molecule-aio-ovn
@@ -307,6 +138,8 @@
       - test-playbooks/molecule/run.yml
     vars:
       atmosphere_network_backend: ovn
+      molecule_environment:
+        ATMOSPHERE_NETWORK_BACKEND: ovn
 
 - job:
     name: atmosphere-molecule-keycloak

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -55,7 +55,7 @@
       - zuul: opendev.org/openstack/openstack-helm
     vars:
       molecule_environment:
-        ATMOSPHERE_ZUUL_INVENTORY: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/inventory.yaml"
+        ATMOSPHERE_MOLECULE_INVENTORY: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/inventory.yaml"
       atmosphere_image_prefix: "harbor.atmosphere.dev/"
       ceph_fsid: 4837cbf8-4f90-4300-b3f6-726c9b9f89b4
       ceph_public_network: "{{ ansible_facts['default_ipv4']['network'] + '/' + (ansible_facts['default_ipv4']['prefix'] | string) }}"

--- a/doc/source/quick-start.rst
+++ b/doc/source/quick-start.rst
@@ -83,6 +83,16 @@ command:
 
     $ tox -e molecule-aio-openvswitch
 
+Both scenarios run the parallel deployment orchestrator. The molecule
+``converge`` step builds the ``atmosphere`` Go binary from the
+repository and invokes ``atmosphere deploy --inventory ./inventory.yaml``,
+so the all-in-one host receives every component in parallel waves
+instead of running roles sequentially. To exercise a subset, set
+``atmosphere_deploy_tags`` to a comma-separated list and re-run
+``converge``. The orchestrator resolves the requested tags along with
+their dependencies and runs them in waves. For details on the
+orchestrator itself, see :doc:`deploy/parallel`.
+
 Once the deployment is done, it will have a full deployment of all services
 inside the same host, so you can use the cloud from the same machine by
 referencing the usage section.

--- a/molecule/aio/converge.yml
+++ b/molecule/aio/converge.yml
@@ -1,28 +1,55 @@
 ---
 - hosts: all
   gather_facts: false
+  vars:
+    _project_dir: "{{ zuul.project.src_dir | default(playbook_dir + '/../..') }}"
   tasks:
     - name: Build atmosphere binary
       ansible.builtin.command:
         cmd: go build -o ./bin/atmosphere ./cmd/atmosphere
       args:
-        chdir: "{{ zuul.project.src_dir | default(playbook_dir + '/../..') }}"
+        chdir: "{{ _project_dir }}"
       run_once: true
       changed_when: false
       environment:
         CGO_ENABLED: "0"
         PATH: "/usr/local/go/bin:{{ ansible_env.PATH | default(lookup('env', 'PATH')) }}"
 
+    - name: Create local inventory
+      when: zuul is not defined
+      ansible.builtin.copy:
+        dest: "{{ _project_dir }}/inventory.yaml"
+        mode: "0644"
+        content: |
+          all:
+            hosts:
+              instance:
+                ansible_connection: local
+                ansible_become: true
+            children:
+              controllers:
+                hosts:
+                  instance: {}
+              cephs:
+                hosts:
+                  instance: {}
+              computes:
+                hosts:
+                  instance: {}
+      run_once: true
+
     - name: Deploy with parallel orchestrator
       ansible.builtin.shell:
         cmd: >
-          . .venv/bin/activate &&
+          {% if zuul is defined %}. .venv/bin/activate && {% endif %}
           ./bin/atmosphere deploy
           --inventory ./inventory.yaml
           {{ '--tags ' + atmosphere_deploy_tags if atmosphere_deploy_tags is defined else '' }}
         executable: /bin/bash
       args:
-        chdir: "{{ zuul.project.src_dir | default(playbook_dir + '/../..') }}"
+        chdir: "{{ _project_dir }}"
+      environment:
+        ATMOSPHERE_NETWORK_BACKEND: "{{ atmosphere_network_backend | default(lookup('env', 'ATMOSPHERE_NETWORK_BACKEND')) | default('openvswitch', true) }}"
       run_once: true
       changed_when: false
 

--- a/molecule/aio/converge.yml
+++ b/molecule/aio/converge.yml
@@ -50,6 +50,8 @@
         chdir: "{{ _project_dir }}"
       environment:
         ATMOSPHERE_NETWORK_BACKEND: "{{ atmosphere_network_backend | default(lookup('env', 'ATMOSPHERE_NETWORK_BACKEND')) | default('openvswitch', true) }}"
+        PATH: "{{ ansible_env.PATH | default(lookup('env', 'PATH')) }}"
+        ANSIBLE_COLLECTIONS_PATH: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') | default(lookup('env', 'HOME') + '/.ansible/collections', true) }}"
       run_once: true
       changed_when: false
 

--- a/molecule/aio/converge.yml
+++ b/molecule/aio/converge.yml
@@ -48,10 +48,15 @@
         executable: /bin/bash
       args:
         chdir: "{{ _project_dir }}"
-      environment:
-        ATMOSPHERE_NETWORK_BACKEND: "{{ atmosphere_network_backend | default(lookup('env', 'ATMOSPHERE_NETWORK_BACKEND')) | default('openvswitch', true) }}"
-        PATH: "{{ ansible_env.PATH | default(lookup('env', 'PATH')) }}"
-        ANSIBLE_COLLECTIONS_PATH: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') | default(lookup('env', 'HOME') + '/.ansible/collections', true) }}"
+      environment: >-
+        {{
+          {'ATMOSPHERE_NETWORK_BACKEND': atmosphere_network_backend | default(lookup('env', 'ATMOSPHERE_NETWORK_BACKEND')) | default('openvswitch', true)}
+          | combine(
+            {'PATH': ansible_env.PATH | default(lookup('env', 'PATH')),
+             'ANSIBLE_COLLECTIONS_PATH': lookup('env', 'ANSIBLE_COLLECTIONS_PATH') | default(lookup('env', 'HOME') + '/.ansible/collections', true)}
+            if zuul is not defined else {}
+          )
+        }}
       run_once: true
       changed_when: false
 

--- a/molecule/aio/group_vars/all/molecule.yml
+++ b/molecule/aio/group_vars/all/molecule.yml
@@ -1,0 +1,196 @@
+atmosphere_image_prefix: "{{ lookup('env', 'ATMOSPHERE_IMAGE_PREFIX') | default('', True) }}"
+atmosphere_network_backend: "{{ lookup('env', 'ATMOSPHERE_NETWORK_BACKEND') | default('openvswitch', True) }}"
+cluster_issuer_type: self-signed
+ceph_conf_overrides:
+  - section: global
+    option: mon allow pool size one
+    value: true
+  - section: global
+    option: osd crush chooseleaf type
+    value: 0
+  - section: mon
+    option: auth allow insecure global id reclaim
+    value: false
+ceph_osd_devices:
+  - "/dev/ceph-{{ inventory_hostname_short }}-osd0/data"
+  - "/dev/ceph-{{ inventory_hostname_short }}-osd1/data"
+  - "/dev/ceph-{{ inventory_hostname_short }}-osd2/data"
+cilium_helm_values:
+  operator:
+    replicas: 1
+ceph_csi_rbd_helm_values:
+  provisioner:
+    replicaCount: 1
+
+ceph_version: 18.2.7
+kubernetes_keepalived_interface: br-mgmt
+csi_driver: local-path-provisioner
+valkey_helm_values:
+  replica:
+    replicaCount: 1
+ingress_nginx_helm_values:
+  controller:
+    config:
+      worker-processes: 2
+percona_xtradb_cluster_spec:
+  allowUnsafeConfigurations: true
+  pxc:
+    size: 1
+  haproxy:
+    size: 1
+keystone_helm_values:
+  pod:
+    replicas:
+      api: 1
+barbican_helm_values:
+  pod:
+    replicas:
+      api: 1
+rook_ceph_cluster_radosgw_spec:
+  metadataPool:
+    failureDomain: osd
+  dataPool:
+    failureDomain: osd
+  gateway:
+    instances: 1
+glance_helm_values:
+  conf:
+    glance:
+      DEFAULT:
+        workers: 2
+      glance_store:
+        rbd_store_replication: 1
+  pod:
+    replicas:
+      api: 1
+glance_images:
+  - name: cirros
+    url: http://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
+    min_disk: 1
+    disk_format: raw
+    container_format: bare
+    is_public: true
+staffeln_helm_values:
+  pod:
+    replicas:
+      api: 1
+      conductor: 1
+cinder_helm_values:
+  conf:
+    ceph:
+      pools:
+        backup:
+          replication: 1
+        cinder.volumes:
+          replication: 1
+    cinder:
+      DEFAULT:
+        osapi_volume_workers: 2
+  pod:
+    replicas:
+      api: 1
+      scheduler: 1
+placement_helm_values:
+  conf:
+    placement_api_uwsgi:
+      uwsgi:
+        processes: 2
+  pod:
+    replicas:
+      api: 1
+ovn_helm_values:
+  conf:
+    auto_bridge_add:
+      br-ex: null
+  pod:
+    replicas:
+      ovn_ovsdb_nb: 1
+      ovn_ovsdb_sb: 1
+      ovn_northd: 1
+coredns_helm_values:
+  replicaCount: 1
+nova_helm_values:
+  conf:
+    nova:
+      DEFAULT:
+        osapi_compute_workers: 2
+        metadata_workers: 2
+      conductor:
+        workers: 2
+      scheduler:
+        workers: 2
+  pod:
+    replicas:
+      api_metadata: 1
+      osapi: 1
+      conductor: 1
+      scheduler: 1
+      novncproxy: 1
+      spiceproxy: 1
+neutron_helm_values:
+  conf:
+    neutron:
+      DEFAULT:
+        api_workers: 2
+        rpc_workers: 2
+        metadata_workers: 2
+  pod:
+    replicas:
+      server: 1
+      rpc_server: 1
+heat_helm_values:
+  conf:
+    heat:
+      DEFAULT:
+        num_engine_workers: 2
+      heat_api:
+        workers: 2
+      heat_api_cfn:
+        workers: 2
+      heat_api_cloudwatch:
+        workers: 2
+  pod:
+    replicas:
+      api: 1
+      cfn: 1
+      cloudwatch: 1
+      engine: 1
+octavia_helm_values:
+  conf:
+    octavia:
+      controller_worker:
+        workers: 2
+    octavia_api_uwsgi:
+      uwsgi:
+        processes: 2
+  pod:
+    replicas:
+      api: 1
+      worker: 1
+      housekeeping: 1
+magnum_helm_values:
+  conf:
+    magnum:
+      api:
+        workers: 2
+      conductor:
+        workers: 2
+  pod:
+    replicas:
+      api: 1
+      conductor: 1
+magnum_image_disk_format: qcow2
+magnum_images: "[ {{ _magnum_images[-1] }} ]"
+manila_helm_values:
+  conf:
+    manila:
+      DEFAULT:
+        osapi_share_workers: 2
+  pod:
+    replicas:
+      api: 1
+      scheduler: 1
+horizon_helm_values:
+  pod:
+    replicas:
+      server: 1

--- a/molecule/aio/molecule.yml
+++ b/molecule/aio/molecule.yml
@@ -1,14 +1,43 @@
-# Copyright (c) 2025 VEXXHOST, Inc.
+# Copyright (c) 2026 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-ansible:
-  cfg:
+dependency:
+  name: galaxy
+driver:
+  name: default
+  options:
+    managed: False
+    ansible_connection_options:
+      ansible_become: "true"
+      ansible_connection: local
+platforms:
+  - name: instance
+    groups:
+      - controllers
+      - cephs
+      - computes
+provisioner:
+  name: ansible
+  env:
+    DOCKER_TIMEOUT: 600
+  config_options:
     defaults:
       callbacks_enabled: ansible.posix.profile_tasks
     connection:
       pipelining: true
+    tags:
+      run: ${ATMOSPHERE_ANSIBLE_TAGS-all}
+  options:
+    skip-tags: "${ATMOSPHERE_ANSIBLE_SKIP_TAGS-molecule-notest,notest}"
+  inventory:
+    links:
+      host_vars: "${ATMOSPHERE_ANSIBLE_VARS_PATH-$MOLECULE_SCENARIO_DIRECTORY}/host_vars"
+      group_vars: "${ATMOSPHERE_ANSIBLE_VARS_PATH-$MOLECULE_SCENARIO_DIRECTORY}/group_vars"
+ansible:
   executor:
     backend: ansible-playbook
     args:
       ansible_playbook:
-        - --inventory=${MOLECULE_PROJECT_DIRECTORY}/inventory.yaml
+        - --inventory=${ATMOSPHERE_ZUUL_INVENTORY:-/dev/null}
+verifier:
+  name: ansible

--- a/molecule/aio/molecule.yml
+++ b/molecule/aio/molecule.yml
@@ -38,6 +38,6 @@ ansible:
     backend: ansible-playbook
     args:
       ansible_playbook:
-        - --inventory=${ATMOSPHERE_ZUUL_INVENTORY:-/dev/null}
+        - --inventory=${ATMOSPHERE_MOLECULE_INVENTORY:-/dev/null}
 verifier:
   name: ansible

--- a/molecule/aio/prepare.yml
+++ b/molecule/aio/prepare.yml
@@ -28,6 +28,24 @@
         state: absent
         purge: true
 
+    - name: Install Go toolchain for local builds
+      when: zuul is not defined
+      block:
+        - name: Download Go toolchain
+          ansible.builtin.get_url:
+            url: https://go.dev/dl/go1.24.4.linux-amd64.tar.gz
+            dest: /tmp/go.tar.gz
+            mode: "0644"
+        - name: Remove any existing Go installation
+          ansible.builtin.file:
+            path: /usr/local/go
+            state: absent
+        - name: Extract Go toolchain
+          ansible.builtin.unarchive:
+            src: /tmp/go.tar.gz
+            dest: /usr/local
+            remote_src: true
+
 - name: Generate workspace
   ansible.builtin.import_playbook: vexxhost.atmosphere.generate_workspace
   vars:

--- a/molecule/aio/prepare.yml
+++ b/molecule/aio/prepare.yml
@@ -34,6 +34,31 @@
     workspace_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
     domain_name: "{{ ansible_default_ipv4['address'].replace('.', '-') }}.nip.io"
 
+- name: Copy AIO overrides to workspace
+  hosts: all
+  become: true
+  tasks:
+    - name: Copy molecule.yml overrides to project group_vars
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/group_vars/all/molecule.yml"
+        dest: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/group_vars/all/molecule.yml"
+        mode: "0644"
+      run_once: true
+
+- name: Overwrite OSD devices with LVM-backed paths
+  hosts: all
+  become: true
+  tasks:
+    - name: Overwrite existing osds.yml file
+      ansible.builtin.copy:
+        dest: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/group_vars/cephs/osds.yml"
+        mode: '0644'
+        content: |
+          ceph_osd_devices:
+            - "/dev/ceph-{{ inventory_hostname_short }}-osd0/data"
+            - "/dev/ceph-{{ inventory_hostname_short }}-osd1/data"
+            - "/dev/ceph-{{ inventory_hostname_short }}-osd2/data"
+
 - name: Setup networking
   hosts: all
   become: true

--- a/molecule/aio/verify.yml
+++ b/molecule/aio/verify.yml
@@ -16,9 +16,14 @@
   hosts: localhost
   gather_facts: false
   tasks:
+    - name: Check for .venv stestr
+      ansible.builtin.stat:
+        path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/.venv/bin/stestr"
+      register: _venv_stestr
+
     - name: Run "stestr" tests
       become: true
-      ansible.builtin.shell: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/.venv/bin/stestr run"
+      ansible.builtin.shell: "{{ _venv_stestr.stat.path if _venv_stestr.stat.exists else 'stestr' }} run"
       args:
         chdir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
       environment:

--- a/molecule/csi/molecule.yml
+++ b/molecule/csi/molecule.yml
@@ -11,4 +11,4 @@ ansible:
     backend: ansible-playbook
     args:
       ansible_playbook:
-        - --inventory=${ATMOSPHERE_ZUUL_INVENTORY:-/dev/null}
+        - --inventory=${ATMOSPHERE_MOLECULE_INVENTORY:-/dev/null}

--- a/molecule/csi/molecule.yml
+++ b/molecule/csi/molecule.yml
@@ -11,4 +11,4 @@ ansible:
     backend: ansible-playbook
     args:
       ansible_playbook:
-        - --inventory=${MOLECULE_PROJECT_DIRECTORY}/inventory.yaml
+        - --inventory=${ATMOSPHERE_ZUUL_INVENTORY:-/dev/null}

--- a/molecule/keycloak/group_vars/all/molecule.yml
+++ b/molecule/keycloak/group_vars/all/molecule.yml
@@ -1,0 +1,1 @@
+../../../aio/group_vars/all/molecule.yml

--- a/molecule/keycloak/host_vars
+++ b/molecule/keycloak/host_vars
@@ -1,0 +1,1 @@
+../aio/host_vars

--- a/pkg/dag/dag.go
+++ b/pkg/dag/dag.go
@@ -185,25 +185,28 @@ func (g *Graph[T]) Run(ctx context.Context, concurrency int, fn func(ctx context
 
 	priorities := g.CriticalPath()
 
-	eg, ctx := errgroup.WithContext(ctx)
+	eg, schedulingCtx := errgroup.WithContext(ctx)
 	for id, val := range g.nodes {
 		id, val := id, val
 		eg.Go(func() error {
 			for _, dep := range g.edges[id] {
 				select {
 				case <-done[dep]:
-				case <-ctx.Done():
-					return ctx.Err()
+				case <-schedulingCtx.Done():
+					return schedulingCtx.Err()
 				}
 			}
 
 			if sched != nil {
-				if err := sched.acquire(ctx, priorities[id]); err != nil {
+				if err := sched.acquire(schedulingCtx, priorities[id]); err != nil {
 					return err
 				}
 				defer sched.release()
 			}
 
+			// A sibling failure stops new scheduling but must not cancel work
+			// already in flight. The parent context still propagates an explicit
+			// caller cancellation to active components.
 			if err := fn(ctx, id, val); err != nil {
 				return err
 			}

--- a/pkg/dag/dag_test.go
+++ b/pkg/dag/dag_test.go
@@ -347,6 +347,64 @@ func TestRunStopsDependentsOnError(t *testing.T) {
 	_ = strings.TrimSpace // keep strings import used if trimmed in future
 }
 
+func TestRunLetsInflightNodesFinishOnError(t *testing.T) {
+	g := NewGraph[string]()
+	for _, n := range []string{"fail", "inflight"} {
+		_ = g.AddNode(n, n)
+	}
+
+	inflightStarted := make(chan struct{})
+	var inflightCompleted atomic.Bool
+	wantErr := errors.New("boom")
+
+	err := g.Run(context.Background(), 0, func(ctx context.Context, id string, _ string) error {
+		switch id {
+		case "fail":
+			<-inflightStarted
+			return wantErr
+		case "inflight":
+			close(inflightStarted)
+			select {
+			case <-time.After(20 * time.Millisecond):
+				inflightCompleted.Store(true)
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return nil
+	})
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected wantErr, got %v", err)
+	}
+	if !inflightCompleted.Load() {
+		t.Fatal("in-flight node was cancelled after its sibling failed")
+	}
+}
+
+func TestRunCancelsInflightNodesWithParentContext(t *testing.T) {
+	g := NewGraph[string]()
+	_ = g.AddNode("inflight", "inflight")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	result := make(chan error, 1)
+	go func() {
+		result <- g.Run(ctx, 0, func(ctx context.Context, _ string, _ string) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+
+	<-started
+	cancel()
+	if err := <-result; !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
 // TestRunConcurrencyCap asserts the global concurrency cap limits in-flight
 // nodes across the whole graph (not just within one wave).
 func TestRunConcurrencyCap(t *testing.T) {

--- a/releasenotes/notes/fix-molecule-aio-local-parallel-88a32558ad704a33.yaml
+++ b/releasenotes/notes/fix-molecule-aio-local-parallel-88a32558ad704a33.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    ``molecule`` is now pinned to ``26.4.0`` and ``ansible-compat`` to
+    ``26.3.0`` in ``tox.ini`` for Molecule environments.
+fixes:
+  - |
+    Restored local execution support for the all-in-one Molecule scenario.
+    Local builds now use the parallel deployment orchestrator, matching
+    the CI behavior.

--- a/releasenotes/notes/parallel-deploy-finish-inflight-components-9d4fb613f2b4a671.yaml
+++ b/releasenotes/notes/parallel-deploy-finish-inflight-components-9d4fb613f2b4a671.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Prevents a failed parallel deployment component from cancelling unrelated
+    components that are already running. In-flight components now finish on
+    the caller context, avoiding Helm releases left in a ``context canceled``
+    state, while pending dependents still stop after the first failure.

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,11 @@ deps =
 setenv =
   openvswitch: ATMOSPHERE_NETWORK_BACKEND = openvswitch
   ovn: ATMOSPHERE_NETWORK_BACKEND = ovn
+  ATMOSPHERE_MOLECULE_INVENTORY = {toxinidir}/inventory.yaml
+allowlist_externals =
+  touch
 commands =
+  touch {toxinidir}/inventory.yaml
   molecule test -s aio {posargs}
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,8 @@ passenv =
   ATMOSPHERE_*
   OS_*
 deps =
-  molecule==24.9.0
-  ansible-compat==24.10.0
+  molecule==26.4.0
+  ansible-compat==26.3.0
   kubernetes
   oslotest
   stestr


### PR DESCRIPTION
## Summary

- stop scheduling dependents after the first DAG error
- let component deployments that already started finish on their original parent context
- preserve explicit caller cancellation for all active components

This prevents one component failure from canceling unrelated active Helm operations and leaving releases in `failed: context canceled` state.

## Classification

General production fix. This is not Ubuntu 24.04-specific and contains no AIO emulation or test configuration.

## Validation

- `go test ./pkg/dag ./internal/deploy`
- `go test -race ./pkg/dag`
- regression coverage for sibling failure and explicit parent cancellation

Depends on #3842.