### PR TITLE
fix(monitoring): reclassify multicast alert

### DIFF
--- a/doc/source/admin/monitoring.rst
+++ b/doc/source/admin/monitoring.rst
@@ -1445,26 +1445,79 @@ confirm the issue is both sustained and ongoing. At this burn rate, the entire
 ``NodeNetworkMulticast``
 ========================
 
-This alert fires when a node receives large volumes of multicast traffic, which
-can indicate an incorrectly configured network or a malicious actor.
+This P5 capacity-planning alert fires when an interface receives more than
+1,000 multicast or broadcast packets per second for 24 hours. The underlying
+``node_network_receive_multicast_total`` counter is driver-provided and can
+include layer-2 broadcast traffic such as ARP. The alert therefore does not, by
+itself, indicate a multicast application, a network attack, or user-visible
+impact.
 
-This can result in high CPU usage on the node and can cause the node to become
-unresponsive. It can also cause a high amount of software interrupts on the
-node.
+Common causes include expected multicast protocols, ARP or neighbour discovery
+on a shared provider network, broadcast unknown multicast (BUM) replication in
+an EVPN/VXLAN fabric, a layer-2 loop, or a misconfigured or malicious sender.
+Shared OpenStack provider networks can amplify normal gateway ARP requests to
+every compute host, so the same traffic can produce one alert per node without
+overloading any node.
 
-To find the root cause of this issue, use the following commands:
+This alert is informational and must not be escalated based on packet rate
+alone. Page-worthy impact is covered by the softnet backlog and drop alerts,
+network interface errors, and node CPU alerts. Investigate during business
+hours to establish a baseline and determine whether capacity work is needed.
 
-.. code-block:: console
+1. Identify the affected interface and confirm its packet and error counters:
 
-  iftop -ni $DEV -f 'multicast and not broadcast'
+   .. code-block:: console
 
-With this command, you can see which IP addresses send the multicast traffic.
-Once you have the IP address, use the following command to find the server
-behind it:
+     DEV=<interface-from-alert>
+     ip -s link show dev "$DEV"
+     ethtool -S "$DEV" | grep -Ei 'multicast|broadcast|drop|error|miss'
 
-.. code-block:: console
+2. Capture a bounded sample before deciding that the traffic is multicast.
+   Preserve Ethernet headers so that broadcast ARP can be distinguished from
+   IPv4 or IPv6 multicast:
 
-  openstack server list --all-projects --long -n --ip $IP
+   .. code-block:: console
+
+     timeout 30 tcpdump -nn -e -i "$DEV" 'ether multicast' -c 5000
+
+3. Check whether the node is experiencing packet-processing impact. A high
+   packet rate without increasing drops, ``time_squeeze``, or sustained CPU
+   pressure is a capacity signal rather than an incident:
+
+   .. code-block:: console
+
+     mpstat -P ALL 1 10
+     watch -n 1 cat /proc/net/softnet_stat
+     ip -s link show dev "$DEV"
+
+4. If the capture shows tenant traffic, map the source IP or MAC address to an
+   OpenStack port and server:
+
+   .. code-block:: console
+
+     openstack port list --all-projects --mac-address <source-mac>
+     openstack server list --all-projects --long --ip <source-ip>
+
+5. If the capture shows ARP or neighbour discovery from a gateway, inspect the
+   gateway neighbour table and the VXLAN flood list. Failed or incomplete
+   neighbours across unallocated addresses commonly indicate Internet scans
+   causing otherwise normal resolution attempts:
+
+   .. code-block:: console
+
+     ip neigh show dev <provider-bridge> nud failed
+     ip neigh show dev <provider-bridge> nud incomplete
+     bridge -d link show dev <vxlan-interface>
+     bridge fdb show dev <vxlan-interface>
+
+6. Compare the measured rate with node CPU, softnet, interface-drop, and VXLAN
+   counters. If there is no impact, record the source and baseline; do not
+   change neighbour retry settings or apply storm control solely to clear this
+   alert. If impact is present, stop a loop or malicious sender when identified,
+   or filter unwanted traffic at the ingress gateway after verifying that the
+   policy cannot block dynamically allocated OpenStack addresses. Longer-term
+   EVPN ARP/ND suppression or routed host prefixes require complete,
+   automatically maintained control-plane bindings.
 
 
 ``SmartctlDiskAttributeFailing``

--- a/releasenotes/notes/multicast-alert-priority-8d775a0a92dcd976.yaml
+++ b/releasenotes/notes/multicast-alert-priority-8d775a0a92dcd976.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The ``NodeNetworkMulticast`` alert is now an informational capacity signal
+    instead of a critical page. It fires only when the packet rate remains high
+    for 24 hours and includes a runbook for distinguishing multicast from
+    broadcast traffic and checking for node impact.

--- a/roles/kube_prometheus_stack/files/jsonnet/legacy.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/legacy.libsonnet
@@ -192,24 +192,6 @@
           ],
         },
         {
-          name: 'network',
-          rules: [
-            {
-              alert: 'NodeNetworkMulticast',
-              expr: 'rate(node_network_receive_multicast_total[1m]) > 1000',
-              'for': '5m',
-              labels: {
-                severity: 'critical',
-              },
-              annotations: {
-                summary: 'High multicast traffic on node {{ $labels.instance }}: {{ $value }} packets/sec',
-                description: 'This can result in high software interrupt load on the node which can bring network performance down.',
-                runbook_url: 'https://github.com/vexxhost/atmosphere/tree/main/roles/kube_prometheus_stack#NodeNetworkMulticast',
-              },
-            },
-          ],
-        },
-        {
           name: 'softnet',
           rules:
             local capitalize(s) = std.asciiUpper(std.substr(s, 0, 1)) + std.substr(s, 1, std.length(s) - 1);

--- a/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
@@ -299,6 +299,7 @@ local mixins = {
     },
   goldpinger: (import 'goldpinger.libsonnet'),
   nginx: (import 'nginx.libsonnet'),
+  network: (import 'network.libsonnet'),
   openstack: (import 'openstack.libsonnet'),
   smartctl: (import 'smartctl.libsonnet'),
 } + (import 'legacy.libsonnet');

--- a/roles/kube_prometheus_stack/files/jsonnet/network.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/network.libsonnet
@@ -1,0 +1,24 @@
+{
+  prometheusAlerts+: {
+    groups: [
+      {
+        name: 'network',
+        rules: [
+          {
+            alert: 'NodeNetworkMulticast',
+            expr: 'rate(node_network_receive_multicast_total{job="node-exporter"}[5m]) > 1000',
+            'for': '24h',
+            labels: {
+              severity: 'P5',
+            },
+            annotations: {
+              summary: 'Node network: sustained multicast or broadcast traffic is increasing packet-processing load',
+              description: '{{ $labels.instance }} interface {{ $labels.device }} has received {{ printf "%.2f" $value }} multicast or broadcast packets per second over the last 5 minutes, above the 1,000 packets per second capacity-planning threshold for 24 hours. Normal behavior is below 1,000 packets per second or limited to short bursts.',
+              runbook_url: 'https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodenetworkmulticast',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -2,6 +2,37 @@
 # SPDX-License-Identifier: Apache-2.0
 
 tests:
+  # NodeNetworkMulticast - should NOT fire for sustained traffic below the
+  # capacity-planning threshold.
+  - interval: 1m
+    input_series:
+      - series: 'node_network_receive_multicast_total{device="bond0",instance="192.0.2.10:9100",job="node-exporter"}'
+        values: '0+30000x1500'
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: NodeNetworkMulticast
+        exp_alerts: []
+
+  # NodeNetworkMulticast - should fire only after the high rate is sustained
+  # for the full 24-hour capacity-planning window.
+  - interval: 1m
+    input_series:
+      - series: 'node_network_receive_multicast_total{device="bond0",instance="192.0.2.10:9100",job="node-exporter"}'
+        values: '0+120000x1500'
+    alert_rule_test:
+      - eval_time: 25h
+        alertname: NodeNetworkMulticast
+        exp_alerts:
+          - exp_labels:
+              device: bond0
+              instance: 192.0.2.10:9100
+              job: node-exporter
+              severity: P5
+            exp_annotations:
+              summary: "Node network: sustained multicast or broadcast traffic is increasing packet-processing load"
+              description: "192.0.2.10:9100 interface bond0 has received 2000.00 multicast or broadcast packets per second over the last 5 minutes, above the 1,000 packets per second capacity-planning threshold for 24 hours. Normal behavior is below 1,000 packets per second or limited to short bursts."
+              runbook_url: "https://vexxhost.github.io/atmosphere/admin/monitoring.html#nodenetworkmulticast"
+
   - interval: 1m
     input_series:
       - series: 'openstack_neutron_network{id="4cf895c9-c3d1-489e-b02e-59b5c8976809",is_external="false",is_shared="false",name="public",provider_network_type="vlan",provider_physical_network="external",provider_segmentation_id="3",status="ACTIVE",subnets="54d6f61d-db07-451c-9ab3-b9609b6b6f0b",tags="tag1,tag2",tenant_id="4fd44f30292945e481c7b8a0c8908869"} 0'


### PR DESCRIPTION
## What changed

- reclassify `NodeNetworkMulticast` from P1 paging to a P5 capacity-planning signal
- use a five-minute rate and require 24 hours of sustained traffic
- move the rule from the legacy mixin into a dedicated network rules file
- add positive and negative `promtool` tests
- replace the old runbook with packet classification, host-impact checks, OpenStack source mapping, and EVPN/VXLAN diagnostics
- add a release note

## Why

The YUL1 investigation showed these alerts were caused by broadcast ARP from Linux edge gateways being replicated across a shared OpenStack provider network. At the observed rate, the nodes had CPU headroom and no softnet, interface, capture, qdisc, or VXLAN drops. Packet rate alone therefore did not demonstrate user-visible impact and should not page as P1.

This follows the repository alerting policy and Google SRE guidance to page on symptoms requiring immediate action, while retaining cause-based metrics as nonpaging capacity signals:

- https://sre.google/sre-book/monitoring-distributed-systems/
- https://sre.google/sre-book/practical-alerting/

## Impact

Short ARP, multicast, and BUM bursts no longer create critical incidents on every compute host. Sustained elevated traffic remains visible for business-hours capacity review. Existing softnet backlog/drop, network error, and CPU alerts continue to detect actual host impact.

## Validation

- `go test ./roles/kube_prometheus_stack -run TestPrometheusRules -count=1` with CI-pinned `promtool` 2.53.4
- focused positive and negative `NodeNetworkMulticast` tests
- `jsonnetfmt --test` on the new rule and edited legacy Jsonnet files
- `git diff --check`
- Sphinx rendered the new runbook and release note without new warnings; the full docs build remains blocked by four pre-existing warnings outside this change
