### PR TITLE
fix(octavia): configure health manager interface MTU

### DIFF
--- a/charts/octavia/templates/bin/_octavia-health-manager-nic-init.sh.tpl
+++ b/charts/octavia/templates/bin/_octavia-health-manager-nic-init.sh.tpl
@@ -28,8 +28,12 @@ ovs-vsctl --may-exist add-port br-int o-hm0 \
         -- set Interface o-hm0 external-ids:iface-status=active \
         -- set Interface o-hm0 external-ids:attached-mac=$HM_PORT_MAC \
         -- set Interface o-hm0 external-ids:iface-id=$HM_PORT_ID \
-        -- set Interface o-hm0 external-ids:skip_cleanup=true
+        -- set Interface o-hm0 external-ids:skip_cleanup=true{{- if .Values.network.health_manager.interface_mtu }} \
+        -- set Interface o-hm0 mtu_request={{ .Values.network.health_manager.interface_mtu }}{{- end }}
 
 ip link set dev o-hm0 address $HM_PORT_MAC
+{{- if .Values.network.health_manager.interface_mtu }}
+ip link set dev o-hm0 mtu {{ .Values.network.health_manager.interface_mtu }}
+{{- end }}
 
 iptables -I INPUT -i o-hm0 -p udp --dport {{ .Values.conf.octavia.health_manager.bind_port }} -j ACCEPT

--- a/charts/octavia/templates/bin/_octavia-health-manager.sh.tpl
+++ b/charts/octavia/templates/bin/_octavia-health-manager.sh.tpl
@@ -28,11 +28,19 @@ HOOK
   chmod +x /etc/dhcp/dhclient-enter-hooks.d/nodns
 
   cat > /tmp/dhclient.conf <<EOF
+{{- if .Values.network.health_manager.interface_mtu }}
+request subnet-mask,broadcast-address;
+supersede interface-mtu {{ .Values.network.health_manager.interface_mtu }};
+{{- else }}
 request subnet-mask,broadcast-address,interface-mtu;
+{{- end }}
 do-forward-updates false;
 EOF
 
   dhclient -v o-hm0 -cf /tmp/dhclient.conf
+{{- if .Values.network.health_manager.interface_mtu }}
+  ip link set dev o-hm0 mtu {{ .Values.network.health_manager.interface_mtu }}
+{{- end }}
 
   exec octavia-health-manager \
         --config-file /etc/octavia/octavia.conf

--- a/charts/octavia/values.yaml
+++ b/charts/octavia/values.yaml
@@ -86,6 +86,8 @@ network:
     node_port:
       enabled: false
       port: 30826
+  health_manager:
+    interface_mtu: null
 
 dependencies:
   dynamic:

--- a/charts/patches/octavia/0004-Add-Octavia-management-interface-MTU-options.patch
+++ b/charts/patches/octavia/0004-Add-Octavia-management-interface-MTU-options.patch
@@ -1,0 +1,63 @@
+From 6dfbaaf079df043dac5bea25a367e4a23a801b15 Mon Sep 17 00:00:00 2001
+Subject: [PATCH] Add Octavia management interface MTU options
+
+Backport the health-manager portion of
+https://review.opendev.org/c/openstack/openstack-helm/+/996204 to the
+Octavia 0.2.9 chart. The worker interface from that change is not present
+in this chart version.
+
+diff --git a/octavia/templates/bin/_octavia-health-manager-nic-init.sh.tpl b/octavia/templates/bin/_octavia-health-manager-nic-init.sh.tpl
+index 0317c3d33..4db18c606 100644
+--- a/octavia/templates/bin/_octavia-health-manager-nic-init.sh.tpl
++++ b/octavia/templates/bin/_octavia-health-manager-nic-init.sh.tpl
+@@ -28,8 +28,12 @@ ovs-vsctl --may-exist add-port br-int o-hm0 \
+         -- set Interface o-hm0 external-ids:iface-status=active \
+         -- set Interface o-hm0 external-ids:attached-mac=$HM_PORT_MAC \
+         -- set Interface o-hm0 external-ids:iface-id=$HM_PORT_ID \
+-        -- set Interface o-hm0 external-ids:skip_cleanup=true
++        -- set Interface o-hm0 external-ids:skip_cleanup=true{{- if .Values.network.health_manager.interface_mtu }} \
++        -- set Interface o-hm0 mtu_request={{ .Values.network.health_manager.interface_mtu }}{{- end }}
+ 
+ ip link set dev o-hm0 address $HM_PORT_MAC
++{{- if .Values.network.health_manager.interface_mtu }}
++ip link set dev o-hm0 mtu {{ .Values.network.health_manager.interface_mtu }}
++{{- end }}
+ 
+ iptables -I INPUT -i o-hm0 -p udp --dport {{ .Values.conf.octavia.health_manager.bind_port }} -j ACCEPT
+diff --git a/octavia/templates/bin/_octavia-health-manager.sh.tpl b/octavia/templates/bin/_octavia-health-manager.sh.tpl
+index 220597eb7..345d9d4cb 100644
+--- a/octavia/templates/bin/_octavia-health-manager.sh.tpl
++++ b/octavia/templates/bin/_octavia-health-manager.sh.tpl
+@@ -28,11 +28,19 @@ HOOK
+   chmod +x /etc/dhcp/dhclient-enter-hooks.d/nodns
+ 
+   cat > /tmp/dhclient.conf <<EOF
++{{- if .Values.network.health_manager.interface_mtu }}
++request subnet-mask,broadcast-address;
++supersede interface-mtu {{ .Values.network.health_manager.interface_mtu }};
++{{- else }}
+ request subnet-mask,broadcast-address,interface-mtu;
++{{- end }}
+ do-forward-updates false;
+ EOF
+ 
+   dhclient -v o-hm0 -cf /tmp/dhclient.conf
++{{- if .Values.network.health_manager.interface_mtu }}
++  ip link set dev o-hm0 mtu {{ .Values.network.health_manager.interface_mtu }}
++{{- end }}
+ 
+   exec octavia-health-manager \
+         --config-file /etc/octavia/octavia.conf
+diff --git a/octavia/values.yaml b/octavia/values.yaml
+index 2fb67563e..0dc2c9428 100644
+--- a/octavia/values.yaml
++++ b/octavia/values.yaml
+@@ -86,6 +86,8 @@ network:
+     node_port:
+       enabled: false
+       port: 30826
++  health_manager:
++    interface_mtu: null
+ 
+ dependencies:
+   dynamic:

--- a/releasenotes/notes/octavia-health-manager-interface-mtu-9df61e134c20ec8f.yaml
+++ b/releasenotes/notes/octavia-health-manager-interface-mtu-9df61e134c20ec8f.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - The Octavia health manager interface MTU can now be configured with
+    ``octavia_health_manager_interface_mtu``.

--- a/roles/octavia/README.md
+++ b/roles/octavia/README.md
@@ -1,1 +1,12 @@
 # `octavia`
+
+## Health manager interface MTU
+
+Set `octavia_health_manager_interface_mtu` when the Octavia management
+network uses an MTU that differs from the Open vSwitch default. Atmosphere
+configures the DHCP client, the Linux `o-hm0` interface, and the Open vSwitch
+`mtu_request` value:
+
+```yaml
+octavia_health_manager_interface_mtu: 9000
+```

--- a/roles/octavia/defaults/main.yml
+++ b/roles/octavia/defaults/main.yml
@@ -41,8 +41,15 @@ octavia_jobboard_sentinel_secret_name: valkey-server-certs
 # Heartbeat key
 octavia_heartbeat_key: "{{ undef(hint='You must specify a Octavia heartbeat key') }}"
 
-# Octavia management subnet (CIDR)
+# Octavia management network.
 octavia_management_network_name: lb-mgmt-net
+
+# Octavia health manager interface MTU.
+#
+# octavia_health_manager_interface_mtu: 9000
+octavia_health_manager_interface_mtu: null
+
+# Octavia management subnet.
 octavia_management_subnet_name: lb-mgmt-subnet
 octavia_management_subnet_cidr: "172.24.0.0/22"
 

--- a/roles/octavia/vars/main.yml
+++ b/roles/octavia/vars/main.yml
@@ -19,6 +19,9 @@ _octavia_helm_values:
   endpoints: "{{ openstack_helm_endpoints }}"
   images:
     tags: "{{ atmosphere_images | vexxhost.atmosphere.openstack_helm_image_tags('octavia') }}"
+  network:
+    health_manager:
+      interface_mtu: "{{ octavia_health_manager_interface_mtu }}"
   pod:
     labels:
       include_app_kubernetes_io: false


### PR DESCRIPTION
Supersedes #4123, which GitHub no longer permits reopening after its head branch was recreated.

## Summary

- expose `octavia_health_manager_interface_mtu` through the Octavia role
- backport the health-manager portion of [OpenStack-Helm change 996204](https://review.opendev.org/c/openstack/openstack-helm/+/996204) under `charts/patches/octavia`
- configure DHCP, the Linux `o-hm0` interface, and Open vSwitch `mtu_request`
- preserve the current behavior when the option is unset

## Root cause

The Octavia health-manager port is an Open vSwitch internal interface. DHCP advertised the management-network MTU, but OVS could reconcile `o-hm0` back to the bridge default because `mtu_request` was unset. Oversized health-manager heartbeat packets were then dropped.

The upstream OpenStack-Helm change also updates the newer worker `o-w0` interface. Atmosphere pins Octavia chart 0.2.9, which does not contain that worker NIC-init path, so this backport intentionally includes only the applicable health-manager changes.

## Validation

- `helm lint charts/octavia`
- default render contains no MTU override
- render with `network.health_manager.interface_mtu=9000` contains the DHCP override, `ip link set dev o-hm0 mtu 9000`, and `mtu_request=9000`
- `go test ./roles/octavia`
- pinned `chart-vendor` regeneration leaves `charts/octavia` unchanged
- live multi-controller validation confirmed `o-hm0` MTU and OVS `mtu_request` at 9000, with the related alert resolved
