### PR TITLE
chore(monitoring): use packaged smartctl exporter image

### DIFF
--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -225,7 +225,7 @@ _atmosphere_images:
   prometheus_memcached_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/memcached-exporter:v0.14.3"
   prometheus_mysqld_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/mysqld-exporter:v0.17.0"
   prometheus_node_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/node-exporter:v1.8.1"
-  prometheus_smartctl_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheuscommunity/smartctl-exporter:v0.14.0@sha256:cfe22c36d7d2fac48ebf619707305acb65eb0fb670656eb80f356e606d782bc1"
+  prometheus_smartctl_exporter: "{{ atmosphere_image_prefix }}packages.vexxhost.com/smartctl-exporter:0.14.0-1"
   prometheus_openstack_database_exporter: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/openstack-database-exporter:v1.1.0@sha256:b8ae955645124e5d6054a3ce98069169e29dc1464d7979a4431f496ead50958e"
   prometheus_openstack_exporter: "{{ atmosphere_image_prefix }}ghcr.io/openstack-exporter/openstack-exporter:1.7.0"
   prometheus_operator_kube_webhook_certgen: "{{ atmosphere_image_prefix }}registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6"


### PR DESCRIPTION
## What changed

- switch the default SMART exporter image from the upstream Quay image to `packages.vexxhost.com/smartctl-exporter:0.14.0-1`
- use the maintained release tag without a manifest digest pin

## Why

The first VEXXHOST-packaged SMART exporter release is now published successfully in Pulp. Using that image makes Atmosphere consume the artifact produced by the new release workflow instead of the upstream image.

## Impact

New deployments and upgrades use the VEXXHOST-packaged multi-architecture SMART exporter image by default. The exporter version remains `0.14.0`.

## Validation

- verified the public registry tag resolves to OCI index digest `sha256:db9a79e49c98ec92e4f92cbe1248f2824646ffc87470445627c1b37280b1d76a`
- `git diff --check`