### PR TITLE
[Backport stable/zed] chore(monitoring): use packaged smartctl exporter image

### DIFF
--- a/roles/defaults/vars/main.yml
+++ b/roles/defaults/vars/main.yml
@@ -207,7 +207,7 @@ _atmosphere_images:
   prometheus_memcached_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/memcached-exporter:v0.10.0"
   prometheus_mysqld_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/mysqld-exporter:v0.14.0"
   prometheus_node_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheus/node-exporter:v1.7.0"
-  prometheus_smartctl_exporter: "{{ atmosphere_image_prefix }}quay.io/prometheuscommunity/smartctl-exporter:v0.14.0@sha256:cfe22c36d7d2fac48ebf619707305acb65eb0fb670656eb80f356e606d782bc1"
+  prometheus_smartctl_exporter: "{{ atmosphere_image_prefix }}packages.vexxhost.com/smartctl-exporter:0.14.0-1"
   prometheus_openstack_database_exporter: "{{ atmosphere_image_prefix }}ghcr.io/vexxhost/openstack-database-exporter:v1.1.0@sha256:b8ae955645124e5d6054a3ce98069169e29dc1464d7979a4431f496ead50958e"
   prometheus_openstack_exporter: "{{ atmosphere_image_prefix }}ghcr.io/openstack-exporter/openstack-exporter:1.7.0"
   prometheus_operator_kube_webhook_certgen: "{{ atmosphere_image_prefix }}registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6"


### PR DESCRIPTION
# Description
Backport of #4153 to `stable/zed`.