### PR TITLE
docs(glance): describe role purpose

### DIFF
--- a/roles/glance/README.md
+++ b/roles/glance/README.md
@@ -1,4 +1,4 @@
 # `glance`
 
 This role deploys the OpenStack Image service using the vendored Glance Helm
-chart.
+chart. It also configures the service endpoints and image storage integration.

--- a/roles/glance/README.md
+++ b/roles/glance/README.md
@@ -2,3 +2,4 @@
 
 This role deploys the OpenStack Image service using the vendored Glance Helm
 chart. It also configures the service endpoints and image storage integration.
+Configured images are imported after the service becomes available.

--- a/roles/glance/README.md
+++ b/roles/glance/README.md
@@ -3,3 +3,4 @@
 This role deploys the OpenStack Image service using the vendored Glance Helm
 chart. It also configures the service endpoints and image storage integration.
 Configured images are imported after the service becomes available.
+Image definitions are supplied through the `glance_images` role variable.

--- a/roles/glance/README.md
+++ b/roles/glance/README.md
@@ -1,1 +1,4 @@
 # `glance`
+
+This role deploys the OpenStack Image service using the vendored Glance Helm
+chart.


### PR DESCRIPTION
## Purpose

Validate PR #4152 with a Glance-only change.

## Expected selective plan

- target: `glance`
- schedule only `aio-openvswitch`
- deploy Glance and its dependency closure
- run `^tempest\.api\.image\.` smoke tests

This PR changes only `roles/glance/**` against `main`.

Depends-On: https://github.com/vexxhost/atmosphere/pull/4152