### PR TITLE
docs(cinder): describe role purpose

### DIFF
--- a/roles/cinder/README.md
+++ b/roles/cinder/README.md
@@ -4,6 +4,7 @@ This role deploys the OpenStack Block Storage service using the vendored Cinder
 Helm chart. It configures the API, scheduler, and volume services used by the
 deployment.
 Backend-specific chart values can be supplied through the role variables.
+Those values are merged with the generated chart defaults during deployment.
 
 ## Operations
 

--- a/roles/cinder/README.md
+++ b/roles/cinder/README.md
@@ -1,5 +1,8 @@
 # `cinder`
 
+This role deploys the OpenStack Block Storage service using the vendored Cinder
+Helm chart.
+
 ## Operations
 
 ### Auditing orphan attachments

--- a/roles/cinder/README.md
+++ b/roles/cinder/README.md
@@ -3,6 +3,7 @@
 This role deploys the OpenStack Block Storage service using the vendored Cinder
 Helm chart. It configures the API, scheduler, and volume services used by the
 deployment.
+Backend-specific chart values can be supplied through the role variables.
 
 ## Operations
 

--- a/roles/cinder/README.md
+++ b/roles/cinder/README.md
@@ -1,7 +1,8 @@
 # `cinder`
 
 This role deploys the OpenStack Block Storage service using the vendored Cinder
-Helm chart.
+Helm chart. It configures the API, scheduler, and volume services used by the
+deployment.
 
 ## Operations
 


### PR DESCRIPTION
## Purpose

Validate PR #4152 with a Cinder-only change.

## Expected selective plan

- target: `cinder`
- schedule only `aio-openvswitch`
- deploy Cinder and its dependency/test closure
- run `^tempest\.api\.volume\.` smoke tests

This PR changes only `roles/cinder/**` against `main`.

Depends-On: https://github.com/vexxhost/atmosphere/pull/4152