### PR TITLE
docs(nova): describe role purpose

### DIFF
--- a/roles/nova/README.md
+++ b/roles/nova/README.md
@@ -1,4 +1,5 @@
 # `nova`
 
 This role deploys the OpenStack Compute service using the vendored Nova Helm
-chart.
+chart. It configures the API, scheduler, and compute services used by the
+deployment.

--- a/roles/nova/README.md
+++ b/roles/nova/README.md
@@ -3,3 +3,4 @@
 This role deploys the OpenStack Compute service using the vendored Nova Helm
 chart. It configures the API, scheduler, and compute services used by the
 deployment.
+Configured flavors are created after the Compute API becomes available.

--- a/roles/nova/README.md
+++ b/roles/nova/README.md
@@ -4,3 +4,4 @@ This role deploys the OpenStack Compute service using the vendored Nova Helm
 chart. It configures the API, scheduler, and compute services used by the
 deployment.
 Configured flavors are created after the Compute API becomes available.
+Flavor definitions are supplied through the `nova_flavors` role variable.

--- a/roles/nova/README.md
+++ b/roles/nova/README.md
@@ -1,1 +1,4 @@
 # `nova`
+
+This role deploys the OpenStack Compute service using the vendored Nova Helm
+chart.


### PR DESCRIPTION
## Purpose

Validate PR #4152 with a Nova-only change.

## Expected selective plan

- target: `nova`
- schedule only `aio-openvswitch`
- deploy Nova and its dependency/test closure
- run focused compute and server-scenario smoke tests

This PR changes only `roles/nova/**` against `main`.

Depends-On: https://github.com/vexxhost/atmosphere/pull/4152