### PR TITLE
docs(cinder): describe role purpose

### DIFF
--- a/roles/cinder/README.md
+++ b/roles/cinder/README.md
@@ -1,5 +1,7 @@
 # `cinder`
 
+This role deploys the OpenStack Block Storage service.
+
 ## Operations
 
 ### Auditing orphan attachments


### PR DESCRIPTION
## Purpose

Validate PR #4152 with a Cinder-only change.

## Expected selective plan

- target: `cinder`
- schedule only `aio-openvswitch`
- deploy Cinder and its dependency/test closure
- run `^tempest\.api\.volume\.` smoke tests

This PR changes only `roles/cinder/**` against `main`.

Depends-On: https://github.com/vexxhost/atmosphere/pull/4152