### PR TITLE
test(barbican): validate selective CI

### DIFF
--- a/roles/barbican/SELECTIVE_CI_VALIDATION.md
+++ b/roles/barbican/SELECTIVE_CI_VALIDATION.md
@@ -1,0 +1,3 @@
+# Selective CI validation
+
+This temporary file validates the isolated Barbican change path.


### PR DESCRIPTION
## Purpose

Temporary isolated barbican selector/deployment validation for #4152.

Expected scheduler result: exactly one AIO Open vSwitch job with focused Key Manager verification.

The diff against `main` contains only one file under the component role path.

Depends-On: https://github.com/vexxhost/atmosphere/pull/4152