### PR TITLE
test(neutron): validate selective CI

### DIFF
--- a/roles/neutron/SELECTIVE_CI_VALIDATION.md
+++ b/roles/neutron/SELECTIVE_CI_VALIDATION.md
@@ -1,0 +1,3 @@
+# Selective CI validation
+
+This temporary file validates both Neutron network backends.


### PR DESCRIPTION
## Purpose

Temporary isolated neutron selector/deployment validation for #4152.

Expected scheduler result: exactly two jobs, AIO Open vSwitch and AIO OVN, both with focused Network tests.

The diff against `main` contains only one file under the component role path.

Depends-On: https://github.com/vexxhost/atmosphere/pull/4152