### PR TITLE
test(openstack-cli): validate selective CI

### DIFF
--- a/roles/openstack_cli/SELECTIVE_CI_VALIDATION.md
+++ b/roles/openstack_cli/SELECTIVE_CI_VALIDATION.md
@@ -1,0 +1,3 @@
+# Selective CI validation
+
+This temporary file validates the isolated OpenStack client change path.


### PR DESCRIPTION
## Purpose

Temporary isolated OpenStack client selector/deployment validation for #4152.

Expected scheduler result: exactly one AIO Open vSwitch job.

The diff against `main` contains only one file under the component role path.

Depends-On: https://github.com/vexxhost/atmosphere/pull/4152