### PR TITLE
test(frr-k8s): validate selective CI

### DIFF
--- a/roles/frr_k8s/SELECTIVE_CI_VALIDATION.md
+++ b/roles/frr_k8s/SELECTIVE_CI_VALIDATION.md
@@ -1,0 +1,3 @@
+# Selective CI validation
+
+This temporary file validates the isolated FRR Kubernetes change path.


### PR DESCRIPTION
## Purpose

Temporary isolated FRR Kubernetes network selector/deployment validation for #4152.

Expected scheduler result: exactly one AIO OVN job.

The diff against `main` contains only one file under the component role path.

Depends-On: https://github.com/vexxhost/atmosphere/pull/4152