### PR TITLE
test(openvswitch): validate selective CI

### DIFF
--- a/roles/openvswitch/SELECTIVE_CI_VALIDATION.md
+++ b/roles/openvswitch/SELECTIVE_CI_VALIDATION.md
@@ -1,0 +1,3 @@
+# Selective CI validation
+
+This temporary file validates the isolated Open vSwitch change path.


### PR DESCRIPTION
## Purpose

Temporary isolated Open vSwitch network selector/deployment validation for #4152.

Expected scheduler result: exactly one AIO Open vSwitch job.

The diff against `main` contains only one file under the component role path.

Depends-On: https://github.com/vexxhost/atmosphere/pull/4152