### PR TITLE
test(ci): validate cross-job-foundation combination

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -12,6 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+# Temporary selective CI group validation change.
+
 - hosts: "{{ target | default('all') }}"
   become: true
   pre_tasks:

--- a/roles/ethtool/SELECTIVE_CI_GROUP_VALIDATION.md
+++ b/roles/ethtool/SELECTIVE_CI_GROUP_VALIDATION.md
@@ -1,0 +1,3 @@
+# Selective CI group validation
+
+This temporary file represents a Kubernetes foundation change.

--- a/roles/keycloak/SELECTIVE_CI_GROUP_VALIDATION.md
+++ b/roles/keycloak/SELECTIVE_CI_GROUP_VALIDATION.md
@@ -1,0 +1,3 @@
+# Selective CI group validation
+
+This temporary file represents a Keycloak change.


### PR DESCRIPTION
## Purpose

Temporary multi-component selective-CI union validation for #4152: cross-job-foundation.

This verifies that each job receives only the components, dependencies, checks, and Tempest patterns assigned to that job.

Depends-On: https://github.com/vexxhost/atmosphere/pull/4152