### PR TITLE
test(ipmi-exporter): validate selective CI

### DIFF
--- a/roles/ipmi_exporter/SELECTIVE_CI_VALIDATION.md
+++ b/roles/ipmi_exporter/SELECTIVE_CI_VALIDATION.md
@@ -1,0 +1,3 @@
+# Selective CI validation
+
+This temporary file validates the isolated IPMI exporter change path.


### PR DESCRIPTION
## Purpose

Temporary isolated ipmi-exporter selector, dependency, and verifier validation for #4152.

The diff against main contains only one file under the component role path.

Depends-On: https://github.com/vexxhost/atmosphere/pull/4152