### PR TITLE
test(ceph): validate selective CI

### DIFF
--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -12,6 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+# Temporary selective CI validation change.
+
 - hosts: "{{ target | default('all') }}"
   become: true
   pre_tasks:


### PR DESCRIPTION
## Purpose

Temporary isolated ceph selector, dependency, and verifier validation for #4152.

The diff against main contains only one file under the component role path.

Depends-On: https://github.com/vexxhost/atmosphere/pull/4152