### PR TITLE
test(rabbitmq-cluster-operator): validate selective CI

### DIFF
--- a/roles/rabbitmq_cluster_operator/SELECTIVE_CI_VALIDATION.md
+++ b/roles/rabbitmq_cluster_operator/SELECTIVE_CI_VALIDATION.md
@@ -1,0 +1,3 @@
+# Selective CI validation
+
+This temporary file validates the isolated RabbitMQ operator change path.


### PR DESCRIPTION
## Purpose

Temporary isolated rabbitmq-cluster-operator selector, dependency, and verifier validation for #4152.

The diff against main contains only one file under the component role path.

Depends-On: https://github.com/vexxhost/atmosphere/pull/4152