### PR TITLE
test(percona-xtradb-cluster-operator): validate selective CI

### DIFF
--- a/roles/percona_xtradb_cluster_operator/SELECTIVE_CI_VALIDATION.md
+++ b/roles/percona_xtradb_cluster_operator/SELECTIVE_CI_VALIDATION.md
@@ -1,0 +1,3 @@
+# Selective CI validation
+
+This temporary file validates the isolated PXC operator change path.


### PR DESCRIPTION
## Purpose

Temporary isolated percona-xtradb-cluster-operator selector, dependency, and verifier validation for #4152.

The diff against main contains only one file under the component role path.

Depends-On: https://github.com/vexxhost/atmosphere/pull/4152