### PR TITLE
fix: disable missing Ironic log config cleanly

### DIFF
--- a/releasenotes/notes/ironic-empty-log-config-57f81ea05b6c29d4.yaml
+++ b/releasenotes/notes/ironic-empty-log-config-57f81ea05b6c29d4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Renders an empty ``log_config_append`` value when file-based Ironic
+    logging is disabled. This avoids serializing YAML ``null`` as the literal
+    ``<no value>`` filename in ``ironic.conf``.

--- a/roles/ironic/vars/main.yml
+++ b/roles/ironic/vars/main.yml
@@ -44,7 +44,7 @@ _ironic_helm_values:
   conf:
     ironic:
       DEFAULT:
-        log_config_append: null
+        log_config_append: ""
         enabled_network_interfaces: flat,neutron
         default_network_interface: flat
         rbac_service_role_elevated_access: true

--- a/roles/ironic/vars_test.go
+++ b/roles/ironic/vars_test.go
@@ -61,3 +61,20 @@ func TestHelmValues(t *testing.T) {
 	testutils.TestAllPodsHaveRuntimeClass(t, vals)
 	testutils.TestAllPodsHavePriorityClass(t, vals)
 }
+func TestDisabledLogConfigRendersEmptyValue(t *testing.T) {
+	var values struct {
+		HelmValues struct {
+			Conf struct {
+				Ironic struct {
+					Default map[string]any `yaml:"DEFAULT"`
+				} `yaml:"ironic"`
+			} `yaml:"conf"`
+		} `yaml:"_ironic_helm_values"`
+	}
+	err := yaml.UnmarshalWithOptions(varsFile, &values)
+	require.NoError(t, err)
+	require.Contains(t, values.HelmValues.Conf.Ironic.Default,
+		"log_config_append")
+	require.Equal(t, "",
+		values.HelmValues.Conf.Ironic.Default["log_config_append"])
+}


### PR DESCRIPTION
## Category

Production compatibility fix. No emulation, credentials, or environment-specific data is included.

## Summary

- render disabled `log_config_append` as an empty value instead of YAML `null`
- prevent Helm from writing the literal `<no value>` filename into `ironic.conf`
- add role regression coverage and a release note

## Validation

- `go test ./roles/ironic/...`
- `helm lint charts/ironic`
- current Ironic runtime parses an empty `log_config_append` as disabled