### PR TITLE
feat(ironic): configure Redfish Virtual Media boot

### DIFF
--- a/releasenotes/notes/enable-redfish-virtual-media-3da9fb17bb2d391e.yaml
+++ b/releasenotes/notes/enable-redfish-virtual-media-3da9fb17bb2d391e.yaml
@@ -1,0 +1,16 @@
+---
+features:
+  - |
+    Enables the Ironic configuration required for Redfish virtual-media
+    deployment. The role enables the ``redfish-virtual-media`` boot interface,
+    disables Swift temporary URLs, configures the x86_64 UEFI bootloader ESP,
+    and writes GRUB configuration to the Ubuntu signed GRUB prefix.
+
+    Runtime image selection remains managed through
+    ``atmosphere_image_overrides``. Deployments must select an Ironic image
+    that contains the configured bootloader ESP and required virtual-media
+    implementation.
+
+    Compatible bare metal nodes still need to select the
+    ``redfish-virtual-media`` boot interface and use a BMC-reachable media
+    publisher URL.

--- a/releasenotes/notes/enable-redfish-virtual-media-3da9fb17bb2d391e.yaml
+++ b/releasenotes/notes/enable-redfish-virtual-media-3da9fb17bb2d391e.yaml
@@ -1,16 +1,19 @@
 ---
 features:
   - |
-    Enables the Ironic configuration required for Redfish virtual-media
-    deployment. The role enables the ``redfish-virtual-media`` boot interface,
-    disables Swift temporary URLs, configures the x86_64 UEFI bootloader ESP,
-    and writes GRUB configuration to the Ubuntu signed GRUB prefix.
+    Adds ``redfish-virtual-media`` to the boot interfaces advertised by
+    Ironic. Compatible bare metal nodes still opt in by selecting that boot
+    interface, so existing nodes keep their selected PXE or iPXE path.
+
+    Deployment-specific publisher and UEFI settings remain opt-in through
+    ``ironic_redfish_virtual_media_enabled``. Enabling them disables Swift
+    temporary URLs, configures the x86_64 UEFI bootloader ESP, and writes GRUB
+    configuration to the Ubuntu signed GRUB prefix.
 
     Runtime image selection remains managed through
     ``atmosphere_image_overrides``. Deployments must select an Ironic image
     that contains the configured bootloader ESP and required virtual-media
     implementation.
 
-    Compatible bare metal nodes still need to select the
-    ``redfish-virtual-media`` boot interface and use a BMC-reachable media
-    publisher URL.
+    Nodes using the deployment-specific settings also need a BMC-reachable
+    media publisher URL.

--- a/releasenotes/notes/enable-redfish-virtual-media-3da9fb17bb2d391e.yaml
+++ b/releasenotes/notes/enable-redfish-virtual-media-3da9fb17bb2d391e.yaml
@@ -1,19 +1,21 @@
 ---
 features:
   - |
-    Adds ``redfish-virtual-media`` to the boot interfaces advertised by
-    Ironic. Compatible bare metal nodes still opt in by selecting that boot
-    interface, so existing nodes keep their selected PXE or iPXE path.
+    Enables the Ironic configuration required for Redfish virtual-media
+    deployment by default for Redfish-backed deployments. This advertises the
+    ``redfish-virtual-media`` boot interface, disables Swift temporary URLs,
+    configures the x86_64 UEFI bootloader ESP, and writes GRUB configuration to
+    the Ubuntu signed GRUB prefix.
 
-    Deployment-specific publisher and UEFI settings remain opt-in through
-    ``ironic_redfish_virtual_media_enabled``. Enabling them disables Swift
-    temporary URLs, configures the x86_64 UEFI bootloader ESP, and writes GRUB
-    configuration to the Ubuntu signed GRUB prefix.
+    Deployments that do not enable the Redfish hardware type can opt out with
+    ``ironic_redfish_virtual_media_enabled: false``. Compatible bare metal
+    nodes still select the ``redfish-virtual-media`` boot interface
+    individually, so existing PXE or iPXE selections are unchanged.
 
     Runtime image selection remains managed through
     ``atmosphere_image_overrides``. Deployments must select an Ironic image
     that contains the configured bootloader ESP and required virtual-media
     implementation.
 
-    Nodes using the deployment-specific settings also need a BMC-reachable
-    media publisher URL.
+    Nodes using Redfish virtual media also need a BMC-reachable media publisher
+    URL.

--- a/roles/ironic/defaults/main.yml
+++ b/roles/ironic/defaults/main.yml
@@ -26,15 +26,10 @@ ironic_ingress_class_name: "{{ atmosphere_ingress_class_name }}"
 # List of annotations to apply to the Ingress
 ironic_ingress_annotations: {}
 
-# Advertise Redfish virtual media by default. Compatible nodes still opt in by
-# selecting the redfish-virtual-media boot interface.
-ironic_enabled_boot_interfaces: ipxe,pxe,redfish-virtual-media
-
-# Configure the deployment-specific local publisher and UEFI bootloader
-# settings used by Redfish virtual media. Keep these settings opt-in because
-# Redfish power or management support does not guarantee usable virtual media,
-# a BMC-reachable publisher, or the required ESP in the selected Ironic image.
-ironic_redfish_virtual_media_enabled: false
+# Enable Redfish virtual media by default for Redfish-backed deployments.
+# Deployments that do not enable the Redfish hardware type can opt out. Nodes
+# still select the redfish-virtual-media boot interface individually.
+ironic_redfish_virtual_media_enabled: true
 ironic_redfish_virtual_media_use_swift: false
 ironic_redfish_virtual_media_bootloader_by_arch: >-
   x86_64:file:///usr/share/ironic/esp/x86_64.img
@@ -42,6 +37,7 @@ ironic_redfish_virtual_media_grub_config_path: EFI/ubuntu/grub.cfg
 ironic_redfish_virtual_media_file_url_allowed_paths:
   - /var/lib/ironic
   - /usr/share/ironic/esp
+ironic_enabled_boot_interfaces: ipxe,pxe,redfish-virtual-media
 
 # Ironic bare metal network used for PXE
 ironic_bare_metal_network_manage: true

--- a/roles/ironic/defaults/main.yml
+++ b/roles/ironic/defaults/main.yml
@@ -26,6 +26,18 @@ ironic_ingress_class_name: "{{ atmosphere_ingress_class_name }}"
 # List of annotations to apply to the Ingress
 ironic_ingress_annotations: {}
 
+# Enable the Ironic-side Redfish virtual-media support. Compatible nodes still
+# opt in by selecting the redfish-virtual-media boot interface.
+ironic_redfish_virtual_media_enabled: false
+ironic_redfish_virtual_media_use_swift: false
+ironic_redfish_virtual_media_bootloader_by_arch: >-
+  x86_64:file:///usr/share/ironic/esp/x86_64.img
+ironic_redfish_virtual_media_grub_config_path: EFI/ubuntu/grub.cfg
+ironic_redfish_virtual_media_file_url_allowed_paths:
+  - /var/lib/ironic
+  - /usr/share/ironic/esp
+ironic_enabled_boot_interfaces: ipxe,pxe,redfish-virtual-media
+
 # Ironic bare metal network used for PXE
 ironic_bare_metal_network_manage: true
 ironic_bare_metal_network_name: baremetal

--- a/roles/ironic/defaults/main.yml
+++ b/roles/ironic/defaults/main.yml
@@ -26,8 +26,14 @@ ironic_ingress_class_name: "{{ atmosphere_ingress_class_name }}"
 # List of annotations to apply to the Ingress
 ironic_ingress_annotations: {}
 
-# Enable the Ironic-side Redfish virtual-media support. Compatible nodes still
-# opt in by selecting the redfish-virtual-media boot interface.
+# Advertise Redfish virtual media by default. Compatible nodes still opt in by
+# selecting the redfish-virtual-media boot interface.
+ironic_enabled_boot_interfaces: ipxe,pxe,redfish-virtual-media
+
+# Configure the deployment-specific local publisher and UEFI bootloader
+# settings used by Redfish virtual media. Keep these settings opt-in because
+# Redfish power or management support does not guarantee usable virtual media,
+# a BMC-reachable publisher, or the required ESP in the selected Ironic image.
 ironic_redfish_virtual_media_enabled: false
 ironic_redfish_virtual_media_use_swift: false
 ironic_redfish_virtual_media_bootloader_by_arch: >-
@@ -36,7 +42,6 @@ ironic_redfish_virtual_media_grub_config_path: EFI/ubuntu/grub.cfg
 ironic_redfish_virtual_media_file_url_allowed_paths:
   - /var/lib/ironic
   - /usr/share/ironic/esp
-ironic_enabled_boot_interfaces: ipxe,pxe,redfish-virtual-media
 
 # Ironic bare metal network used for PXE
 ironic_bare_metal_network_manage: true

--- a/roles/ironic/vars/main.yml
+++ b/roles/ironic/vars/main.yml
@@ -45,7 +45,12 @@ _ironic_helm_values:
     ironic:
       DEFAULT:
         log_config_append: null
-        enabled_boot_interfaces: "{{ ironic_enabled_boot_interfaces }}"
+        enabled_boot_interfaces: >-
+          {{
+            ironic_enabled_boot_interfaces
+            if ironic_redfish_virtual_media_enabled | bool
+            else omit
+          }}
         enabled_network_interfaces: flat,neutron
         grub_config_path: >-
           {{

--- a/roles/ironic/vars/main.yml
+++ b/roles/ironic/vars/main.yml
@@ -45,13 +45,37 @@ _ironic_helm_values:
     ironic:
       DEFAULT:
         log_config_append: null
+        enabled_boot_interfaces: >-
+          {{
+            ironic_enabled_boot_interfaces
+            if ironic_redfish_virtual_media_enabled | bool
+            else omit
+          }}
         enabled_network_interfaces: flat,neutron
+        grub_config_path: >-
+          {{
+            ironic_redfish_virtual_media_grub_config_path
+            if ironic_redfish_virtual_media_enabled | bool
+            else omit
+          }}
         default_network_interface: flat
         rbac_service_role_elevated_access: true
       conductor:
         clean_step_priority_override: deploy.erase_devices_express:5
         deploy_kernel: "{{ ironic_python_agent_deploy_kernel.images.0.id }}"
         deploy_ramdisk: "{{ ironic_python_agent_deploy_ramdisk.images.0.id }}"
+        bootloader_by_arch: >-
+          {{
+            ironic_redfish_virtual_media_bootloader_by_arch
+            if ironic_redfish_virtual_media_enabled | bool
+            else omit
+          }}
+        file_url_allowed_paths: >-
+          {{
+            ironic_redfish_virtual_media_file_url_allowed_paths
+            if ironic_redfish_virtual_media_enabled | bool
+            else omit
+          }}
       database:
         connection_recycle_time: 600
         max_overflow: 50
@@ -67,6 +91,13 @@ _ironic_helm_values:
         rescuing_network: "{{ ironic_bare_metal_network_name }}"
       pxe:
         kernel_append_params: "ipa-insecure=true systemd.journald.forward_to_console=yes"
+      redfish:
+        use_swift: >-
+          {{
+            ironic_redfish_virtual_media_use_swift | bool
+            if ironic_redfish_virtual_media_enabled | bool
+            else omit
+          }}
       service_catalog:
         valid_interfaces: public
     rabbitmq:

--- a/roles/ironic/vars/main.yml
+++ b/roles/ironic/vars/main.yml
@@ -45,12 +45,7 @@ _ironic_helm_values:
     ironic:
       DEFAULT:
         log_config_append: null
-        enabled_boot_interfaces: >-
-          {{
-            ironic_enabled_boot_interfaces
-            if ironic_redfish_virtual_media_enabled | bool
-            else omit
-          }}
+        enabled_boot_interfaces: "{{ ironic_enabled_boot_interfaces }}"
         enabled_network_interfaces: flat,neutron
         grub_config_path: >-
           {{

--- a/roles/ironic/vars_test.go
+++ b/roles/ironic/vars_test.go
@@ -13,6 +13,9 @@ import (
 )
 
 var (
+	//go:embed defaults/main.yml
+	defaultsFile []byte
+
 	//go:embed vars/main.yml
 	varsFile []byte
 	vars     Vars
@@ -20,6 +23,25 @@ var (
 
 type Vars struct {
 	openstack_helm.HelmValues `yaml:"_ironic_helm_values"`
+}
+
+type Defaults struct {
+	RedfishVirtualMediaEnabled             bool     `yaml:"ironic_redfish_virtual_media_enabled"`
+	RedfishVirtualMediaUseSwift            bool     `yaml:"ironic_redfish_virtual_media_use_swift"`
+	RedfishVirtualMediaBootloaderByArch    string   `yaml:"ironic_redfish_virtual_media_bootloader_by_arch"`
+	RedfishVirtualMediaGrubConfigPath      string   `yaml:"ironic_redfish_virtual_media_grub_config_path"`
+	RedfishVirtualMediaFileURLAllowedPaths []string `yaml:"ironic_redfish_virtual_media_file_url_allowed_paths"`
+}
+
+func TestRedfishVirtualMediaDefaults(t *testing.T) {
+	var defaults Defaults
+	err := yaml.UnmarshalWithOptions(defaultsFile, &defaults)
+	require.NoError(t, err)
+	require.False(t, defaults.RedfishVirtualMediaEnabled)
+	require.False(t, defaults.RedfishVirtualMediaUseSwift)
+	require.Equal(t, "x86_64:file:///usr/share/ironic/esp/x86_64.img", defaults.RedfishVirtualMediaBootloaderByArch)
+	require.Equal(t, "EFI/ubuntu/grub.cfg", defaults.RedfishVirtualMediaGrubConfigPath)
+	require.Contains(t, defaults.RedfishVirtualMediaFileURLAllowedPaths, "/usr/share/ironic/esp")
 }
 
 func TestMain(m *testing.M) {
@@ -38,9 +60,9 @@ func TestHelmValues(t *testing.T) {
 	// for the actual template. Like:
 	// {{ tuple "heat_api" . | include "helm-toolkit.snippets.kubernetes_pod_priority_class" }}
 	vars.HelmValues.Pod.PriorityClass = map[string]string{
-		"bootstrap": "high-priority",
-		"db_sync": "high-priority",
-		"ironic_api": "high-priority",
+		"bootstrap":        "high-priority",
+		"db_sync":          "high-priority",
+		"ironic_api":       "high-priority",
 		"ironic_conductor": "high-priority",
 	}
 	// (rlin): Before you add any new runtime class here.
@@ -49,9 +71,9 @@ func TestHelmValues(t *testing.T) {
 	// for the actual template. Like:
 	// {{ tuple "heat_api" . | include "helm-toolkit.snippets.kubernetes_pod_runtime_class" }}
 	vars.HelmValues.Pod.RuntimeClass = map[string]string{
-		"bootstrap": "kata-clh",
-		"db_sync": "kata-clh",
-		"ironic_api": "kata-clh",
+		"bootstrap":        "kata-clh",
+		"db_sync":          "kata-clh",
+		"ironic_api":       "kata-clh",
 		"ironic_conductor": "kata-clh",
 	}
 	vals, err := openstack_helm.CoalescedHelmValues("../../charts/ironic", &vars.HelmValues)

--- a/roles/ironic/vars_test.go
+++ b/roles/ironic/vars_test.go
@@ -51,18 +51,19 @@ func TestRedfishVirtualMediaDefaults(t *testing.T) {
 	err := yaml.UnmarshalWithOptions(defaultsFile, &defaults)
 	require.NoError(t, err)
 	require.Equal(t, "ipxe,pxe,redfish-virtual-media", defaults.EnabledBootInterfaces)
-	require.False(t, defaults.RedfishVirtualMediaEnabled)
+	require.True(t, defaults.RedfishVirtualMediaEnabled)
 	require.False(t, defaults.RedfishVirtualMediaUseSwift)
 	require.Equal(t, "x86_64:file:///usr/share/ironic/esp/x86_64.img", defaults.RedfishVirtualMediaBootloaderByArch)
 	require.Equal(t, "EFI/ubuntu/grub.cfg", defaults.RedfishVirtualMediaGrubConfigPath)
 	require.Contains(t, defaults.RedfishVirtualMediaFileURLAllowedPaths, "/usr/share/ironic/esp")
 }
 
-func TestRedfishVirtualMediaBootInterfaceIsAlwaysAdvertised(t *testing.T) {
+func TestRedfishVirtualMediaBootInterfaceFollowsFeature(t *testing.T) {
 	var ironicVars IronicVars
 	err := yaml.UnmarshalWithOptions(varsFile, &ironicVars)
 	require.NoError(t, err)
-	require.Equal(t, "{{ ironic_enabled_boot_interfaces }}", ironicVars.HelmValues.Conf.Ironic.Default.EnabledBootInterfaces)
+	require.Contains(t, ironicVars.HelmValues.Conf.Ironic.Default.EnabledBootInterfaces, "if ironic_redfish_virtual_media_enabled | bool")
+	require.Contains(t, ironicVars.HelmValues.Conf.Ironic.Default.EnabledBootInterfaces, "else omit")
 }
 
 func TestMain(m *testing.M) {

--- a/roles/ironic/vars_test.go
+++ b/roles/ironic/vars_test.go
@@ -26,6 +26,7 @@ type Vars struct {
 }
 
 type Defaults struct {
+	EnabledBootInterfaces                  string   `yaml:"ironic_enabled_boot_interfaces"`
 	RedfishVirtualMediaEnabled             bool     `yaml:"ironic_redfish_virtual_media_enabled"`
 	RedfishVirtualMediaUseSwift            bool     `yaml:"ironic_redfish_virtual_media_use_swift"`
 	RedfishVirtualMediaBootloaderByArch    string   `yaml:"ironic_redfish_virtual_media_bootloader_by_arch"`
@@ -33,15 +34,35 @@ type Defaults struct {
 	RedfishVirtualMediaFileURLAllowedPaths []string `yaml:"ironic_redfish_virtual_media_file_url_allowed_paths"`
 }
 
+type IronicVars struct {
+	HelmValues struct {
+		Conf struct {
+			Ironic struct {
+				Default struct {
+					EnabledBootInterfaces string `yaml:"enabled_boot_interfaces"`
+				} `yaml:"DEFAULT"`
+			} `yaml:"ironic"`
+		} `yaml:"conf"`
+	} `yaml:"_ironic_helm_values"`
+}
+
 func TestRedfishVirtualMediaDefaults(t *testing.T) {
 	var defaults Defaults
 	err := yaml.UnmarshalWithOptions(defaultsFile, &defaults)
 	require.NoError(t, err)
+	require.Equal(t, "ipxe,pxe,redfish-virtual-media", defaults.EnabledBootInterfaces)
 	require.False(t, defaults.RedfishVirtualMediaEnabled)
 	require.False(t, defaults.RedfishVirtualMediaUseSwift)
 	require.Equal(t, "x86_64:file:///usr/share/ironic/esp/x86_64.img", defaults.RedfishVirtualMediaBootloaderByArch)
 	require.Equal(t, "EFI/ubuntu/grub.cfg", defaults.RedfishVirtualMediaGrubConfigPath)
 	require.Contains(t, defaults.RedfishVirtualMediaFileURLAllowedPaths, "/usr/share/ironic/esp")
+}
+
+func TestRedfishVirtualMediaBootInterfaceIsAlwaysAdvertised(t *testing.T) {
+	var ironicVars IronicVars
+	err := yaml.UnmarshalWithOptions(varsFile, &ironicVars)
+	require.NoError(t, err)
+	require.Equal(t, "{{ ironic_enabled_boot_interfaces }}", ironicVars.HelmValues.Conf.Ironic.Default.EnabledBootInterfaces)
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
## Summary

- enable the Redfish Virtual Media deployment configuration by default for Redfish-backed Ironic deployments
- advertise `redfish-virtual-media` while the feature is enabled
- keep boot-interface selection explicit per bare metal node, preserving existing PXE and iPXE selections
- provide `ironic_redfish_virtual_media_enabled: false` as the opt-out for deployments that do not enable Redfish
- retain runtime image ownership in the existing `atmosphere_image_overrides` contract

## Why

Redfish is part of the standard Ironic configuration, so its Virtual Media deployment path should work by default rather than require a second opt-in. Enabling the deployment configuration does not change the boot interface already selected on existing nodes; compatible nodes still select `redfish-virtual-media` individually.

While enabled, the role advertises the interface, disables Swift temporary URLs, permits the local media paths, and configures the x86_64 UEFI bootloader ESP and GRUB path. Deployments that do not use the Redfish hardware type can explicitly disable the feature.

Deployments remain responsible for selecting a compatible Ironic image and providing a BMC-reachable media publisher URL.

## Validation

- `go test ./roles/ironic/...`
- `git diff --check`
- local `pre-commit` command is unavailable; the PR CI pre-commit job provides that validation
- confirmed the diff contains no downstream repository, image, environment, address, or credential references