### PR TITLE
fix(tempest): make Helm test hooks rerunnable

### DIFF
--- a/releasenotes/notes/tempest-rerun-hook-8bb58cbe6ec11675.yaml
+++ b/releasenotes/notes/tempest-rerun-hook-8bb58cbe6ec11675.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Tempest verification now forces the Helm upgrade so repeated role runs
+    create a fresh test Job even when the chart and values are unchanged. If
+    Helm does not create the Job, the role reports the deployment error instead
+    of trying to read logs from a stale or missing pod.

--- a/roles/tempest/tasks/main.yml
+++ b/roles/tempest/tasks/main.yml
@@ -86,8 +86,10 @@
     release_namespace: "{{ tempest_helm_release_namespace }}"
     kubeconfig: "{{ tempest_helm_kubeconfig }}"
     values: "{{ _tempest_helm_values | combine(_tempest_network_backend_settings[atmosphere_network_backend], recursive=True) | combine(tempest_helm_values, recursive=True) }}" # noqa: yaml[line-length]
+    force: true
     wait: true
     wait_timeout: 20m
+  register: _tempest_helm_result
 
 - name: Get tempest job object
   kubernetes.core.k8s_info:
@@ -96,6 +98,13 @@
     name: tempest-run-tests
     namespace: openstack
   register: _tempest_job_obj
+
+- name: Fail when tempest job was not created
+  ansible.builtin.fail:
+    msg: >-
+      Tempest Helm deployment did not create tempest-run-tests:
+      {{ _tempest_helm_result.msg | default(_tempest_helm_result.stderr | default('no Helm error reported')) }}
+  when: _tempest_job_obj.resources | length == 0
 
 - name: Get tempest log
   kubernetes.core.k8s_log:


### PR DESCRIPTION
## Summary

- force the Tempest Helm upgrade during verification runs
- ensure repeated role executions create a fresh test Job
- fail with the Helm deployment result when the expected Job is missing

## Why

The Tempest test Job is a post-install and post-upgrade Helm hook. When the
chart and values are unchanged, a repeated role run may not execute an upgrade
and can observe a completed, failed, or missing Job from the previous run.
Forcing the upgrade makes the verification lifecycle explicit and repeatable.

The Helm task intentionally retains its existing deferred failure handling so
the role can report the Tempest Job result. The added missing-Job check prevents
the subsequent log and status tasks from indexing an empty resource list.

## Validation

- `go test ./...`
- `git diff --check`
- confirmed the diff contains no downstream repository, environment, address,
  image, or credential references

Local `pre-commit` setup is blocked on this validation host because Python 3.8
cannot build the current ansible-lint dependency metadata. Upstream CI provides
the supported validation environment.
