### PR TITLE
fix(rabbitmq): retry transient cluster deployment failures

### DIFF
--- a/releasenotes/notes/rabbitmq-transient-deployment-retries-3702de29914fad26.yaml
+++ b/releasenotes/notes/rabbitmq-transient-deployment-retries-3702de29914fad26.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
   - |
-    RabbitMQ cluster deployment now retries temporary failures while waiting\n    for the cluster to become available.
+    RabbitMQ cluster deployment now retries temporary failures while waiting
+    for the cluster to become available.

--- a/releasenotes/notes/rabbitmq-transient-deployment-retries-3702de29914fad26.yaml
+++ b/releasenotes/notes/rabbitmq-transient-deployment-retries-3702de29914fad26.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    RabbitMQ cluster deployment now retries temporary failures while waiting\n    for the cluster to become available.

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -62,3 +62,7 @@
     wait_condition:
       type: ClusterAvailable
       status: "True"
+  register: _rabbitmq_cluster_deployment
+  retries: 3
+  delay: 5
+  until: _rabbitmq_cluster_deployment is not failed


### PR DESCRIPTION
## What changed

- retry temporary failures while deploying and waiting for a RabbitMQ cluster;
- keep the existing three-attempt, five-second retry behavior from the validated selective-CI branch;
- add a release note.

## Why

The Kubernetes API or RabbitMQ operator can briefly reject or fail the wait operation while the cluster is converging. The role previously failed immediately, making otherwise healthy deployments flaky.

This production fix is extracted from #4152 so it can be reviewed, released, and backported independently from selective CI.

## Validation

- file-scoped pre-commit hooks passed;
- `git diff --check` passed;
- the repository-wide Ansible lint traversal reached all roles, including RabbitMQ, and only failed on the existing `galaxy[no-changelog]` metadata issue;
- Reno parsed the new note and only reported the repository's existing duplicate release-note UID.