### PR TITLE
fix(octavia): retry transient quota requests

### DIFF
--- a/releasenotes/notes/octavia-quota-request-retries-33284ed85339a6c3.yaml
+++ b/releasenotes/notes/octavia-quota-request-retries-33284ed85339a6c3.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
   - |
-    Compute quota updates for the Octavia service now retry temporary API\n    failures.
+    Compute quota updates for the Octavia service now retry temporary API
+    failures.

--- a/releasenotes/notes/octavia-quota-request-retries-33284ed85339a6c3.yaml
+++ b/releasenotes/notes/octavia-quota-request-retries-33284ed85339a6c3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Compute quota updates for the Octavia service now retry temporary API\n    failures.

--- a/roles/octavia/tasks/main.yml
+++ b/roles/octavia/tasks/main.yml
@@ -95,6 +95,10 @@
     gigabytes: -1
     security_group: -1
     security_group_rule: -1
+  register: _octavia_admin_compute_quotaset
+  retries: 60
+  delay: 5
+  until: _octavia_admin_compute_quotaset is not failed
 
 - name: Deploy Helm chart
   run_once: true


### PR DESCRIPTION
## What changed

- retry the Octavia administrative compute quota update for up to five minutes;
- add a release note.

## Why

The quota request can race with OpenStack API readiness during deployment. A temporary API failure previously stopped Octavia even when the service recovered moments later.

This production fix is extracted from #4152 so it can be reviewed, released, and backported independently from selective CI.

## Validation

- file-scoped pre-commit hooks passed;
- `git diff --check` passed;
- the repository-wide Ansible lint traversal reached all roles and only failed on the existing `galaxy[no-changelog]` metadata issue;
- Reno parsed the new note and only reported the repository's existing duplicate release-note UID.