### PR TITLE
fix(keepalived): create deployment namespace

### DIFF
--- a/releasenotes/notes/keepalived-create-namespace-7795c45dfb60f2da.yaml
+++ b/releasenotes/notes/keepalived-create-namespace-7795c45dfb60f2da.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The Keepalived role now creates the ``openstack`` namespace when enabled\n    before deploying its resources.

--- a/releasenotes/notes/keepalived-create-namespace-7795c45dfb60f2da.yaml
+++ b/releasenotes/notes/keepalived-create-namespace-7795c45dfb60f2da.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
   - |
-    The Keepalived role now creates the ``openstack`` namespace when enabled\n    before deploying its resources.
+    The Keepalived role now creates the ``openstack`` namespace when enabled
+    before deploying its resources.

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -12,6 +12,17 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Create namespace
+  run_once: true
+  when: keepalived_enabled | bool
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openstack
+
 - name: Deploy service
   run_once: true
   when: keepalived_enabled | bool

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -12,23 +12,17 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Create namespace
-  run_once: true
-  when: keepalived_enabled | bool
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: openstack
-
 - name: Deploy service
   run_once: true
   when: keepalived_enabled | bool
   kubernetes.core.k8s:
     state: present
     definition:
+      - apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: openstack
+
       - apiVersion: v1
         kind: Secret
         metadata:


### PR DESCRIPTION
## What changed

- create the `openstack` namespace before deploying Keepalived resources;
- preserve the existing `keepalived_enabled` guard;
- add a release note.

## Why

The role assumed another role had already created its namespace. Running Keepalived in a focused or reordered deployment therefore failed even though all of its other inputs were present.

This production fix is extracted from #4152 so it can be reviewed, released, and backported independently from selective CI.

## Validation

- file-scoped pre-commit hooks passed;
- `git diff --check` passed;
- the repository-wide Ansible lint traversal reached all roles and only failed on the existing `galaxy[no-changelog]` metadata issue;
- Reno parsed the new note and only reported the repository's existing duplicate release-note UID.