### PR TITLE
fix(ceph-provisioners): create deployment namespace

### DIFF
--- a/releasenotes/notes/ceph-provisioners-create-namespace-52bf4b8d56327393.yaml
+++ b/releasenotes/notes/ceph-provisioners-create-namespace-52bf4b8d56327393.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The Ceph provisioners role now creates its configured deployment namespace\n    before creating Kubernetes resources.

--- a/releasenotes/notes/ceph-provisioners-create-namespace-52bf4b8d56327393.yaml
+++ b/releasenotes/notes/ceph-provisioners-create-namespace-52bf4b8d56327393.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
   - |
-    The Ceph provisioners role now creates its configured deployment namespace\n    before creating Kubernetes resources.
+    The Ceph provisioners role now creates its configured deployment namespace
+    before creating Kubernetes resources.

--- a/roles/ceph_provisioners/tasks/main.yml
+++ b/roles/ceph_provisioners/tasks/main.yml
@@ -12,16 +12,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Create namespace
-  run_once: true
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: "{{ ceph_provisioners_helm_release_namespace }}"
-
 - name: Collect "ceph mon dump" output from a monitor
   delegate_to: "{{ groups[ceph_provisioners_ceph_mon_group][0] }}"
   run_once: true
@@ -40,29 +30,34 @@
       }}
   loop: "{{ _ceph_mon_dump.stdout | from_json | community.general.json_query('mons[*].addr') | map('regex_replace', '(.*):(.*)', '\\1') }}"
 
-- name: Create Ceph service
+- name: Create Ceph namespace and service
   kubernetes.core.k8s:
     state: present
     definition:
-      apiVersion: v1
-      kind: Service
-      metadata:
-        name: ceph-mon
-        namespace: "{{ ceph_provisioners_helm_release_namespace }}"
-        labels:
-          application: ceph
-      spec:
-        clusterIP: None
-        ports:
-          - name: mon
-            port: 6789
-            targetPort: 6789
-          - name: mon-msgr2
-            port: 3300
-            targetPort: 3300
-          - name: metrics
-            port: 9283
-            targetPort: 9283
+      - apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: "{{ ceph_provisioners_helm_release_namespace }}"
+
+      - apiVersion: v1
+        kind: Service
+        metadata:
+          name: ceph-mon
+          namespace: "{{ ceph_provisioners_helm_release_namespace }}"
+          labels:
+            application: ceph
+        spec:
+          clusterIP: None
+          ports:
+            - name: mon
+              port: 6789
+              targetPort: 6789
+            - name: mon-msgr2
+              port: 3300
+              targetPort: 3300
+            - name: metrics
+              port: 9283
+              targetPort: 9283
 
 - name: Create Ceph endpoints
   kubernetes.core.k8s:

--- a/roles/ceph_provisioners/tasks/main.yml
+++ b/roles/ceph_provisioners/tasks/main.yml
@@ -12,6 +12,16 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Create namespace
+  run_once: true
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ ceph_provisioners_helm_release_namespace }}"
+
 - name: Collect "ceph mon dump" output from a monitor
   delegate_to: "{{ groups[ceph_provisioners_ceph_mon_group][0] }}"
   run_once: true

--- a/roles/ceph_provisioners/tasks/main.yml
+++ b/roles/ceph_provisioners/tasks/main.yml
@@ -31,6 +31,7 @@
   loop: "{{ _ceph_mon_dump.stdout | from_json | community.general.json_query('mons[*].addr') | map('regex_replace', '(.*):(.*)', '\\1') }}"
 
 - name: Create Ceph namespace and service
+  run_once: true
   kubernetes.core.k8s:
     state: present
     definition:

--- a/roles/ceph_provisioners/tasks/main.yml
+++ b/roles/ceph_provisioners/tasks/main.yml
@@ -48,7 +48,7 @@
       kind: Service
       metadata:
         name: ceph-mon
-        namespace: openstack
+        namespace: "{{ ceph_provisioners_helm_release_namespace }}"
         labels:
           application: ceph
       spec:
@@ -72,7 +72,7 @@
       kind: Endpoints
       metadata:
         name: ceph-mon
-        namespace: openstack
+        namespace: "{{ ceph_provisioners_helm_release_namespace }}"
         labels:
           application: ceph
       subsets:
@@ -109,7 +109,7 @@
       type: kubernetes.io/rbd
       metadata:
         name: pvc-ceph-client-key
-        namespace: openstack
+        namespace: "{{ ceph_provisioners_helm_release_namespace }}"
         labels:
           application: ceph
       stringData:


### PR DESCRIPTION
## What changed

- create the configured Ceph provisioners namespace before creating Kubernetes resources;
- add a release note.

## Why

The role assumed its namespace had been created by an earlier deployment step. That hidden ordering dependency breaks focused deployments and makes the role non-self-contained.

This production fix is extracted from #4152 so it can be reviewed, released, and backported independently from selective CI.

## Validation

- file-scoped pre-commit hooks passed;
- `git diff --check` passed;
- the repository-wide Ansible lint traversal reached all roles and only failed on the existing `galaxy[no-changelog]` metadata issue;
- Reno parsed the new note and only reported the repository's existing duplicate release-note UID.