### PR TITLE
fix(valkey): create deployment namespace

### DIFF
--- a/releasenotes/notes/valkey-create-namespace-eb0189a13c793180.yaml
+++ b/releasenotes/notes/valkey-create-namespace-eb0189a13c793180.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The Valkey role now creates its configured deployment namespace before\n    creating certificate resources.

--- a/releasenotes/notes/valkey-create-namespace-eb0189a13c793180.yaml
+++ b/releasenotes/notes/valkey-create-namespace-eb0189a13c793180.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
   - |
-    The Valkey role now creates its configured deployment namespace before\n    creating certificate resources.
+    The Valkey role now creates its configured deployment namespace before
+    creating certificate resources.

--- a/roles/valkey/tasks/main.yml
+++ b/roles/valkey/tasks/main.yml
@@ -1,6 +1,16 @@
 # Copyright (c) 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+- name: Create namespace
+  run_once: true
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ valkey_helm_release_namespace }}"
+
 - name: Create TLS resources
   kubernetes.core.k8s:
     state: present

--- a/roles/valkey/tasks/main.yml
+++ b/roles/valkey/tasks/main.yml
@@ -1,20 +1,16 @@
 # Copyright (c) 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-- name: Create namespace
+- name: Create TLS resources
   run_once: true
   kubernetes.core.k8s:
     state: present
     definition:
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: "{{ valkey_helm_release_namespace }}"
+      - apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: "{{ valkey_helm_release_namespace }}"
 
-- name: Create TLS resources
-  kubernetes.core.k8s:
-    state: present
-    definition:
       - apiVersion: cert-manager.io/v1
         kind: Certificate
         metadata:


### PR DESCRIPTION
## What changed

- create the configured Valkey namespace before creating certificate resources;
- add a release note.

## Why

Valkey created namespaced certificate resources before ensuring the target namespace existed. This made the role depend on unrelated deployment ordering.

This production fix is extracted from #4152 so it can be reviewed, released, and backported independently from selective CI.

## Validation

- file-scoped pre-commit hooks passed;
- `git diff --check` passed;
- the repository-wide Ansible lint traversal reached all roles and only failed on the existing `galaxy[no-changelog]` metadata issue;
- Reno parsed the new note and only reported the repository's existing duplicate release-note UID.