### PR TITLE
fix(ipmi-exporter): create deployment namespace

### DIFF
--- a/releasenotes/notes/ipmi-exporter-create-namespace-5b3040547995e4e4.yaml
+++ b/releasenotes/notes/ipmi-exporter-create-namespace-5b3040547995e4e4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The IPMI exporter role now creates the ``monitoring`` namespace before\n    deploying its resources.

--- a/releasenotes/notes/ipmi-exporter-create-namespace-5b3040547995e4e4.yaml
+++ b/releasenotes/notes/ipmi-exporter-create-namespace-5b3040547995e4e4.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
   - |
-    The IPMI exporter role now creates the ``monitoring`` namespace before\n    deploying its resources.
+    The IPMI exporter role now creates the ``monitoring`` namespace before
+    deploying its resources.

--- a/roles/ipmi_exporter/tasks/main.yml
+++ b/roles/ipmi_exporter/tasks/main.yml
@@ -12,6 +12,16 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Create namespace
+  run_once: true
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: monitoring
+
 - name: Deploy service
   kubernetes.core.k8s:
     state: present

--- a/roles/ipmi_exporter/tasks/main.yml
+++ b/roles/ipmi_exporter/tasks/main.yml
@@ -12,20 +12,16 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Create namespace
+- name: Deploy service
   run_once: true
   kubernetes.core.k8s:
     state: present
     definition:
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: monitoring
+      - apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: monitoring
 
-- name: Deploy service
-  kubernetes.core.k8s:
-    state: present
-    definition:
       - apiVersion: v1
         kind: ConfigMap
         metadata:


### PR DESCRIPTION
## What changed

- create the `monitoring` namespace before deploying IPMI exporter resources;
- add a release note.

## Why

The role assumed monitoring infrastructure had already created the namespace. A focused IPMI exporter deployment therefore failed on a fresh cluster.

This production fix is extracted from #4152 so it can be reviewed, released, and backported independently from selective CI.

## Validation

- file-scoped pre-commit hooks passed;
- `git diff --check` passed;
- the repository-wide Ansible lint traversal reached all roles and only failed on the existing `galaxy[no-changelog]` metadata issue;
- Reno parsed the new note and only reported the repository's existing duplicate release-note UID.