### PR TITLE
fix(rook-ceph-cluster): create service scope

### DIFF
--- a/releasenotes/notes/rook-ceph-create-service-scope-067b1fffc0d7e209.yaml
+++ b/releasenotes/notes/rook-ceph-create-service-scope-067b1fffc0d7e209.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
   - |
-    The Rook Ceph cluster role now creates the ``service`` domain and project\n    before configuring the object storage identity.
+    The Rook Ceph cluster role now creates the ``service`` domain and project
+    before configuring the object storage identity.

--- a/releasenotes/notes/rook-ceph-create-service-scope-067b1fffc0d7e209.yaml
+++ b/releasenotes/notes/rook-ceph-create-service-scope-067b1fffc0d7e209.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The Rook Ceph cluster role now creates the ``service`` domain and project\n    before configuring the object storage identity.

--- a/roles/rook_ceph_cluster/tasks/main.yml
+++ b/roles/rook_ceph_cluster/tasks/main.yml
@@ -108,6 +108,19 @@
     kubeconfig: "{{ rook_ceph_cluster_helm_kubeconfig }}"
     values: "{{ _rook_ceph_cluster_helm_values | combine(rook_ceph_cluster_helm_values, recursive=True) }}"
 
+- name: Create OpenStack service domain
+  run_once: true
+  vexxhost.atmosphere.identity_domain:
+    name: service
+
+- name: Create OpenStack service project
+  run_once: true
+  changed_when: false
+  ansible.builtin.command:
+    cmd: openstack project create --or-show --enable --domain service service
+  environment:
+    OS_CLOUD: atmosphere
+
 - name: Create OpenStack user
   openstack.cloud.identity_user:
     cloud: atmosphere


### PR DESCRIPTION
## What changed

- create the OpenStack `service` domain;
- create or reuse the `service` project before configuring the object storage user;
- add a release note.

## Why

The Rook Ceph cluster role assumed Keystone or another service had already created this identity scope. Focused deployments exposed that hidden ordering dependency.

This production fix is extracted from #4152 so it can be reviewed, released, and backported independently from selective CI. A separate SDK cleanup will follow after this prerequisite merges.

## Validation

- file-scoped pre-commit hooks passed;
- `git diff --check` passed;
- the repository-wide Ansible lint traversal reached all roles and only failed on the existing `galaxy[no-changelog]` metadata issue;
- Reno parsed the new note and only reported the repository's existing duplicate release-note UID.