### PR TITLE
feat(keycloak): make Helm timeout configurable

### DIFF
--- a/releasenotes/notes/keycloak-configurable-helm-timeout-c42f4fcbff6cb47c.yaml
+++ b/releasenotes/notes/keycloak-configurable-helm-timeout-c42f4fcbff6cb47c.yaml
@@ -1,4 +1,5 @@
 ---
 features:
   - |
-    The Keycloak role now exposes ``keycloak_helm_timeout`` to configure how\n    long Helm operations may run.
+    The Keycloak role now exposes ``keycloak_helm_timeout`` to configure how
+    long Helm operations may run.

--- a/releasenotes/notes/keycloak-configurable-helm-timeout-c42f4fcbff6cb47c.yaml
+++ b/releasenotes/notes/keycloak-configurable-helm-timeout-c42f4fcbff6cb47c.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The Keycloak role now exposes ``keycloak_helm_timeout`` to configure how\n    long Helm operations may run.

--- a/roles/keycloak/README.md
+++ b/roles/keycloak/README.md
@@ -1,1 +1,11 @@
 # `keycloak`
+
+## Configuration
+
+`keycloak_helm_timeout` sets the maximum time allowed for Keycloak Helm
+operations. It accepts a Go duration string such as `15m0s` and defaults to
+`10m0s`.
+
+```yaml
+keycloak_helm_timeout: 15m0s
+```

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -20,6 +20,11 @@ keycloak_helm_release_namespace: auth-system
 keycloak_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
 keycloak_helm_values: {}
 
+# Time to wait for Helm operations to complete, using Go duration syntax.
+#
+# keycloak_helm_timeout: 15m0s
+keycloak_helm_timeout: 10m0s
+
 keycloak_host: "{{ undef('You must specify a Keycloak host using keycloak_host') }}"
 keycloak_ingress_annotations: {}
 keycloak_ingress_class_name: "{{ atmosphere_ingress_class_name }}"

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -77,7 +77,7 @@
     create_namespace: true
     kubeconfig: "{{ keycloak_helm_kubeconfig }}"
     wait: true
-    timeout: 10m
+    timeout: "{{ keycloak_helm_timeout }}"
     values: "{{ _keycloak_helm_values | combine(keycloak_helm_values, recursive=True) }}"
 
 - name: Wait until keycloak ready


### PR DESCRIPTION
## What changed

- add `keycloak_helm_timeout` with the existing ten-minute behavior as its default;
- use it for Keycloak Helm operations;
- add a release note.

## Why

The hard-coded timeout could not be adjusted for slower database migrations or environments without editing the role.

This production improvement is extracted from #4152 so it can be reviewed, released, and backported independently from selective CI.

## Validation

- file-scoped pre-commit hooks passed;
- `git diff --check` passed;
- the repository-wide Ansible lint traversal reached all roles and only failed on the existing `galaxy[no-changelog]` metadata issue;
- Reno parsed the new note and only reported the repository's existing duplicate release-note UID.