### PR TITLE
feat(nova): make Helm timeout configurable

### DIFF
--- a/releasenotes/notes/nova-configurable-helm-timeout-ebfe1ae35205caa1.yaml
+++ b/releasenotes/notes/nova-configurable-helm-timeout-ebfe1ae35205caa1.yaml
@@ -1,4 +1,5 @@
 ---
 features:
   - |
-    The Nova role now exposes ``nova_helm_timeout`` to configure how long Helm\n    operations may run.
+    The Nova role now exposes ``nova_helm_timeout`` to configure how long Helm
+    operations may run.

--- a/releasenotes/notes/nova-configurable-helm-timeout-ebfe1ae35205caa1.yaml
+++ b/releasenotes/notes/nova-configurable-helm-timeout-ebfe1ae35205caa1.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The Nova role now exposes ``nova_helm_timeout`` to configure how long Helm\n    operations may run.

--- a/roles/nova/README.md
+++ b/roles/nova/README.md
@@ -1,1 +1,10 @@
 # `nova`
+
+## Configuration
+
+`nova_helm_timeout` sets the maximum time allowed for Nova Helm operations. It
+accepts a Go duration string such as `10m0s` and defaults to `5m0s`.
+
+```yaml
+nova_helm_timeout: 10m0s
+```

--- a/roles/nova/defaults/main.yml
+++ b/roles/nova/defaults/main.yml
@@ -20,6 +20,11 @@ nova_helm_release_namespace: openstack
 nova_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
 nova_helm_values: {}
 
+# Time to wait for Helm operations to complete, using Go duration syntax.
+#
+# nova_helm_timeout: 10m0s
+nova_helm_timeout: 5m0s
+
 # Private SSH key used for cold & live migration
 nova_ssh_key: "{{ undef(hint='You must specifiy an SSH key for Nova.') }}"
 

--- a/roles/nova/tasks/main.yml
+++ b/roles/nova/tasks/main.yml
@@ -53,6 +53,7 @@
     create_namespace: true
     kubeconfig: "{{ nova_helm_kubeconfig }}"
     values: "{{ _nova_helm_values | combine(nova_helm_values, recursive=True) }}"
+    timeout: "{{ nova_helm_timeout }}"
 
 - name: Create Ingress
   ansible.builtin.include_role:


### PR DESCRIPTION
## What changed

- add `nova_helm_timeout` with a five-minute default;
- use it for Nova Helm operations;
- add a release note.

## Why

Nova database migrations can need more time, but the role offered no supported way to extend the Helm operation timeout.

This production improvement is extracted from #4152 so it can be reviewed, released, and backported independently from selective CI.

## Validation

- file-scoped pre-commit hooks passed;
- `git diff --check` passed;
- the repository-wide Ansible lint traversal reached all roles and only failed on the existing `galaxy[no-changelog]` metadata issue;
- Reno parsed the new note and only reported the repository's existing duplicate release-note UID.