### PR TITLE
feat(neutron): make Helm timeout configurable

### DIFF
--- a/doc/source/deploy/neutron.rst
+++ b/doc/source/deploy/neutron.rst
@@ -7,6 +7,18 @@ configurations to optimize and tailor network performance. This includes
 integrating hardware acceleration technologies to enhance networking
 capabilities within your OpenStack environment.
 
+**********************
+Helm Operation Timeout
+**********************
+
+``neutron_helm_timeout`` sets the maximum time allowed for Neutron Helm
+operations. It accepts a Go duration string such as ``10m0s`` and defaults to
+``5m0s``.
+
+.. code-block:: yaml
+
+    neutron_helm_timeout: 10m0s
+
 *********************
 Hardware Acceleration
 *********************

--- a/releasenotes/notes/neutron-configurable-helm-timeout-dc245fe474face06.yaml
+++ b/releasenotes/notes/neutron-configurable-helm-timeout-dc245fe474face06.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The Neutron role now exposes ``neutron_helm_timeout`` to configure how long\n    Helm operations may run.

--- a/releasenotes/notes/neutron-configurable-helm-timeout-dc245fe474face06.yaml
+++ b/releasenotes/notes/neutron-configurable-helm-timeout-dc245fe474face06.yaml
@@ -1,4 +1,5 @@
 ---
 features:
   - |
-    The Neutron role now exposes ``neutron_helm_timeout`` to configure how long\n    Helm operations may run.
+    The Neutron role now exposes ``neutron_helm_timeout`` to configure how long
+    Helm operations may run.

--- a/roles/neutron/defaults/main.yml
+++ b/roles/neutron/defaults/main.yml
@@ -20,6 +20,11 @@ neutron_helm_release_namespace: openstack
 neutron_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
 neutron_helm_values: {}
 
+# Time to wait for Helm operations to complete, using Go duration syntax.
+#
+# neutron_helm_timeout: 10m0s
+neutron_helm_timeout: 5m0s
+
 # List of networks to provision inside OpenStack
 neutron_networks: []
 

--- a/roles/neutron/tasks/main.yml
+++ b/roles/neutron/tasks/main.yml
@@ -64,6 +64,7 @@
     release_namespace: "{{ neutron_helm_release_namespace }}"
     create_namespace: true
     kubeconfig: "{{ neutron_helm_kubeconfig }}"
+    timeout: "{{ neutron_helm_timeout }}"
     values: "{{ _neutron_helm_values | combine(neutron_helm_values, recursive=True) }}"
 
 - name: Create Ingress


### PR DESCRIPTION
## What changed

- add `neutron_helm_timeout` with a five-minute default;
- use it for Neutron Helm operations;
- add a release note.

## Why

Deployments that need more time had no supported way to extend the Helm operation timeout.

This production improvement is extracted from #4152 so it can be reviewed, released, and backported independently from selective CI.

## Validation

- file-scoped pre-commit hooks passed;
- `git diff --check` passed;
- the repository-wide Ansible lint traversal reached all roles and only failed on the existing `galaxy[no-changelog]` metadata issue;
- Reno parsed the new note and only reported the repository's existing duplicate release-note UID.