### PR TITLE
feat(octavia): make Helm timeout configurable

### DIFF
--- a/releasenotes/notes/octavia-configurable-helm-timeout-2cb8dd73c3849e28.yaml
+++ b/releasenotes/notes/octavia-configurable-helm-timeout-2cb8dd73c3849e28.yaml
@@ -1,4 +1,5 @@
 ---
 features:
   - |
-    The Octavia role now exposes ``octavia_helm_timeout`` to configure how long\n    Helm operations may run.
+    The Octavia role now exposes ``octavia_helm_timeout`` to configure how long
+    Helm operations may run.

--- a/releasenotes/notes/octavia-configurable-helm-timeout-2cb8dd73c3849e28.yaml
+++ b/releasenotes/notes/octavia-configurable-helm-timeout-2cb8dd73c3849e28.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The Octavia role now exposes ``octavia_helm_timeout`` to configure how long\n    Helm operations may run.

--- a/roles/octavia/README.md
+++ b/roles/octavia/README.md
@@ -1,1 +1,11 @@
 # `octavia`
+
+## Configuration
+
+`octavia_helm_timeout` sets the maximum time allowed for Octavia Helm
+operations. It accepts a Go duration string such as `10m0s` and defaults to
+`5m0s`.
+
+```yaml
+octavia_helm_timeout: 10m0s
+```

--- a/roles/octavia/defaults/main.yml
+++ b/roles/octavia/defaults/main.yml
@@ -20,6 +20,11 @@ octavia_helm_release_namespace: openstack
 octavia_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
 octavia_helm_values: {}
 
+# Time to wait for Helm operations to complete, using Go duration syntax.
+#
+# octavia_helm_timeout: 10m0s
+octavia_helm_timeout: 5m0s
+
 # Class name to use for the Ingress
 octavia_ingress_class_name: "{{ atmosphere_ingress_class_name }}"
 

--- a/roles/octavia/tasks/main.yml
+++ b/roles/octavia/tasks/main.yml
@@ -104,6 +104,7 @@
     release_namespace: "{{ octavia_helm_release_namespace }}"
     create_namespace: true
     kubeconfig: "{{ octavia_helm_kubeconfig }}"
+    timeout: "{{ octavia_helm_timeout }}"
     values: "{{ _octavia_helm_values | combine(octavia_helm_values, recursive=True) }}"
 
 - name: Add implied roles


### PR DESCRIPTION
## What changed

- add `octavia_helm_timeout` with a five-minute default;
- use it for Octavia Helm operations;
- add a release note.

## Why

Deployments that need more time had no supported way to extend the Helm operation timeout.

This production improvement is extracted from #4152 so it can be reviewed, released, and backported independently from selective CI.

## Validation

- file-scoped pre-commit hooks passed;
- `git diff --check` passed;
- the repository-wide Ansible lint traversal reached all roles and only failed on the existing `galaxy[no-changelog]` metadata issue;
- Reno parsed the new note and only reported the repository's existing duplicate release-note UID.