### PR TITLE
feat(manila): make Helm timeout configurable

### DIFF
--- a/releasenotes/notes/manila-configurable-helm-timeout-6528c9851cfbb767.yaml
+++ b/releasenotes/notes/manila-configurable-helm-timeout-6528c9851cfbb767.yaml
@@ -1,4 +1,5 @@
 ---
 features:
   - |
-    The Manila role now exposes ``manila_helm_timeout`` to configure how long\n    Helm operations may run.
+    The Manila role now exposes ``manila_helm_timeout`` to configure how long
+    Helm operations may run.

--- a/releasenotes/notes/manila-configurable-helm-timeout-6528c9851cfbb767.yaml
+++ b/releasenotes/notes/manila-configurable-helm-timeout-6528c9851cfbb767.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The Manila role now exposes ``manila_helm_timeout`` to configure how long\n    Helm operations may run.

--- a/roles/manila/README.md
+++ b/roles/manila/README.md
@@ -1,1 +1,10 @@
 # `manila`
+
+## Configuration
+
+`manila_helm_timeout` sets the maximum time allowed for Manila Helm operations.
+It accepts a Go duration string such as `10m0s` and defaults to `5m0s`.
+
+```yaml
+manila_helm_timeout: 10m0s
+```

--- a/roles/manila/defaults/main.yml
+++ b/roles/manila/defaults/main.yml
@@ -20,6 +20,11 @@ manila_helm_release_namespace: openstack
 manila_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
 manila_helm_values: {}
 
+# Maximum time allowed for Manila Helm operations.
+#
+# manila_helm_timeout: 10m0s
+manila_helm_timeout: 5m0s
+
 # Class name to use for the Ingress
 manila_ingress_class_name: "{{ atmosphere_ingress_class_name }}"
 

--- a/roles/manila/tasks/main.yml
+++ b/roles/manila/tasks/main.yml
@@ -29,6 +29,7 @@
     create_namespace: true
     kubeconfig: "{{ manila_helm_kubeconfig }}"
     values: "{{ _manila_helm_values | combine(manila_helm_values, recursive=True) }}"
+    timeout: "{{ manila_helm_timeout }}"
 
 - name: Create Ingress
   ansible.builtin.include_role:


### PR DESCRIPTION
## What changed

- add `manila_helm_timeout` with a five-minute default;
- use it for Manila Helm operations;
- add a release note.

## Why

Manila chart deployment can need more time, but the role offered no supported way to extend the Helm operation timeout.

This production improvement is extracted from #4152 so it can be reviewed, released, and backported independently from selective CI.

## Validation

- file-scoped pre-commit hooks passed;
- `git diff --check` passed;
- the repository-wide Ansible lint traversal reached all roles and only failed on the existing `galaxy[no-changelog]` metadata issue;
- Reno parsed the new note and only reported the repository's existing duplicate release-note UID.