### PR TITLE
[Backport stable/2023.1] feat(neutron): make Helm timeout configurable

### DIFF
--- a/doc/source/deploy/neutron.rst
+++ b/doc/source/deploy/neutron.rst
@@ -7,6 +7,18 @@ configurations to optimize and tailor network performance. This includes
 integrating hardware acceleration technologies to enhance networking
 capabilities within your OpenStack environment.
 
+**********************
+Helm Operation Timeout
+**********************
+
+``neutron_helm_timeout`` sets the maximum time allowed for Neutron Helm
+operations. It accepts a Go duration string such as ``10m0s`` and defaults to
+``5m0s``.
+
+.. code-block:: yaml
+
+    neutron_helm_timeout: 10m0s
+
 *********************
 Hardware Acceleration
 *********************

--- a/releasenotes/notes/neutron-configurable-helm-timeout-dc245fe474face06.yaml
+++ b/releasenotes/notes/neutron-configurable-helm-timeout-dc245fe474face06.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The Neutron role now exposes ``neutron_helm_timeout`` to configure how long
+    Helm operations may run.

--- a/roles/neutron/defaults/main.yml
+++ b/roles/neutron/defaults/main.yml
@@ -19,6 +19,11 @@ neutron_helm_chart_ref: /usr/local/src/neutron
 neutron_helm_release_namespace: openstack
 neutron_helm_values: {}
 
+# Time to wait for Helm operations to complete, using Go duration syntax.
+#
+# neutron_helm_timeout: 10m0s
+neutron_helm_timeout: 5m0s
+
 # List of networks to provision inside OpenStack
 neutron_networks: []
 

--- a/roles/neutron/tasks/main.yml
+++ b/roles/neutron/tasks/main.yml
@@ -64,6 +64,7 @@
     release_namespace: "{{ neutron_helm_release_namespace }}"
     create_namespace: true
     kubeconfig: /etc/kubernetes/admin.conf
+    timeout: "{{ neutron_helm_timeout }}"
     values: "{{ _neutron_helm_values | combine(neutron_helm_values, recursive=True) }}"
 
 - name: Create Ingress


### PR DESCRIPTION
# Description
Backport of #4250 to `stable/2023.1`.