### PR TITLE
[Backport stable/zed] feat(octavia): make Helm timeout configurable

### DIFF
--- a/releasenotes/notes/octavia-configurable-helm-timeout-2cb8dd73c3849e28.yaml
+++ b/releasenotes/notes/octavia-configurable-helm-timeout-2cb8dd73c3849e28.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The Octavia role now exposes ``octavia_helm_timeout`` to configure how long
+    Helm operations may run.

--- a/roles/octavia/README.md
+++ b/roles/octavia/README.md
@@ -1,1 +1,11 @@
 # `octavia`
+
+## Configuration
+
+`octavia_helm_timeout` sets the maximum time allowed for Octavia Helm
+operations. It accepts a Go duration string such as `10m0s` and defaults to
+`5m0s`.
+
+```yaml
+octavia_helm_timeout: 10m0s
+```

--- a/roles/octavia/defaults/main.yml
+++ b/roles/octavia/defaults/main.yml
@@ -19,6 +19,11 @@ octavia_helm_chart_ref: /usr/local/src/octavia
 octavia_helm_release_namespace: openstack
 octavia_helm_values: {}
 
+# Time to wait for Helm operations to complete, using Go duration syntax.
+#
+# octavia_helm_timeout: 10m0s
+octavia_helm_timeout: 5m0s
+
 # List of annotations to apply to the Ingress
 octavia_ingress_annotations: {}
 

--- a/roles/octavia/tasks/main.yml
+++ b/roles/octavia/tasks/main.yml
@@ -132,6 +132,7 @@
     release_namespace: "{{ octavia_helm_release_namespace }}"
     create_namespace: true
     kubeconfig: /etc/kubernetes/admin.conf
+    timeout: "{{ octavia_helm_timeout }}"
     values: "{{ _octavia_helm_values | combine(octavia_helm_values, recursive=True) }}"
 
 - name: Add implied roles


### PR DESCRIPTION
# Description
Backport of #4251 to `stable/zed`.