### PR TITLE
fix(rook-ceph-cluster): manage identity with SDK

### DIFF
--- a/releasenotes/notes/rook-ceph-sdk-role-assignment-87e44518a8f73e7c.yaml
+++ b/releasenotes/notes/rook-ceph-sdk-role-assignment-87e44518a8f73e7c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The Rook Ceph cluster role now manages object storage identity assignments
+    through the OpenStack API, making repeated deployments idempotent.

--- a/roles/rook_ceph_cluster/tasks/main.yml
+++ b/roles/rook_ceph_cluster/tasks/main.yml
@@ -115,11 +115,12 @@
 
 - name: Create OpenStack service project
   run_once: true
-  changed_when: false
-  ansible.builtin.command:
-    cmd: openstack project create --or-show --enable --domain service service
-  environment:
-    OS_CLOUD: atmosphere
+  openstack.cloud.project:
+    cloud: atmosphere
+    name: service
+    domain: service
+    enabled: true
+    state: present
 
 - name: Create OpenStack user
   openstack.cloud.identity_user:
@@ -130,16 +131,13 @@
 
 # NOTE(mnaser): https://storyboard.openstack.org/#!/story/2010579
 - name: Grant access to "service" project
-  changed_when: false
-  ansible.builtin.command:
-    cmd: >-
-      openstack role add
-      --user-domain service
-      --project service
-      --user {{ openstack_helm_endpoints.identity.auth.rgw.username }}
-      admin
-  environment:
-    OS_CLOUD: atmosphere
+  openstack.cloud.role_assignment:
+    cloud: atmosphere
+    user: "{{ openstack_helm_endpoints.identity.auth.rgw.username }}"
+    user_domain: service
+    role: admin
+    project: service
+    project_domain: service
 
 - name: Create OpenStack service
   openstack.cloud.catalog_service:

--- a/roles/rook_ceph_cluster/tasks/main.yml
+++ b/roles/rook_ceph_cluster/tasks/main.yml
@@ -134,10 +134,9 @@
   openstack.cloud.role_assignment:
     cloud: atmosphere
     user: "{{ openstack_helm_endpoints.identity.auth.rgw.username }}"
-    user_domain: service
     role: admin
     project: service
-    project_domain: service
+    domain: service
 
 - name: Create OpenStack service
   openstack.cloud.catalog_service:


### PR DESCRIPTION
## What changed

- replace shell-based service project creation with the OpenStack SDK project module;
- replace shell-based role assignment with the OpenStack SDK role-assignment module;
- use the shared service-domain lookup supported by the minimum openstack.cloud 2.0.0 requirement;
- add a concise release note.

## Why

The shell commands always reported no change and made repeated deployments less observable. The SDK modules provide idempotent state management and explicit domain selection.

This is the final production runtime concern extracted from #4152, as requested in review pullrequestreview-4900414469. It follows the service-scope prerequisite merged in #4247.

## Validation

- file hygiene hooks passed;
- Ansible syntax validation reached the Rook Ceph cluster role successfully and reported only the existing repository-wide galaxy no-changelog metadata finding;
- the module arguments were checked against the official openstack.cloud 2.0.0 source required by galaxy.yml;
- git diff --check passed;
- both commits carry the required DCO sign-off.

Depends-On: https://github.com/vexxhost/ansible-collection-ceph/pull/124
