### PR TITLE
feat(monitoring): deploy Ironic Prometheus exporter

### DIFF
--- a/charts/ironic/templates/statefulset-conductor.yaml
+++ b/charts/ironic/templates/statefulset-conductor.yaml
@@ -253,6 +253,9 @@ spec:
               mountPath: /var/lib/openstack-helm
 {{ if $mounts_ironic_conductor.volumeMounts }}{{ toYaml $mounts_ironic_conductor.volumeMounts | indent 12 }}{{ end }}
 {{- end }}
+        {{- with .Values.conductor.extraContainers }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
       volumes:
         - name: pod-tmp
           emptyDir: {}

--- a/charts/ironic/values.yaml
+++ b/charts/ironic/values.yaml
@@ -208,6 +208,9 @@ conf:
       datefmt: "%Y-%m-%d %H:%M:%S"
 
 conductor:
+  # -- Additional containers to add to the conductor pods
+  ## Note: Supports use of custom Helm templates
+  extraContainers: []
   http:
     enabled: true
     init_script: |

--- a/charts/patches/ironic/0002-allow-extra-containers-for-conductor.patch
+++ b/charts/patches/ironic/0002-allow-extra-containers-for-conductor.patch
@@ -1,0 +1,28 @@
+diff --git a/ironic/templates/statefulset-conductor.yaml b/ironic/templates/statefulset-conductor.yaml
+index 920d4afc1..f4d29b248 100644
+--- a/ironic/templates/statefulset-conductor.yaml
++++ b/ironic/templates/statefulset-conductor.yaml
+@@ -253,6 +253,9 @@ spec:
+               mountPath: /var/lib/openstack-helm
+ {{ if $mounts_ironic_conductor.volumeMounts }}{{ toYaml $mounts_ironic_conductor.volumeMounts | indent 12 }}{{ end }}
+ {{- end }}
++        {{- with .Values.conductor.extraContainers }}
++        {{- tpl (toYaml .) $ | nindent 8 }}
++        {{- end }}
+       volumes:
+         - name: pod-tmp
+           emptyDir: {}
+diff --git a/ironic/values.yaml b/ironic/values.yaml
+index 2228bfc34..5a6e16483 100644
+--- a/ironic/values.yaml
++++ b/ironic/values.yaml
+@@ -208,6 +208,9 @@ conf:
+       datefmt: "%Y-%m-%d %H:%M:%S"
+ 
+ conductor:
++  # -- Additional containers to add to the conductor pods
++  ## Note: Supports use of custom Helm templates
++  extraContainers: []
+   http:
+     enabled: true
+     init_script: |

--- a/releasenotes/notes/add-ironic-hardware-sensor-monitoring-f7584f0c5cd2bf8e.yaml
+++ b/releasenotes/notes/add-ironic-hardware-sensor-monitoring-f7584f0c5cd2bf8e.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    Ironic hardware sensor metrics can now be collected with the upstream
+    Ironic Prometheus Exporter by setting
+    ``ironic_prometheus_exporter_enabled``. Atmosphere injects the exporter
+    through ``conductor.extraContainers`` and shares its metrics directory
+    through the generic conductor mount hooks without replacing existing
+    list entries. The ``PodMonitor``, dashboards, and alerts are disabled by
+    default and gated by ``atmosphere_ironic_enabled``. Active-node alerting
+    additionally requires ``openstack_exporter_baremetal_enabled``. The
+    exporter uses the same Ironic runtime image as the conductor, which
+    supplies the notification driver, HTTP application, and uWSGI.

--- a/roles/ironic/README.md
+++ b/roles/ironic/README.md
@@ -12,3 +12,39 @@ atmosphere_ironic_enabled: true
 
 The playbook condition uses `default(false)`, so inventories that do not define
 the variable retain the existing deployment behavior.
+
+## Hardware sensor metrics
+
+Hardware sensor collection is separately disabled by default. Enable it only
+when the selected Ironic runtime image includes upstream
+`ironic-prometheus-exporter` and uWSGI:
+
+```yaml
+atmosphere_ironic_enabled: true
+ironic_prometheus_exporter_enabled: true
+ironic_prometheus_exporter_sensor_interval: 600
+ironic_prometheus_exporter_collect_undeployed_nodes: false
+```
+
+The role appends the `prometheus_exporter` notification driver to any existing
+string, list, or Helm toolkit `multistring` driver configuration. It does not
+replace existing drivers or their notification transport. Each conductor pod
+runs an exporter through the chart's generic `conductor.extraContainers` hook
+and shares a pod-local metrics directory through the generic conductor mount
+hooks. Existing extra containers, volume mounts, and volumes are retained.
+The names `ironic-prometheus-exporter` and `ironic-prometheus-metrics`, and the
+mount path `/var/lib/ironic/metrics`, are reserved while the integration is
+enabled so conflicting definitions fail before Helm runs.
+
+The exporter reuses the exact image selected for `ironic_conductor`; that image
+must provide the notification driver, HTTP application, and uWSGI. Resource
+requests and limits can be adjusted with
+`ironic_prometheus_exporter_resources`. The generic upstream example is
+proposed in
+[`openstack/openstack-helm` change 1002515](https://review.opendev.org/c/openstack/openstack-helm/+/1002515).
+
+Active-node-only sensor alerts also require lifecycle collection:
+
+```yaml
+openstack_exporter_baremetal_enabled: true
+```

--- a/roles/ironic/defaults/main.yml
+++ b/roles/ironic/defaults/main.yml
@@ -20,6 +20,21 @@ ironic_helm_release_namespace: openstack
 ironic_helm_kubeconfig: "{{ kubeconfig_path | default('/etc/kubernetes/admin.conf') }}"
 ironic_helm_values: {}
 
+# Hardware sensor metrics
+ironic_prometheus_exporter_enabled: false
+ironic_prometheus_exporter_port: 9608
+ironic_prometheus_exporter_workers: 1
+ironic_prometheus_exporter_sensor_interval: 600
+ironic_prometheus_exporter_collect_undeployed_nodes: false
+ironic_prometheus_exporter_image_pull_policy: IfNotPresent
+ironic_prometheus_exporter_resources:
+  requests:
+    memory: 64Mi
+    cpu: 50m
+  limits:
+    memory: 256Mi
+    cpu: 500m
+
 # Class name to use for the Ingress
 ironic_ingress_class_name: "{{ atmosphere_ingress_class_name }}"
 

--- a/roles/ironic/tasks/main.yml
+++ b/roles/ironic/tasks/main.yml
@@ -12,6 +12,20 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Validate Ironic Prometheus exporter service gate
+  ansible.builtin.assert:
+    that:
+      - atmosphere_ironic_enabled | default(false) | bool
+      - ironic_prometheus_exporter_port | int > 0
+      - ironic_prometheus_exporter_port | int < 65536
+      - ironic_prometheus_exporter_workers | int > 0
+      - ironic_prometheus_exporter_sensor_interval | int >= 60
+    fail_msg: >-
+      Ironic Prometheus exporter requires atmosphere_ironic_enabled=true,
+      a valid TCP port, at least one worker, and a sensor interval of at
+      least 60 seconds.
+  when: ironic_prometheus_exporter_enabled | bool
+
 - name: Create bare metal network
   when: ironic_bare_metal_network_manage | bool
   ansible.builtin.import_tasks: network/create.yml
@@ -76,6 +90,263 @@
     image: "{{ ironic_python_agent_deploy_ramdisk_name }}"
   register: ironic_python_agent_deploy_ramdisk
 
+- name: Build base Ironic Helm values
+  ansible.builtin.set_fact:
+    _ironic_effective_helm_values: >-
+      {{ _ironic_helm_values | combine(ironic_helm_values, recursive=True) }}
+
+- name: Read existing Ironic exporter Helm values
+  ansible.builtin.set_fact:
+    _ironic_notification_driver: >-
+      {{
+        _ironic_effective_helm_values
+        .get('conf', {})
+        .get('ironic', {})
+        .get('oslo_messaging_notifications', {})
+        .get('driver', [])
+      }}
+    _ironic_conductor_extra_containers: >-
+      {{
+        _ironic_effective_helm_values
+        .get('conductor', {})
+        .get('extraContainers', [])
+        | default([], true)
+      }}
+    _ironic_conductor_volume_mounts: >-
+      {{
+        _ironic_effective_helm_values
+        .get('pod', {})
+        .get('mounts', {})
+        .get('ironic_conductor', {})
+        .get('ironic_conductor', {})
+        .get('volumeMounts', [])
+        | default([], true)
+      }}
+    _ironic_conductor_volumes: >-
+      {{
+        _ironic_effective_helm_values
+        .get('pod', {})
+        .get('mounts', {})
+        .get('ironic_conductor', {})
+        .get('ironic_conductor', {})
+        .get('volumes', [])
+        | default([], true)
+      }}
+  when: ironic_prometheus_exporter_enabled | bool
+
+- name: Validate existing Ironic exporter Helm values
+  ansible.builtin.assert:
+    that:
+      - >-
+        _ironic_conductor_extra_containers is sequence
+        and _ironic_conductor_extra_containers is not string
+        and _ironic_conductor_extra_containers is not mapping
+      - >-
+        _ironic_conductor_volume_mounts is sequence
+        and _ironic_conductor_volume_mounts is not string
+        and _ironic_conductor_volume_mounts is not mapping
+      - >-
+        _ironic_conductor_volumes is sequence
+        and _ironic_conductor_volumes is not string
+        and _ironic_conductor_volumes is not mapping
+      - >-
+        (_ironic_conductor_extra_containers | select('mapping') | list | length)
+        == (_ironic_conductor_extra_containers | length)
+      - >-
+        (_ironic_conductor_volume_mounts | select('mapping') | list | length)
+        == (_ironic_conductor_volume_mounts | length)
+      - >-
+        (_ironic_conductor_volumes | select('mapping') | list | length)
+        == (_ironic_conductor_volumes | length)
+      - >-
+        'ironic-prometheus-exporter' not in
+        (_ironic_conductor_extra_containers
+         | map(attribute='name', default='') | list)
+      - >-
+        'ironic-prometheus-metrics' not in
+        (_ironic_conductor_volume_mounts
+         | map(attribute='name', default='') | list)
+      - >-
+        '/var/lib/ironic/metrics' not in
+        (_ironic_conductor_volume_mounts
+         | map(attribute='mountPath', default='') | list)
+      - >-
+        'ironic-prometheus-metrics' not in
+        (_ironic_conductor_volumes
+         | map(attribute='name', default='') | list)
+      - ironic_prometheus_exporter_resources is mapping
+      - >-
+        _ironic_effective_helm_values
+        .get('images', {})
+        .get('tags', {})
+        .get('ironic_conductor', '') | length > 0
+    fail_msg: >-
+      Ironic exporter integration requires list-valued extraContainers,
+      conductor volumeMounts, and conductor volumes; mapping entries; an
+      ironic_conductor image; and no pre-existing objects that use the
+      reserved ironic-prometheus-exporter or ironic-prometheus-metrics names.
+  when: ironic_prometheus_exporter_enabled | bool
+
+- name: Validate existing Ironic notification driver format
+  ansible.builtin.assert:
+    that:
+      - >-
+        _ironic_notification_driver is string
+        or (_ironic_notification_driver is sequence
+            and _ironic_notification_driver is not string
+            and _ironic_notification_driver is not mapping)
+        or (_ironic_notification_driver is mapping
+            and _ironic_notification_driver.get('type', '') == 'multistring'
+            and _ironic_notification_driver.get('values', []) is sequence
+            and _ironic_notification_driver.get('values', []) is not string
+            and _ironic_notification_driver.get('values', []) is not mapping)
+    fail_msg: >-
+      Ironic notification drivers must be a string, a list, or a Helm toolkit
+      multistring mapping before prometheus_exporter can be appended.
+  when: ironic_prometheus_exporter_enabled | bool
+
+- name: Normalize existing Ironic notification drivers
+  ansible.builtin.set_fact:
+    _ironic_notification_drivers: >-
+      {{
+        [_ironic_notification_driver]
+        if _ironic_notification_driver is string
+        else (_ironic_notification_driver.get('values', [])
+              if _ironic_notification_driver is mapping
+              else _ironic_notification_driver)
+      }}
+  when: ironic_prometheus_exporter_enabled | bool
+
+- name: Add Ironic Prometheus exporter Helm values
+  ansible.builtin.set_fact:
+    _ironic_effective_helm_values: >-
+      {{
+        _ironic_effective_helm_values
+        | combine(
+            {
+              'conf': {
+                'ironic': {
+                  'metrics': {'backend': 'collector'},
+                  'oslo_messaging_notifications': {
+                    'driver': {
+                      'type': 'multistring',
+                      'values': (
+                        _ironic_notification_drivers
+                        | reject('equalto', 'prometheus_exporter')
+                        | list
+                      ) + ['prometheus_exporter'],
+                    },
+                    'location': '/var/lib/ironic/metrics',
+                  },
+                  'sensor_data': {
+                    'enable_for_undeployed_nodes': (
+                      ironic_prometheus_exporter_collect_undeployed_nodes
+                      | bool
+                    ),
+                    'interval': ironic_prometheus_exporter_sensor_interval,
+                    'send_sensor_data': true,
+                  },
+                },
+              },
+              'conductor': {
+                'extraContainers': _ironic_conductor_extra_containers + [
+                  {
+                    'name': 'ironic-prometheus-exporter',
+                    'image': (
+                      _ironic_effective_helm_values
+                      .get('images', {})
+                      .get('tags', {})
+                      .get('ironic_conductor')
+                    ),
+                    'imagePullPolicy': (
+                      ironic_prometheus_exporter_image_pull_policy
+                    ),
+                    'command': ['uwsgi'],
+                    'args': [
+                      '--http-socket',
+                      '0.0.0.0:'
+                      ~ (ironic_prometheus_exporter_port | string),
+                      '--processes',
+                      ironic_prometheus_exporter_workers | string,
+                      '--master',
+                      '--die-on-term',
+                      '--need-app',
+                      '--module',
+                      'ironic_prometheus_exporter.app.wsgi:application',
+                    ],
+                    'env': [
+                      {
+                        'name': 'IRONIC_CONFIG',
+                        'value': '/etc/ironic/ironic.conf',
+                      },
+                    ],
+                    'ports': [
+                      {
+                        'name': 'metrics',
+                        'containerPort': (
+                          ironic_prometheus_exporter_port | int
+                        ),
+                        'protocol': 'TCP',
+                      },
+                    ],
+                    'livenessProbe': {
+                      'httpGet': {
+                        'path': '/metrics',
+                        'port': 'metrics',
+                      },
+                      'initialDelaySeconds': 10,
+                      'periodSeconds': 30,
+                    },
+                    'readinessProbe': {
+                      'httpGet': {
+                        'path': '/metrics',
+                        'port': 'metrics',
+                      },
+                      'initialDelaySeconds': 5,
+                      'periodSeconds': 10,
+                    },
+                    'resources': ironic_prometheus_exporter_resources,
+                    'volumeMounts': [
+                      {
+                        'name': 'ironic-etc',
+                        'mountPath': '/etc/ironic/ironic.conf',
+                        'subPath': 'ironic.conf',
+                        'readOnly': true,
+                      },
+                      {
+                        'name': 'ironic-prometheus-metrics',
+                        'mountPath': '/var/lib/ironic/metrics',
+                      },
+                    ],
+                  },
+                ],
+              },
+              'pod': {
+                'mounts': {
+                  'ironic_conductor': {
+                    'ironic_conductor': {
+                      'volumeMounts': _ironic_conductor_volume_mounts + [
+                        {
+                          'name': 'ironic-prometheus-metrics',
+                          'mountPath': '/var/lib/ironic/metrics',
+                        },
+                      ],
+                      'volumes': _ironic_conductor_volumes + [
+                        {
+                          'name': 'ironic-prometheus-metrics',
+                          'emptyDir': {},
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+            recursive=True
+          )
+      }}
+  when: ironic_prometheus_exporter_enabled | bool
+
 - name: Deploy Helm chart
   run_once: true
   kubernetes.core.helm:
@@ -84,7 +355,7 @@
     release_namespace: "{{ ironic_helm_release_namespace }}"
     create_namespace: true
     kubeconfig: "{{ ironic_helm_kubeconfig }}"
-    values: "{{ _ironic_helm_values | combine(ironic_helm_values, recursive=True) }}"
+    values: "{{ _ironic_effective_helm_values }}"
 
 - name: Create Ingress
   ansible.builtin.include_role:

--- a/roles/ironic/tests/prometheus_exporter_test.yaml
+++ b/roles/ironic/tests/prometheus_exporter_test.yaml
@@ -1,0 +1,113 @@
+suite: prometheus exporter extra container
+templates:
+  - templates/configmap-bin.yaml
+  - templates/configmap-etc.yaml
+  - templates/statefulset-conductor.yaml
+tests:
+  - it: should not render an exporter without an extra container
+    asserts:
+      - template: templates/statefulset-conductor.yaml
+        documentIndex: 3
+        notContains:
+          path: spec.template.spec.containers
+          content:
+            name: ironic-prometheus-exporter
+      - template: templates/statefulset-conductor.yaml
+        documentIndex: 3
+        notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: ironic-prometheus-metrics
+
+  - it: should append the exporter and preserve other extra containers
+    set:
+      images:
+        tags:
+          ironic_conductor: test.example/ironic:latest
+      conductor:
+        extraContainers:
+          - name: existing-sidecar
+            image: test.example/existing:latest
+          - name: ironic-prometheus-exporter
+            image: "{{ .Values.images.tags.ironic_conductor }}"
+            command:
+              - uwsgi
+            args:
+              - --http-socket
+              - 0.0.0.0:19608
+              - --processes
+              - "2"
+              - --master
+              - --die-on-term
+              - --need-app
+              - --module
+              - ironic_prometheus_exporter.app.wsgi:application
+            ports:
+              - name: metrics
+                containerPort: 19608
+                protocol: TCP
+            volumeMounts:
+              - name: ironic-prometheus-metrics
+                mountPath: /var/lib/ironic/metrics
+      pod:
+        mounts:
+          ironic_conductor:
+            ironic_conductor:
+              volumeMounts:
+                - name: ironic-prometheus-metrics
+                  mountPath: /var/lib/ironic/metrics
+              volumes:
+                - name: ironic-prometheus-metrics
+                  emptyDir: {}
+    asserts:
+      - template: templates/statefulset-conductor.yaml
+        documentIndex: 3
+        contains:
+          path: spec.template.spec.containers
+          any: true
+          content:
+            name: existing-sidecar
+            image: test.example/existing:latest
+      - template: templates/statefulset-conductor.yaml
+        documentIndex: 3
+        contains:
+          path: spec.template.spec.containers
+          any: true
+          content:
+            name: ironic-prometheus-exporter
+            image: test.example/ironic:latest
+            command:
+              - uwsgi
+            args:
+              - --http-socket
+              - 0.0.0.0:19608
+              - --processes
+              - "2"
+              - --master
+              - --die-on-term
+              - --need-app
+              - --module
+              - ironic_prometheus_exporter.app.wsgi:application
+            ports:
+              - name: metrics
+                containerPort: 19608
+                protocol: TCP
+            volumeMounts:
+              - name: ironic-prometheus-metrics
+                mountPath: /var/lib/ironic/metrics
+      - template: templates/statefulset-conductor.yaml
+        documentIndex: 3
+        contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          any: true
+          content:
+            name: ironic-prometheus-metrics
+            mountPath: /var/lib/ironic/metrics
+      - template: templates/statefulset-conductor.yaml
+        documentIndex: 3
+        contains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: ironic-prometheus-metrics
+            emptyDir: {}

--- a/roles/kube_prometheus_stack/files/dashboards/ironic-sensors.json
+++ b/roles/kube_prometheus_stack/files/dashboards/ironic-sensors.json
@@ -1,0 +1,217 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "count(count by (node_uuid) (baremetal_last_payload_timestamp_seconds))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes With Sensor Payloads",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 9,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "time() - baremetal_last_payload_timestamp_seconds",
+          "legendFormat": "{{node_name}} {{node_uuid}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Sensor Payload Age",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "text": "OK"
+                },
+                "1": {
+                  "color": "yellow",
+                  "text": "Warning"
+                },
+                "2": {
+                  "color": "red",
+                  "text": "Critical"
+                }
+              },
+              "type": "value"
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 9,
+        "x": 15,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max({__name__=~\"baremetal_(temperature|power|fan|drive)_status\"})",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Worst Hardware Sensor State",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "expr": "{__name__=~\"baremetal_(temperature|power|fan|drive)_status\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Hardware Sensor Status",
+      "type": "table"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [
+    "openstack",
+    "ironic",
+    "hardware"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "OpenStack Ironic Hardware Sensors",
+  "uid": "openstack-ironic-sensors",
+  "version": 1
+}

--- a/roles/kube_prometheus_stack/files/jsonnet/ironic-sensors.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/ironic-sensors.libsonnet
@@ -1,0 +1,109 @@
+local activeNodes = |||
+  label_replace(
+    openstack_ironic_node{provision_state="active"} == 1,
+    "node_uuid", "$1", "id", "(.+)"
+  )
+|||;
+
+local activeNodesForThirtyMinutes = |||
+  (
+    label_replace(
+      count_over_time(openstack_ironic_node{provision_state="active"}[30m]) >= 20,
+      "node_uuid", "$1", "id", "(.+)"
+    )
+  ) and on (node_uuid) (
+    label_replace(
+      openstack_ironic_node{provision_state="active"} == 1,
+      "node_uuid", "$1", "id", "(.+)"
+    )
+  )
+|||;
+
+local activeSensorStatus(metric, value) =
+  'max by (node_uuid, node_name, instance_uuid, sensor_id) (' + metric + ' == ' + std.toString(value) + ') '
+  + 'and on (node_uuid) (' + activeNodes + ')';
+
+{
+  prometheusRules+:: {
+    groups: [
+      {
+        name: 'ironic-sensor-recording',
+        rules: [
+          {
+            record: 'openstack:ironic_active_sensor_nodes:count',
+            expr: 'count(count by (node_uuid) (baremetal_last_payload_timestamp_seconds) and on (node_uuid) (' + activeNodes + '))',
+          },
+        ],
+      },
+    ],
+  },
+  prometheusAlerts+:: {
+    groups: [
+      {
+        name: 'ironic-sensors',
+        rules: [
+          {
+            alert: 'IronicSensorPayloadStale',
+            expr: '(' + activeNodesForThirtyMinutes + ') unless on (node_uuid) (baremetal_last_payload_timestamp_seconds > time() - 1800)',
+            'for': '10m',
+            labels: { severity: 'P4' },
+            annotations: {
+              summary: 'Active Ironic node sensor payload is stale',
+              description: 'Active Ironic node {{ $labels.name }} ({{ $labels.id }}) has had no fresh hardware sensor payload for at least 30 minutes.',
+            },
+          },
+          {
+            alert: 'IronicActiveNodeTemperatureCritical',
+            expr: activeSensorStatus('baremetal_temperature_status', 2),
+            'for': '5m',
+            labels: { severity: 'P3' },
+            annotations: {
+              summary: 'Active Ironic node temperature is critical',
+              description: 'Temperature sensor {{ $labels.sensor_id }} on active Ironic node {{ $labels.node_name }} ({{ $labels.node_uuid }}) is critical.',
+            },
+          },
+          {
+            alert: 'IronicActiveNodePowerCritical',
+            expr: activeSensorStatus('baremetal_power_status', 2),
+            'for': '5m',
+            labels: { severity: 'P3' },
+            annotations: {
+              summary: 'Active Ironic node power sensor is critical',
+              description: 'Power sensor {{ $labels.sensor_id }} on active Ironic node {{ $labels.node_name }} ({{ $labels.node_uuid }}) is critical.',
+            },
+          },
+          {
+            alert: 'IronicActiveNodeFanCritical',
+            expr: activeSensorStatus('baremetal_fan_status', 2),
+            'for': '5m',
+            labels: { severity: 'P3' },
+            annotations: {
+              summary: 'Active Ironic node fan is critical',
+              description: 'Fan sensor {{ $labels.sensor_id }} on active Ironic node {{ $labels.node_name }} ({{ $labels.node_uuid }}) is critical.',
+            },
+          },
+          {
+            alert: 'IronicActiveNodeDriveCritical',
+            expr: activeSensorStatus('baremetal_drive_status', 2),
+            'for': '5m',
+            labels: { severity: 'P4' },
+            annotations: {
+              summary: 'Active Ironic node drive is critical',
+              description: 'Drive sensor {{ $labels.sensor_id }} on active Ironic node {{ $labels.node_name }} ({{ $labels.node_uuid }}) is critical.',
+            },
+          },
+          {
+            alert: 'IronicActiveNodeHardwareWarning',
+            expr: activeSensorStatus('{__name__=~"baremetal_(temperature|power|fan|drive)_status"}', 1),
+            'for': '15m',
+            labels: { severity: 'P5' },
+            annotations: {
+              summary: 'Active Ironic node hardware sensor reports a warning',
+              description: 'Hardware sensor {{ $labels.sensor_id }} on active Ironic node {{ $labels.node_name }} ({{ $labels.node_uuid }}) has reported a warning for 15 minutes.',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
+++ b/roles/kube_prometheus_stack/files/jsonnet/mixins.libsonnet
@@ -105,6 +105,7 @@ local mixins = {
   coredns: (import 'coredns.libsonnet'),
   geneve: (import 'geneve.libsonnet'),
   ironic: (import 'ironic.libsonnet'),
+  'ironic-sensors': (import 'ironic-sensors.libsonnet'),
   kube: (import 'vendor/github.com/kubernetes-monitoring/kubernetes-mixin/mixin.libsonnet') + {
     _config+:: {
       kubeApiserverSelector: 'job="apiserver"',

--- a/roles/kube_prometheus_stack/files/jsonnet/tests.yml
+++ b/roles/kube_prometheus_stack/files/jsonnet/tests.yml
@@ -97,6 +97,168 @@ tests:
               summary: "Active Ironic node has an unexpected power state"
               description: "Active Ironic node powered-off-node (node-off) has reported power off for more than 15 minutes."
 
+  - interval: 1m
+    input_series:
+      - series: 'openstack_ironic_node{id="node-stale",name="stale-node",provision_state="active",power_state="power on",maintenance="false"}'
+        values: '1x45'
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: IronicSensorPayloadStale
+        exp_alerts:
+          - exp_labels:
+              id: node-stale
+              name: stale-node
+              provision_state: active
+              power_state: power on
+              maintenance: "false"
+              node_uuid: node-stale
+              severity: P4
+            exp_annotations:
+              summary: "Active Ironic node sensor payload is stale"
+              description: "Active Ironic node stale-node (node-stale) has had no fresh hardware sensor payload for at least 30 minutes."
+
+  - interval: 1m
+    input_series:
+      - series: 'openstack_ironic_node{id="node-fresh",name="fresh-node",provision_state="active",power_state="power on",maintenance="false"}'
+        values: '1x45'
+      - series: 'baremetal_last_payload_timestamp_seconds{node_uuid="node-fresh",node_name="fresh-node",instance_uuid="instance-fresh"}'
+        values: '2400x45'
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: IronicSensorPayloadStale
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'openstack_ironic_node{id="node-available",name="available-node",provision_state="available",power_state="power on",maintenance="false"}'
+        values: '1x45'
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: IronicSensorPayloadStale
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'openstack_ironic_node{id="node-transitioned",name="transitioned-node",provision_state="active",power_state="power on",maintenance="false"}'
+        values: '1x29 stale _x15'
+      - series: 'openstack_ironic_node{id="node-transitioned",name="transitioned-node",provision_state="available",power_state="power on",maintenance="false"}'
+        values: '_x29 1x15'
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: IronicSensorPayloadStale
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'openstack_ironic_node{id="node-hot",name="hot-node",provision_state="active",power_state="power on",maintenance="false"}'
+        values: '1x10'
+      - series: 'baremetal_temperature_status{node_uuid="node-hot",node_name="hot-node",instance_uuid="instance-hot",sensor_id="gpu0"}'
+        values: '2x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: IronicActiveNodeTemperatureCritical
+        exp_alerts:
+          - exp_labels:
+              node_uuid: node-hot
+              node_name: hot-node
+              instance_uuid: instance-hot
+              sensor_id: gpu0
+              severity: P3
+            exp_annotations:
+              summary: "Active Ironic node temperature is critical"
+              description: "Temperature sensor gpu0 on active Ironic node hot-node (node-hot) is critical."
+
+  - interval: 1m
+    input_series:
+      - series: 'openstack_ironic_node{id="node-inventory",name="inventory-node",provision_state="available",power_state="power on",maintenance="false"}'
+        values: '1x10'
+      - series: 'baremetal_temperature_status{node_uuid="node-inventory",node_name="inventory-node",instance_uuid="",sensor_id="cpu0"}'
+        values: '2x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: IronicActiveNodeTemperatureCritical
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'openstack_ironic_node{id="node-power",name="power-node",provision_state="active",power_state="power on",maintenance="false"}'
+        values: '1x10'
+      - series: 'baremetal_power_status{node_uuid="node-power",node_name="power-node",instance_uuid="instance-power",sensor_id="psu0"}'
+        values: '2x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: IronicActiveNodePowerCritical
+        exp_alerts:
+          - exp_labels:
+              node_uuid: node-power
+              node_name: power-node
+              instance_uuid: instance-power
+              sensor_id: psu0
+              severity: P3
+            exp_annotations:
+              summary: "Active Ironic node power sensor is critical"
+              description: "Power sensor psu0 on active Ironic node power-node (node-power) is critical."
+
+  - interval: 1m
+    input_series:
+      - series: 'openstack_ironic_node{id="node-fan",name="fan-node",provision_state="active",power_state="power on",maintenance="false"}'
+        values: '1x10'
+      - series: 'baremetal_fan_status{node_uuid="node-fan",node_name="fan-node",instance_uuid="instance-fan",sensor_id="fan0"}'
+        values: '2x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: IronicActiveNodeFanCritical
+        exp_alerts:
+          - exp_labels:
+              node_uuid: node-fan
+              node_name: fan-node
+              instance_uuid: instance-fan
+              sensor_id: fan0
+              severity: P3
+            exp_annotations:
+              summary: "Active Ironic node fan is critical"
+              description: "Fan sensor fan0 on active Ironic node fan-node (node-fan) is critical."
+
+  - interval: 1m
+    input_series:
+      - series: 'openstack_ironic_node{id="node-drive",name="drive-node",provision_state="active",power_state="power on",maintenance="false"}'
+        values: '1x10'
+      - series: 'baremetal_drive_status{node_uuid="node-drive",node_name="drive-node",instance_uuid="instance-drive",sensor_id="drive0"}'
+        values: '2x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: IronicActiveNodeDriveCritical
+        exp_alerts:
+          - exp_labels:
+              node_uuid: node-drive
+              node_name: drive-node
+              instance_uuid: instance-drive
+              sensor_id: drive0
+              severity: P4
+            exp_annotations:
+              summary: "Active Ironic node drive is critical"
+              description: "Drive sensor drive0 on active Ironic node drive-node (node-drive) is critical."
+
+  - interval: 1m
+    input_series:
+      - series: 'openstack_ironic_node{id="node-warning",name="warning-node",provision_state="active",power_state="power on",maintenance="false"}'
+        values: '1x20'
+      - series: 'baremetal_fan_status{node_uuid="node-warning",node_name="warning-node",instance_uuid="instance-warning",sensor_id="fan0"}'
+        values: '1x20'
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: IronicActiveNodeHardwareWarning
+        exp_alerts:
+          - exp_labels:
+              node_uuid: node-warning
+              node_name: warning-node
+              instance_uuid: instance-warning
+              sensor_id: fan0
+              severity: P5
+            exp_annotations:
+              summary: "Active Ironic node hardware sensor reports a warning"
+              description: "Hardware sensor fan0 on active Ironic node warning-node (node-warning) has reported a warning for 15 minutes."
+
   # NodeNetworkMulticast - should NOT fire for sustained traffic below the
   # capacity-planning threshold.
   - interval: 1m

--- a/roles/kube_prometheus_stack/rules_test.go
+++ b/roles/kube_prometheus_stack/rules_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/goccy/go-yaml"
@@ -24,6 +25,12 @@ func TestPrometheusRules(t *testing.T) {
 
 	var rules map[string]any
 	require.NoError(t, json.Unmarshal([]byte(jsonStr), &rules), "failed to parse jsonnet output")
+
+	dns1123Subdomain := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+	for name := range rules {
+		require.LessOrEqual(t, len(name), 253, "rule map key %q exceeds the DNS subdomain limit", name)
+		require.Regexp(t, dns1123Subdomain, name, "rule map key %q must be a DNS-1123 subdomain", name)
+	}
 
 	tempDir := t.TempDir()
 

--- a/roles/kube_prometheus_stack/tasks/main.yml
+++ b/roles/kube_prometheus_stack/tasks/main.yml
@@ -300,11 +300,59 @@
   tags:
     - kube-prometheus-stack-crds
 
+- name: Validate Ironic sensor monitoring service gate
+  ansible.builtin.assert:
+    that:
+      - atmosphere_ironic_enabled | default(false) | bool
+    fail_msg: >-
+      ironic_prometheus_exporter_enabled requires
+      atmosphere_ironic_enabled=true.
+  when: ironic_prometheus_exporter_enabled | default(false) | bool
+  tags:
+    - kube-prometheus-stack-ironic
+
+- name: Manage Ironic Prometheus exporter PodMonitor
+  run_once: true
+  kubernetes.core.k8s:
+    state: >-
+      {{
+        'present'
+        if _kube_prometheus_stack_ironic_sensor_exporter_enabled | bool
+        else 'absent'
+      }}
+    definition:
+      apiVersion: monitoring.coreos.com/v1
+      kind: PodMonitor
+      metadata:
+        name: ironic-prometheus-exporter
+        namespace: "{{ kube_prometheus_stack_helm_release_namespace }}"
+        labels:
+          release: "{{ kube_prometheus_stack_helm_release_name }}"
+      spec:
+        namespaceSelector:
+          matchNames:
+            - "{{ ironic_helm_release_namespace | default('openstack') }}"
+        selector:
+          matchLabels:
+            application: ironic
+            component: conductor
+        podMetricsEndpoints:
+          - port: metrics
+            path: /metrics
+            interval: 60s
+            scrapeTimeout: 30s
+            relabelings:
+              - sourceLabels:
+                  - __meta_kubernetes_pod_name
+                targetLabel: instance
+  tags:
+    - kube-prometheus-stack-ironic
+
 - name: Deploy additional dashboards
   run_once: true
   kubernetes.core.k8s:
     state: "{{ item.state }}"
-    template: configmap-dashboard.yaml.j2
+    definition: "{{ lookup('ansible.builtin.template', 'configmap-dashboard.yaml.j2') | from_yaml }}"
   loop:
     - name: haproxy
       state: present
@@ -338,6 +386,13 @@
           'present'
           if (atmosphere_ironic_enabled | default(false) | bool
               and openstack_exporter_baremetal_enabled | default(false) | bool)
+          else 'absent'
+        }}
+    - name: ironic-sensors
+      state: >-
+        {{
+          'present'
+          if _kube_prometheus_stack_ironic_sensor_exporter_enabled | bool
           else 'absent'
         }}
   tags:

--- a/roles/kube_prometheus_stack/vars/main.yml
+++ b/roles/kube_prometheus_stack/vars/main.yml
@@ -4,7 +4,17 @@ _kube_prometheus_stack_ironic_lifecycle_enabled: >-
     atmosphere_ironic_enabled | default(false) | bool
     and openstack_exporter_baremetal_enabled | default(false) | bool
   }}
-_kube_prometheus_stack_rules: >-
+_kube_prometheus_stack_ironic_sensor_exporter_enabled: >-
+  {{
+    atmosphere_ironic_enabled | default(false) | bool
+    and ironic_prometheus_exporter_enabled | default(false) | bool
+  }}
+_kube_prometheus_stack_ironic_sensor_alerts_enabled: >-
+  {{
+    _kube_prometheus_stack_ironic_lifecycle_enabled | bool
+    and _kube_prometheus_stack_ironic_sensor_exporter_enabled | bool
+  }}
+_kube_prometheus_stack_lifecycle_rules: >-
   {{
     _kube_prometheus_stack_compiled_rules
     if _kube_prometheus_stack_ironic_lifecycle_enabled | bool
@@ -12,6 +22,16 @@ _kube_prometheus_stack_rules: >-
     (_kube_prometheus_stack_compiled_rules
      | dict2items
      | rejectattr('key', 'equalto', 'ironic')
+     | items2dict)
+  }}
+_kube_prometheus_stack_rules: >-
+  {{
+    _kube_prometheus_stack_lifecycle_rules
+    if _kube_prometheus_stack_ironic_sensor_alerts_enabled | bool
+    else
+    (_kube_prometheus_stack_lifecycle_rules
+     | dict2items
+     | rejectattr('key', 'equalto', 'ironic-sensors')
      | items2dict)
   }}
 

--- a/tests/unit/test_ironic_monitoring.py
+++ b/tests/unit/test_ironic_monitoring.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import yaml
+from ansible.parsing.dataloader import DataLoader
+from ansible.template import Templar
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+
+
+def _load_tasks(role):
+    return yaml.safe_load(
+        (REPOSITORY_ROOT / "roles" / role / "tasks" / "main.yml").read_text()
+    )
+
+
+def _task_named(tasks, name):
+    return next(task for task in tasks if task.get("name") == name)
+
+
+def test_ironic_prometheus_exporter_uses_generic_extra_containers():
+    tasks = _load_tasks("ironic")
+    task = _task_named(tasks, "Add Ironic Prometheus exporter Helm values")
+    values = task["ansible.builtin.set_fact"]["_ironic_effective_helm_values"]
+
+    assert "'extraContainers': _ironic_conductor_extra_containers + [" in values
+    assert ".get('ironic_conductor')" in values
+    assert "'command': ['uwsgi']" in values
+    assert "'ironic_prometheus_exporter':" not in values
+
+
+def test_ironic_prometheus_exporter_preserves_mount_lists():
+    tasks = _load_tasks("ironic")
+    task = _task_named(tasks, "Add Ironic Prometheus exporter Helm values")
+    values = task["ansible.builtin.set_fact"]["_ironic_effective_helm_values"]
+
+    assert "'volumeMounts': _ironic_conductor_volume_mounts + [" in values
+    assert "'volumes': _ironic_conductor_volumes + [" in values
+    assert "'emptyDir': {}" in values
+
+
+def test_ironic_prometheus_exporter_composes_with_existing_lists():
+    tasks = _load_tasks("ironic")
+    task = _task_named(tasks, "Add Ironic Prometheus exporter Helm values")
+    expression = task["ansible.builtin.set_fact"]["_ironic_effective_helm_values"]
+    existing_container = {"name": "existing-sidecar", "image": "example/sidecar"}
+    existing_mount = {"name": "existing-volume", "mountPath": "/existing"}
+    existing_volume = {"name": "existing-volume", "emptyDir": {}}
+    effective_values = {
+        "images": {"tags": {"ironic_conductor": "example/ironic@sha256:test"}},
+        "conductor": {"extraContainers": [existing_container]},
+        "pod": {
+            "mounts": {
+                "ironic_conductor": {
+                    "ironic_conductor": {
+                        "volumeMounts": [existing_mount],
+                        "volumes": [existing_volume],
+                    }
+                }
+            }
+        },
+    }
+    variables = {
+        "_ironic_effective_helm_values": effective_values,
+        "_ironic_notification_drivers": ["messagingv2"],
+        "_ironic_conductor_extra_containers": [existing_container],
+        "_ironic_conductor_volume_mounts": [existing_mount],
+        "_ironic_conductor_volumes": [existing_volume],
+        "ironic_prometheus_exporter_port": 19608,
+        "ironic_prometheus_exporter_workers": 2,
+        "ironic_prometheus_exporter_collect_undeployed_nodes": False,
+        "ironic_prometheus_exporter_sensor_interval": 600,
+        "ironic_prometheus_exporter_image_pull_policy": "IfNotPresent",
+        "ironic_prometheus_exporter_resources": {},
+    }
+
+    rendered = Templar(loader=DataLoader(), variables=variables).template(expression)
+    containers = rendered["conductor"]["extraContainers"]
+    mounts = rendered["pod"]["mounts"]["ironic_conductor"]["ironic_conductor"]
+
+    assert containers[0] == existing_container
+    assert containers[1]["name"] == "ironic-prometheus-exporter"
+    assert containers[1]["image"] == "example/ironic@sha256:test"
+    assert containers[1]["args"][1] == "0.0.0.0:19608"
+    assert mounts["volumeMounts"][0] == existing_mount
+    assert mounts["volumes"][0] == existing_volume
+    assert rendered["conf"]["ironic"]["oslo_messaging_notifications"]["driver"][
+        "values"
+    ] == ["messagingv2", "prometheus_exporter"]
+
+
+def test_ironic_prometheus_exporter_rejects_reserved_name_collisions():
+    tasks = _load_tasks("ironic")
+    task = _task_named(tasks, "Validate existing Ironic exporter Helm values")
+    conditions = "\n".join(task["ansible.builtin.assert"]["that"])
+
+    assert "'ironic-prometheus-exporter' not in" in conditions
+    assert "'ironic-prometheus-metrics' not in" in conditions
+    assert "'/var/lib/ironic/metrics' not in" in conditions
+
+
+def test_ironic_prometheus_exporter_rejects_scalar_multistring_values():
+    tasks = _load_tasks("ironic")
+    task = _task_named(tasks, "Validate existing Ironic notification driver format")
+    condition = task["ansible.builtin.assert"]["that"][0]
+
+    sequence_branch, mapping_branch = condition.split("or (")[1:]
+
+    assert "is not string" in sequence_branch
+    assert "is not mapping" in sequence_branch
+    assert "is not string" in mapping_branch
+    assert "is not mapping" in mapping_branch
+
+
+def test_ironic_podmonitor_uses_ironic_release_namespace():
+    tasks = _load_tasks("kube_prometheus_stack")
+    task = _task_named(tasks, "Manage Ironic Prometheus exporter PodMonitor")
+    definition = task["kubernetes.core.k8s"]["definition"]
+
+    assert definition["spec"]["namespaceSelector"]["matchNames"] == [
+        "{{ ironic_helm_release_namespace | default('openstack') }}"
+    ]
+
+
+def test_dashboard_manifests_are_rendered_before_kubernetes_parsing():
+    tasks = _load_tasks("kube_prometheus_stack")
+    task = _task_named(tasks, "Deploy additional dashboards")
+    module_args = task["kubernetes.core.k8s"]
+
+    assert "template" not in module_args
+    assert module_args["definition"] == (
+        "{{ lookup('ansible.builtin.template', "
+        "'configmap-dashboard.yaml.j2') | from_yaml }}"
+    )


### PR DESCRIPTION
Depends-On: https://github.com/vexxhost/docker-ironic/pull/1452

## Summary

- run Ironic Prometheus Exporter beside each conductor through the generic `conductor.extraContainers` hook
- preserve existing extra containers, conductor mounts, volumes, and notification drivers while appending the managed exporter contract
- reuse the conductor image and its existing uWSGI runtime
- share a pod-local metrics directory through the chart's generic conductor mount hooks
- add direct PodMonitor scraping, sensor recording rules, active-node-only alerts, and a Grafana dashboard
- reserve the managed exporter container, volume, and mount names so conflicts fail before Helm
- backport only the generic conductor extra-container hook to the currently vendored Ironic chart

Stacked on #4345. The operator-neutral OpenStack-Helm example is proposed in
[change 1002515](https://review.opendev.org/c/openstack/openstack-helm/+/1002515).

## Validation

- `helm lint charts/ironic`
- `helm unittest -f '../../roles/ironic/tests/prometheus_exporter_test.yaml' charts/ironic` (`2 passed`)
- `go test ./roles/ironic`
- `go test ./roles/kube_prometheus_stack -run 'TestPrometheusRules/Ironic' -count=1`
- focused Python task-contract tests (`7 passed`), including a native Ansible render proving existing list and notification-driver entries are preserved
- Ansible syntax check for `playbooks/openstack.yml`
- `ansible-lint` 25.6.1 with Ansible Core 2.18.6 (`0 failures`, production profile)
- isolated Ironic chart-vendor reproduction applied both Gerrit dependencies and the local patches, then matched `charts/ironic` byte-for-byte

The full chart-vendor run applies the Ironic patch and later stops at the existing unrelated `invalid_reference: invalid tag` failure. The full Python unit suite reports `86 passed`; its only failure is the existing unrelated Magnum image-tag expectation.

## OVN AIO validation

Validated exact Atmosphere commit `fe4318c9d8efa77d662427360b7cd610ddc8f877` with the image built from exact docker-ironic commit `a1e4df9f3e213bae67d7c8978aadc3ca3a9006f5` and two emulated Ironic nodes.

- tag-scoped Ironic deployment completed with `ok=69`, `changed=14`, `failed=0`; the monitoring deployment completed with `ok=23`, `changed=0`, `failed=0`
- Helm revision 11 is deployed; `ironic-conductor-0` is `4/4` Ready with zero restarts
- the exporter runs `uwsgi --http-socket 0.0.0.0:9608 --processes 1 --master --die-on-term --need-app --module ironic_prometheus_exporter.app.wsgi:application`; Gunicorn is absent
- the shared metrics directory is visible from both conductor and exporter and contains current conductor plus Redfish payloads for both nodes
- the exporter serves 47 sensor samples; Prometheus reports the PodMonitor target up with no scrape error and records sensor payloads for two distinct node UUIDs
- `openstack_ironic_up` is 1; the lifecycle and sensor recording counts are 2 active nodes and 2 active sensor nodes
- all Ironic lifecycle and sensor rules report healthy evaluation; all alerts are inactive
- both emulated nodes remain active, powered on, and out of maintenance after deployment

The AIO's newer Ansible runtime required its existing validation-only compatibility overlays for the generic endpoint-discovery and ingress roles. No Ironic, chart, exporter, or monitoring role files were overlaid.
