### PR TITLE
fix(cinder): enable native Ceph image copies

### DIFF
--- a/releasenotes/notes/cinder-native-ceph-image-copy-2bfb1f98a11a3209.yaml
+++ b/releasenotes/notes/cinder-native-ceph-image-copy-2bfb1f98a11a3209.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Cinder now uses native Ceph-to-Ceph copies when creating volumes from
+    Ceph-backed images.

--- a/roles/cinder/vars/main.yml
+++ b/roles/cinder/vars/main.yml
@@ -46,7 +46,6 @@ __cinder_helm_values:
         os_region_name: "{{ openstack_helm_endpoints['identity']['auth']['cinder']['region_name'] }}"
         volume_usage_audit_period: hour
         volume_name_template: volume-%s
-        image_conversion_disable: true
         osapi_volume_workers: 8
       barbican:
         barbican_endpoint_type: internal


### PR DESCRIPTION
## Summary

- stop setting `image_conversion_disable=true` in Cinder
- allow the downstream Cinder implementation to use native Ceph-to-Ceph copies
- add a release note

## Validation

- `git diff --check`
- release note parsing completed; Reno only reported the repository's existing duplicate release-note UID
- pre-commit whitespace and line-ending checks passed
- Ansible lint traversed the repository and only failed on the existing `galaxy[no-changelog]` finding in `galaxy.yml`
