### PR TITLE
fix(ovn): delegate label migration to controller

### DIFF
--- a/roles/ovn/tasks/main.yml
+++ b/roles/ovn/tasks/main.yml
@@ -14,6 +14,7 @@
 
 - name: Replace unnecessary label in ovn-controller daemonset
   run_once: true
+  delegate_to: "{{ groups['controllers'][0] }}"
   when: atmosphere_network_backend == 'ovn'
   block:
     - name: Check if ovn_controller DaemonSet exists
@@ -24,7 +25,6 @@
         name: ovn-controller
         kubeconfig: "{{ ovn_helm_kubeconfig }}"
       register: _ovn_controller_ds_info
-      failed_when: false
 
     - name: Delete existing ovn controller DaemonSet if type label is found
       kubernetes.core.k8s:


### PR DESCRIPTION
When an OVN deployment is limited to a compute host, run_once runs the label-migration lookup on that host. The controller kubeconfig is not available there, and suppressing the lookup error leads to a misleading resources attribute failure.

Delegate the migration block to the first controller so it retains access to the cluster. Let lookup failures be reported directly.