### PR TITLE
chore(magnum): use Ubuntu 24.04 Kubernetes images

### DIFF
--- a/releasenotes/notes/default-magnum-ubuntu-2404-images-672f9316ac514c89.yaml
+++ b/releasenotes/notes/default-magnum-ubuntu-2404-images-672f9316ac514c89.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    The default Magnum Kubernetes images now use Ubuntu 24.04 and Kubernetes
+    versions 1.33.12, 1.34.8, 1.35.5, and 1.36.1.

--- a/roles/magnum/README.md
+++ b/roles/magnum/README.md
@@ -3,13 +3,13 @@
 ## Creating cluster templates
 
 By default, Atmosphere deploys a set of images for Kubernetes. These cover a
-range of Kubernetes versions, from 1.25.11 to 1.27.3. You can create the
-cluster templates for them with the following command:
+range of Kubernetes versions, from 1.33.12 to 1.36.1, on Ubuntu 24.04. You can
+create the cluster templates for them with the following command:
 
 ```shell
-for version in v1.25.11 v1.26.6 v1.27.3; do
+for version in v1.33.12 v1.34.8 v1.35.5 v1.36.1; do
   openstack coe cluster template create \
-        --image $(openstack image show ubuntu-2204-kube-${version} -c id -f value) \
+        --image $(openstack image show ubuntu-2404-kube-${version} -c id -f value) \
         --external-network public \
         --dns-nameserver 8.8.8.8 \
         --master-lb-enabled \

--- a/roles/magnum/vars/main.yml
+++ b/roles/magnum/vars/main.yml
@@ -109,12 +109,15 @@ _magnum_helm_values:
 _magnum_registry_ingress_annotations: {}
 
 _magnum_images:
-  - name: ubuntu-2204-kube-v1.32.10
-    url: https://github.com/vexxhost/capo-image-elements/releases/download/2025.12-3/ubuntu-22.04-v1.32.10.qcow2
+  - name: ubuntu-2404-kube-v1.33.12
+    url: https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/ubuntu-24.04-v1.33.12.qcow2
     distro: ubuntu
-  - name: ubuntu-2204-kube-v1.33.7
-    url: https://github.com/vexxhost/capo-image-elements/releases/download/2025.12-3/ubuntu-22.04-v1.33.7.qcow2
+  - name: ubuntu-2404-kube-v1.34.8
+    url: https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/ubuntu-24.04-v1.34.8.qcow2
     distro: ubuntu
-  - name: ubuntu-2204-kube-v1.34.3
-    url: https://github.com/vexxhost/capo-image-elements/releases/download/2025.12-3/ubuntu-22.04-v1.34.3.qcow2
+  - name: ubuntu-2404-kube-v1.35.5
+    url: https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/ubuntu-24.04-v1.35.5.qcow2
+    distro: ubuntu
+  - name: ubuntu-2404-kube-v1.36.1
+    url: https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/ubuntu-24.04-v1.36.1.qcow2
     distro: ubuntu

--- a/roles/magnum/vars_test.go
+++ b/roles/magnum/vars_test.go
@@ -20,6 +20,13 @@ var (
 
 type Vars struct {
 	openstack_helm.HelmValues `yaml:"_magnum_helm_values"`
+	MagnumImages              []MagnumImage `yaml:"_magnum_images"`
+}
+
+type MagnumImage struct {
+	Name   string `yaml:"name"`
+	URL    string `yaml:"url"`
+	Distro string `yaml:"distro"`
 }
 
 func TestMain(m *testing.M) {
@@ -38,9 +45,9 @@ func TestHelmValues(t *testing.T) {
 	// for the actual template. Like:
 	// {{ tuple "heat_api" . | include "helm-toolkit.snippets.kubernetes_pod_priority_class" }}
 	vars.HelmValues.Pod.PriorityClass = map[string]string{
-		"bootstrap": "high-priority",
-		"db_sync": "high-priority",
-		"magnum_api": "high-priority",
+		"bootstrap":        "high-priority",
+		"db_sync":          "high-priority",
+		"magnum_api":       "high-priority",
 		"magnum_conductor": "high-priority",
 	}
 	// (rlin): Before you add any new runtime class here.
@@ -49,9 +56,9 @@ func TestHelmValues(t *testing.T) {
 	// for the actual template. Like:
 	// {{ tuple "heat_api" . | include "helm-toolkit.snippets.kubernetes_pod_runtime_class" }}
 	vars.HelmValues.Pod.RuntimeClass = map[string]string{
-		"bootstrap": "kata-clh",
-		"db_sync": "kata-clh",
-		"magnum_api": "kata-clh",
+		"bootstrap":        "kata-clh",
+		"db_sync":          "kata-clh",
+		"magnum_api":       "kata-clh",
 		"magnum_conductor": "kata-clh",
 	}
 	vals, err := openstack_helm.CoalescedHelmValues("../../charts/magnum", &vars.HelmValues)
@@ -60,4 +67,29 @@ func TestHelmValues(t *testing.T) {
 	testutils.TestDatabaseConf(t, vals.Conf.Magnum.Database)
 	testutils.TestAllPodsHaveRuntimeClass(t, vals)
 	testutils.TestAllPodsHavePriorityClass(t, vals)
+}
+
+func TestMagnumImages(t *testing.T) {
+	require.Equal(t, []MagnumImage{
+		{
+			Name:   "ubuntu-2404-kube-v1.33.12",
+			URL:    "https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/ubuntu-24.04-v1.33.12.qcow2",
+			Distro: "ubuntu",
+		},
+		{
+			Name:   "ubuntu-2404-kube-v1.34.8",
+			URL:    "https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/ubuntu-24.04-v1.34.8.qcow2",
+			Distro: "ubuntu",
+		},
+		{
+			Name:   "ubuntu-2404-kube-v1.35.5",
+			URL:    "https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/ubuntu-24.04-v1.35.5.qcow2",
+			Distro: "ubuntu",
+		},
+		{
+			Name:   "ubuntu-2404-kube-v1.36.1",
+			URL:    "https://github.com/vexxhost/capo-image-elements/releases/download/2026.05-7/ubuntu-24.04-v1.36.1.qcow2",
+			Distro: "ubuntu",
+		},
+	}, vars.MagnumImages)
 }


### PR DESCRIPTION
## Summary

- switch the managed Magnum guest images from Ubuntu 22.04 to Ubuntu 24.04
- track Kubernetes 1.33.12, 1.34.8, 1.35.5, and 1.36.1 from `capo-image-elements` release `2026.05-7`
- update the Magnum cluster-template example and lock the image matrix in a unit test

This matches the Noble image matrix already exercised by magnum-cluster-api CI after vexxhost/magnum-cluster-api#1087.

## Validation

- `go test ./roles/magnum`
- `pre-commit run end-of-file-fixer --files ...`
- `pre-commit run trailing-whitespace --files ...`
- `pre-commit run mixed-line-ending --files ...`
- `yq eval '.' releasenotes/notes/default-magnum-ubuntu-2404-images-672f9316ac514c89.yaml`
- `git diff --check`
- verified all four QCOW2 assets in `vexxhost/capo-image-elements` release `2026.05-7`
